### PR TITLE
Use PolyKinds in Teletype example, add note to common mistakes

### DIFF
--- a/docs/common_errors.md
+++ b/docs/common_errors.md
@@ -46,3 +46,8 @@ data Teletype (m :: * -> *) k
   deriving (Functor)
 
 ```
+
+Alternatively, to disable this kind-defaulting behavior entirely, use the
+`PolyKinds` language extension. With this extension, the un-annotated version of
+the `Teletype` data type will be inferred to have kind `k -> * -> *`. When you use
+this type, `m`'s kind will correctly be instantiated to `* -> *`.

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE PolyKinds, DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 module Teletype where
 
@@ -23,7 +23,7 @@ spec = describe "teletype" $ do
   prop "writes multiple things" $
     \ input output1 output2 -> run (runTeletypeRet input (write output1 >> write output2)) `shouldBe` ((input, [output1, output2]), ())
 
-data Teletype (m :: * -> *) k
+data Teletype m k
   = Read (String -> k)
   | Write String k
   deriving (Functor)


### PR DESCRIPTION
Using PolyKinds obviates the need for explicit kind annotations on
type parameters of kinds other than `*` (e.g. Teletype's `m` monad
paramter). This seems to be the more general and less verbose
solution to the kind error issue noted in the docs; I have added a
comment to this effect.

Another thought: perhaps it would be good to have a list in the docs of
language extensions you'll probably need to enable to use this library. In
general, I think this is a useful kind of documentation, which I haven't seen
in many libraries. While Hackage lists the language extensions necessary to
*implement* a library, it doesn't have a mechanism to directly document
which ones you need as an end-user of the library (and for what purposes).