### PR TITLE
Generic deriving for HFunctor and Effect

### DIFF
--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE DefaultSignatures, FunctionalDependencies, RankNTypes #-}
+{-# LANGUAGE FlexibleContexts                                      #-}
+{-# LANGUAGE FlexibleInstances                                     #-}
+{-# LANGUAGE ScopedTypeVariables                                   #-}
+{-# LANGUAGE TypeApplications                                      #-}
+{-# LANGUAGE TypeOperators                                         #-}
+
 module Control.Effect.Carrier
 ( HFunctor(..)
 , Effect(..)
@@ -13,6 +19,7 @@ module Control.Effect.Carrier
 
 import Control.Monad (join)
 import Data.Coerce
+import GHC.Generics
 
 class HFunctor h where
   -- | Functor map. This is required to be 'fmap'.
@@ -25,6 +32,37 @@ class HFunctor h where
 
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
   hmap :: (forall x . m x -> n x) -> (h m a -> h n a)
+  default hmap :: (Generic (h m a), Generic (h n a), GHFunctor (Rep (h m a)) (Rep (h n a)) m n)
+                => (forall x . m x -> n x) -> (h m a -> h n a)
+  hmap f = to . ghmap f . from
+
+class GHFunctor s t u v where
+  ghmap :: (forall y. u y -> v y) -> s x -> t x
+
+instance GHFunctor s t u v => GHFunctor (M1 _1 _2 s) (M1 _1 _2 t) u v where
+  ghmap f u = M1 $ ghmap f $ unM1 u
+
+instance (GHFunctor s t u v, GHFunctor s' t' u v) => GHFunctor (s :+: s') (t :+: t') u v where
+  ghmap f (L1 x) = L1 $ ghmap f x
+  ghmap f (R1 x) = R1 $ ghmap f x
+
+instance (GHFunctor s t u v, GHFunctor s' t' u v) => GHFunctor (s :*: s') (t :*: t') u v where
+  ghmap f (x :*: y) = ghmap f x :*: ghmap f y
+
+instance GHFunctor U1 U1 u v where
+  ghmap _ U1 = U1
+
+instance GHFunctor V1 V1 u v where
+  ghmap _ = id
+
+instance {-# INCOHERENT #-} GHFunctor (Rec0 (u x)) (Rec0 (v x)) u v where
+  ghmap f (K1 z) = K1 $ f z
+
+instance {-# INCOHERENT #-} HFunctor l => GHFunctor (Rec0 (l u x)) (Rec0 (l v x)) u v where
+  ghmap f (K1 z) = K1 $ hmap f z
+
+instance {-# INCOHERENT #-} GHFunctor (K1 _1 z) (K1 _1 z) u v where
+  ghmap _ (K1 z) = K1 z
 
 
 -- | The class of effect types, which must:
@@ -32,12 +70,63 @@ class HFunctor h where
 --   1. Be functorial in their last two arguments, and
 --   2. Support threading effects in higher-order positions through using the carrier’s suspended state.
 class HFunctor sig => Effect sig where
-  -- | Handle any effects in a signature by threading the carrier’s state all the way through to the continuation.
+  -- | Handle any effects in a signature by threading the carrier’s state all
+  -- the way through to the continuation.
   handle :: Functor f
          => f ()
          -> (forall x . f (m x) -> n (f x))
          -> sig m (m a)
          -> sig n (n (f a))
+  default handle
+      :: ( Generic (sig m (m a))
+         , Generic (sig n (n (f a)))
+         , GEffect f (Rep (sig m (m a)))
+                     (Rep (sig n (n (f a)))) m n
+         )
+      => f ()
+      -> (forall x . f (m x) -> n (f x))
+      -> sig m (m a)
+      -> sig n (n (f a))
+  handle s f = to . ghandle s f . from
+
+class GEffect f s t u v where
+  ghandle :: f ()
+          -> (forall y. f (u y) -> v (f y))
+          -> s x
+          -> t x
+
+instance GEffect f s t u v => GEffect f (M1 _1 _2 s) (M1 _1 _2 t) u v where
+  ghandle s f u = M1 $ ghandle s f $ unM1 u
+
+instance (GEffect f s t u v, GEffect f s' t' u v) => GEffect f (s :+: s') (t :+: t') u v where
+  ghandle s f (L1 x) = L1 $ ghandle s f x
+  ghandle s f (R1 x) = R1 $ ghandle s f x
+
+instance (GEffect f s t u v, GEffect f s' t' u v) => GEffect f (s :*: s') (t :*: t') u v where
+  ghandle s f (x :*: y) = ghandle s f x :*: ghandle s f y
+
+instance GEffect f U1 U1 u v where
+  ghandle _ _ U1 = U1
+
+instance GEffect f V1 V1 u v where
+  ghandle _ _ _ = undefined
+
+instance {-# INCOHERENT #-} (Functor f, Functor n) => GEffect f (Rec0 (m (m a))) (Rec0 (n (n (f a)))) m n where
+  ghandle s f (K1 z) = K1 $ fmap f $ f $ z <$ s
+
+-- instance {-# INCOHERENT #-} (Functor f, Functor n, HFunctor l) => GEffect f (Rec0 (l m (m a))) (Rec0 (l n (n (f a)))) m n where
+--   ghandle s f (K1 z) = K1 $ hmaphmap  _ $ fmap' (f . (<$ s)) $ z
+
+instance {-# INCOHERENT #-} (Functor f) => GEffect f (Rec0 (s -> m a)) (Rec0 (s -> n (f a))) m n where
+  ghandle s f (K1 z) = K1 $ fmap (f . (<$ s)) $ z
+
+instance {-# INCOHERENT #-} GEffect f (K1 _1 a) (K1 _1 a) u v where
+  ghandle _ _ (K1 z) = K1 z
+
+instance {-# INCOHERENT #-} Functor f => GEffect f (K1 _1 (u a)) (K1 _1 (v (f a))) u v where
+  ghandle s f (K1 z) = K1 $ f $ z <$ s
+
+
 
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'ret' and 'eff' methods.

--- a/src/Control/Effect/NonDet/Internal.hs
+++ b/src/Control/Effect/NonDet/Internal.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DeriveAnyClass                    #-}
+{-# LANGUAGE DeriveGeneric                     #-}
 {-# LANGUAGE DeriveTraversable, KindSignatures #-}
+
 module Control.Effect.NonDet.Internal
 ( NonDet(..)
 , Branch(..)
@@ -8,20 +11,16 @@ module Control.Effect.NonDet.Internal
 
 import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
-import Data.Coerce
+import GHC.Generics (Generic)
 
 data NonDet (m :: * -> *) k
   = Empty
   | Choose (Bool -> k)
-  deriving (Functor)
+  deriving (Functor, Generic)
 
-instance HFunctor NonDet where
-  hmap _ = coerce
-  {-# INLINE hmap #-}
+instance HFunctor NonDet
 
-instance Effect NonDet where
-  handle _     _       Empty      = Empty
-  handle state handler (Choose k) = Choose (handler . (<$ state) . k)
+instance Effect NonDet
 
 
 -- | The result of a nondeterministic branch of a computation.

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -26,11 +26,7 @@ instance HFunctor Resource where
   hmap f (OnError acquire release use k)  = OnError  (f acquire) (f . release) (f . use) k
 
 instance Effect Resource where
-  handle state handler (Resource acquire release use k)
-    = Resource (handler (acquire <$ state))
-               (handler . fmap release)
-               (handler . fmap use)
-               (handler . fmap k)
+  handle state handler (Resource acquire release use k) = Resource (handler (acquire <$ state)) (handler . fmap release) (handler . fmap use) (handler . fmap k)
   handle state handler (OnError acquire release use k)  = OnError  (handler (acquire <$ state)) (handler . fmap release) (handler . fmap use) (handler . fmap k)
 
 -- | Provides a safe idiom to acquire and release resources safely.

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -26,7 +26,11 @@ instance HFunctor Resource where
   hmap f (OnError acquire release use k)  = OnError  (f acquire) (f . release) (f . use) k
 
 instance Effect Resource where
-  handle state handler (Resource acquire release use k) = Resource (handler (acquire <$ state)) (handler . fmap release) (handler . fmap use) (handler . fmap k)
+  handle state handler (Resource acquire release use k)
+    = Resource (handler (acquire <$ state))
+               (handler . fmap release)
+               (handler . fmap use)
+               (handler . fmap k)
   handle state handler (OnError acquire release use k)  = OnError  (handler (acquire <$ state)) (handler . fmap release) (handler . fmap use) (handler . fmap k)
 
 -- | Provides a safe idiom to acquire and release resources safely.

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DeriveAnyClass                                                                                                                                             #-}
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric                                                                                                                                              #-}
+
 module Control.Effect.State
 ( State(..)
 , get
@@ -14,20 +17,16 @@ module Control.Effect.State
 import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.Internal
-import Data.Coerce
+import GHC.Generics (Generic)
 
 data State s (m :: * -> *) k
   = Get (s -> k)
   | Put s k
-  deriving (Functor)
+  deriving (Functor, Generic)
 
-instance HFunctor (State s) where
-  hmap _ = coerce
-  {-# INLINE hmap #-}
+instance HFunctor (State s)
 
-instance Effect (State s) where
-  handle state handler (Get k)   = Get   (handler . (<$ state) . k)
-  handle state handler (Put s k) = Put s (handler . (<$ state) $ k)
+instance Effect (State s)
 
 -- | Get the current state value.
 --

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
+{-# LANGUAGE DeriveGeneric                                                                          #-}
+
 module Control.Effect.Sum
 ( (:+:)(..)
 , handleSum
@@ -6,19 +8,17 @@ module Control.Effect.Sum
 , send
 ) where
 
+import GHC.Generics (Generic)
 import Control.Effect.Carrier
 
 data (f :+: g) (m :: * -> *) k
   = L (f m k)
   | R (g m k)
-  deriving (Eq, Functor, Ord, Show)
+  deriving (Eq, Functor, Ord, Show, Generic)
 
 infixr 4 :+:
 
 instance (HFunctor l, HFunctor r) => HFunctor (l :+: r) where
-  hmap f (L l) = L (hmap f l)
-  hmap f (R r) = R (hmap f r)
-
   fmap' f (L l) = L (fmap' f l)
   fmap' f (R r) = R (fmap' f r)
 

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DeriveAnyClass                                                                                                                 #-}
 {-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric                                                                                                                  #-}
+
 module Control.Effect.Trace
 ( Trace(..)
 , trace
@@ -10,26 +13,23 @@ module Control.Effect.Trace
 , TraceByReturningC(..)
 ) where
 
+import GHC.Generics (Generic)
 import Control.Effect.Carrier
 import Control.Effect.Internal
 import Control.Effect.Sum
 import Control.Monad.IO.Class
 import Data.Bifunctor (first)
-import Data.Coerce
 import System.IO
 
 data Trace (m :: * -> *) k = Trace
   { traceMessage :: String
   , traceCont    :: k
   }
-  deriving (Functor)
+  deriving (Functor, Generic)
 
-instance HFunctor Trace where
-  hmap _ = coerce
-  {-# INLINE hmap #-}
+instance HFunctor Trace
 
-instance Effect Trace where
-  handle state handler (Trace s k) = Trace s (handler (k <$ state))
+instance Effect Trace
 
 -- | Append a message to the trace log.
 trace :: (Member Trace sig, Carrier sig m) => String -> m ()

--- a/src/Control/Effect/Void.hs
+++ b/src/Control/Effect/Void.hs
@@ -1,23 +1,23 @@
+{-# LANGUAGE DeriveAnyClass                                                  #-}
 {-# LANGUAGE DeriveFunctor, EmptyCase, KindSignatures, MultiParamTypeClasses #-}
+{-# LANGUAGE DeriveGeneric                                                   #-}
+
 module Control.Effect.Void
 ( Void
 , run
 , VoidC(..)
 ) where
 
+import GHC.Generics (Generic)
 import Control.Effect.Carrier
 import Control.Effect.Internal
 
 data Void (m :: * -> *) k
-  deriving (Functor)
+  deriving (Functor, Generic)
 
-instance HFunctor Void where
-  hmap _ v = case v of {}
-  {-# INLINE hmap #-}
+instance HFunctor Void
 
-instance Effect Void where
-  handle _ _ v = case v of {}
-  {-# INLINE handle #-}
+instance Effect Void
 
 
 -- | Run an 'Eff' exhausted of effects to produce its final result value.


### PR DESCRIPTION
I used @kcsongor's [approach for deriving bifunctor](https://kcsongor.github.io/generic-deriving-bifunctor/) to give generic implementations for `HFunctor` and `Effect`. 

Unfortunately we can't get `Generic` instances for effects that have existential parameters :(

~TBH I am not super sure that these `INCOHERENT` instances are safe. But if they are, and~ if you like this idea, I'll cleanup the code and write some tests to ensure everything inlines away.