### PR TITLE
Restore but deprecate Eff and legacy handlers.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,22 +1,31 @@
-- Adds `Monad` instances for all carrier types.
+## Backwards-incompatible changes
+
 - Adds `Monad` as a superclass of `Carrier`, obviating the need for a lot of constraints.
   This is a backwards-incompatible change, as any carriers users have defined now require `Monad` instances. Note that in many cases carriers can be composed out of existing carriers and monad transformers, and thus these instances can often be derived using `-XGeneralizedNewtypeDeriving`. We also recommend compiling with `-Wredundant-constraints` as many of these can now be removed.
-- Removes `ret`.
-  This is a backwards-incompatible change, but `pure` or `return` can be used instead.
-- Removes `Eff`, in favour of computing directly in the carriers. This enables the compiler to perform significant optimizations; see the benchmarks for details.
-  This is a backwards-incompatible change to any code mentioning `Eff`. For example, handlers can simply remove the `Eff` wrapping the carrier type & any use of `interpret`. As above, we also recommend compiling with `-Wredundant-constraints` as many of these can now be removed.
-- Removes `handleEither`, `handleReader`, `handleState`, `handleSum`, and `handleTraversable` in favour of composing carrier types directly.
-  This is a backwards-incompatible change for `Carrier` instances making use of these helpers. Instead, carriers can be composed from other carriers and `eff` defined with `handleCoercible`; and other definitions can use `handlePure` & `handle` directly.
 - Replaces `AltC` with a new carrier, `NonDetC`, based on Ralf Hinze’s work in _[Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12)_.
   This is a backwards-incompatible change. `AltC` was equivalent to the `ListT` monad transformer, and had the same well-known limitation to commutative monads. Therefore, the elimination of `Eff` required a more durable approach.
 - Removes `Branch`.
   This is a backwards-incompatible change, but was necessitated by the difficulty of implementing correct `Applicative` & `Monad` instances for carriers which used it. Carriers which were employing `Branch` internally should be reimplemented using `NonDetC` or a similar approach; see `CutC` and `CullC` for examples.
+- Renames `Control.Effect.Void`, `Void`, and `VoidC` to `Control.Effect.Pure`, `Pure`, and `PureC` respectively.
+  This is a backwards-incompatible change for code mentioning `VoidC`; it should be updated to reference `PureC` instead.
+
+## Deprecations
+
+- `Eff` and `interpret`, in favour of computing directly in the carriers. This enables the compiler to perform significant optimizations; see the benchmarks for details.
+   Handlers can simply remove the `Eff` wrapping the carrier type & any use of `interpret`. As above, we also recommend compiling with `-Wredundant-constraints` as many of these can now be removed.
+- `ret`, in favor of `pure` or `return`.
+- `handleEither`, `handleReader`, `handleState`, `handleSum`, and `handleTraversable` in favour of composing carrier types directly.
+   Carriers can be composed from other carriers and `eff` defined with `handleCoercible`; and other definitions can use `handlePure` & `handle` directly.
+
+All deprecated APIs will be removed in the next release.
+
+## Other changes
+
+- Adds `Monad` instances for all carrier types.
 - Rewrites `CutC` using an approach related to `NonDetC`, with the addition of a continuation to distinguish `empty` from `cutfail`.
 - Rewrites `CullC` using `ListC` and `ReaderC`.
 - Moves `OnceC` from `Control.Effect.NonDet` to `Control.Effect.Cull` to avoid cyclic dependencies.
 - Adds a `runCutAll` handler for `Cut` effects, returning a collection of all results.
-- Renames `Control.Effect.Void`, `Void`, and `VoidC` to `Control.Effect.Pure`, `Pure`, and `PureC` respectively.
-  This is a backwards-incompatible change for code mentioning `VoidC`; it should be updated to reference `PureC` instead.
 
 # 0.2.0.1
 

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -1,5 +1,6 @@
 module Control.Effect
 ( module X
+, Eff
 ) where
 
 import Control.Effect.Carrier   as X (Carrier, Effect)
@@ -19,3 +20,6 @@ import Control.Effect.State     as X (State, StateC)
 import Control.Effect.Sum       as X ((:+:), Member, send)
 import Control.Effect.Trace     as X (Trace, TraceByPrintingC, TraceByIgnoringC, TraceByReturningC)
 import Control.Effect.Writer    as X (Writer, WriterC)
+
+type Eff m = m
+{-# DEPRECATED Eff "Carriers are now monads; use @m@ instead of @Eff m@." #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -5,8 +5,14 @@ module Control.Effect.Carrier
 , Carrier(..)
 , handlePure
 , handleCoercible
+, handleReader
+, handleState
+, handleEither
+, handleTraversable
+, interpret
 ) where
 
+import Control.Monad (join)
 import Data.Coerce
 
 class HFunctor h where
@@ -40,6 +46,11 @@ class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   eff :: sig m (m a) -> m a
 
+  -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
+  ret :: a -> m a
+  ret = pure
+
+{-# DEPRECATED ret "Use 'pure' instead; 'ret' is a historical alias and will be removed in future versions" #-}
 
 -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.
 handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g a)
@@ -52,3 +63,31 @@ handlePure handler = hmap handler . fmap' handler
 handleCoercible :: (HFunctor sig, Coercible f g) => sig f (f a) -> sig g (g a)
 handleCoercible = handlePure coerce
 {-# INLINE handleCoercible #-}
+
+{-# DEPRECATED handleReader, handleState, handleEither, handleTraversable
+  "Compose carrier types from other carriers and define 'eff' with handleCoercible instead" #-}
+
+-- | Thread a @Reader@-like carrier through an 'HFunctor'.
+handleReader :: HFunctor sig => r -> (forall x . f x -> r -> g x) -> sig f (f a) -> sig g (g a)
+handleReader r run = handlePure (flip run r)
+{-# INLINE handleReader #-}
+
+-- | Thread a @State@-like carrier through an 'Effect'.
+handleState :: Effect sig => s -> (forall x . f x -> s -> g (s, x)) -> sig f (f a) -> sig g (g (s, a))
+handleState s run = handle (s, ()) (uncurry (flip run))
+{-# INLINE handleState #-}
+
+-- | Thread a carrier producing 'Either's through an 'Effect'.
+handleEither :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
+handleEither run = handle (Right ()) (either (pure . Left) run)
+{-# INLINE handleEither #-}
+
+-- | Thread a carrier producing values in a 'Traversable' 'Monad' (e.g. '[]') through an 'Effect'.
+handleTraversable :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
+handleTraversable run = handle (pure ()) (fmap join . traverse run)
+{-# INLINE handleTraversable #-}
+
+-- | A backwards-compatibility shim, equivalent to 'id'.
+interpret :: carrier a -> carrier a
+interpret = id
+{-# DEPRECATED interpret "Not necessary with monadic carriers; remove or replace with 'id'." #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
+, handleSum
 , Member(..)
 , send
 ) where
@@ -25,6 +26,16 @@ instance (Effect l, Effect r) => Effect (l :+: r) where
   handle state handler (L l) = L (handle state handler l)
   handle state handler (R r) = R (handle state handler r)
 
+-- | Lift algebras for either side of a sum into a single algebra on sums.
+--
+--   Note that the order of the functions is the opposite of members of the sum. This is more convenient for defining effect handlers as lambdas (especially using @-XLambdaCase@) on the right, enabling better error messaging when using typed holes than would be the case with a binding in a where clause.
+{-# DEPRECATED handleSum "Carriers are now monads, so handleSum is obsolete: define handlers with do-notation and pattern-matching on L and R" #-}
+handleSum :: (          sig2  m a -> b)
+          -> ( sig1           m a -> b)
+          -> ((sig1 :+: sig2) m a -> b)
+handleSum alg1 _    (R op) = alg1 op
+handleSum _    alg2 (L op) = alg2 op
+{-# INLINE handleSum #-}
 
 class Member (sub :: (* -> *) -> (* -> *)) sup where
   inj :: sub m a -> sup m a


### PR DESCRIPTION
Because the next release contains significant API churn, we've decided
to make the path easier by restoring but deprecating the legacy idioms
for defining effects. This restores the `handleSum` family of
functions while informing the user that they will be removed in
upcoming releases, as well as defining `Eff m` as a synonym for `m`
and marking it as deprecated.