### PR TITLE
Fix URL breakage caused by repository move.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A fast, flexible, fused effect system for Haskell
 
-[![Build Status](https://travis-ci.com/robrix/fused-effects.svg?branch=master)](https://travis-ci.com/robrix/fused-effects)
+[![Build Status](https://travis-ci.com/fused-effects/fused-effects.svg?branch=master)](https://travis-ci.com/fused-effects/fused-effects)
 
 - [Overview][]
   - [Algebraic effects][]
@@ -20,28 +20,28 @@
   - [Comparison to `mtl`][]
   - [Comparison to `freer-simple`][]
 
-[Overview]: https://github.com/robrix/fused-effects#overview
-[Algebraic effects]: https://github.com/robrix/fused-effects#algebraic-effects
-[Higher-order effects]: https://github.com/robrix/fused-effects#higher-order-effects
-[Fusion]: https://github.com/robrix/fused-effects#fusion
+[Overview]: https://github.com/fused-effects/fused-effects#overview
+[Algebraic effects]: https://github.com/fused-effects/fused-effects#algebraic-effects
+[Higher-order effects]: https://github.com/fused-effects/fused-effects#higher-order-effects
+[Fusion]: https://github.com/fused-effects/fused-effects#fusion
 
-[Usage]: https://github.com/robrix/fused-effects#usage
-[Using built-in effects]: https://github.com/robrix/fused-effects#using-built-in-effects
-[Running effects]: https://github.com/robrix/fused-effects#running-effects
-[Required compiler extensions]: https://github.com/robrix/fused-effects#required-compiler-extensions
-[Defining new effects]: https://github.com/robrix/fused-effects#defining-new-effects
-[Defining effect handlers]: https://github.com/robrix/fused-effects#defining-effect-handlers
+[Usage]: https://github.com/fused-effects/fused-effects#usage
+[Using built-in effects]: https://github.com/fused-effects/fused-effects#using-built-in-effects
+[Running effects]: https://github.com/fused-effects/fused-effects#running-effects
+[Required compiler extensions]: https://github.com/fused-effects/fused-effects#required-compiler-extensions
+[Defining new effects]: https://github.com/fused-effects/fused-effects#defining-new-effects
+[Defining effect handlers]: https://github.com/fused-effects/fused-effects#defining-effect-handlers
 
-[Project overview]: https://github.com/robrix/fused-effects#project-overview
-[Development]: https://github.com/robrix/fused-effects#development
-[Versioning]: https://github.com/robrix/fused-effects#versioning
+[Project overview]: https://github.com/fused-effects/fused-effects#project-overview
+[Development]: https://github.com/fused-effects/fused-effects#development
+[Versioning]: https://github.com/fused-effects/fused-effects#versioning
 
-[Benchmarks]: https://github.com/robrix/fused-effects#benchmarks
+[Benchmarks]: https://github.com/fused-effects/fused-effects#benchmarks
 
-[Related work]: https://github.com/robrix/fused-effects#related-work
-[Contributed packages]: https://github.com/robrix/fused-effects#contributed-packages
-[Comparison to `mtl`]: https://github.com/robrix/fused-effects#comparison-to-mtl
-[Comparison to `freer-simple`]: https://github.com/robrix/fused-effects#comparison-to-freer-simple
+[Related work]: https://github.com/fused-effects/fused-effects#related-work
+[Contributed packages]: https://github.com/fused-effects/fused-effects#contributed-packages
+[Comparison to `mtl`]: https://github.com/fused-effects/fused-effects#comparison-to-mtl
+[Comparison to `freer-simple`]: https://github.com/fused-effects/fused-effects#comparison-to-freer-simple
 
 
 ## Overview
@@ -158,7 +158,7 @@ To use effects, you'll need a relatively-uncontroversial set of extensions: `-XF
 
 When defining your own effects, you'll need `-XTypeOperators` to declare a `Carrier` instance over (`:+:`), and `-XUndecidableInstances` to satisfy the coverage condition for this instance. You may need `-XKindSignatures` if GHC cannot correctly infer the type of your handler; see the [documentation on common errors][common] for more information about this case.
 
-[common]: https://github.com/robrix/fused-effects/blob/master/docs/common_errors.md
+[common]: https://github.com/fused-effects/fused-effects/blob/master/docs/common_errors.md
 
 The following invocation, taken from the teletype example, should suffice for any use or construction of effects:
 
@@ -171,7 +171,7 @@ The following invocation, taken from the teletype example, should suffice for an
 
 The process of defining new effects is outlined in [`docs/defining_effects.md`][], using the classic `Teletype` effect as an example.
 
-[`docs/defining_effects.md`]: https://github.com/robrix/fused-effects/blob/master/docs/defining_effects.md
+[`docs/defining_effects.md`]: https://github.com/fused-effects/fused-effects/blob/master/docs/defining_effects.md
 
 ## Project overview
 
@@ -181,12 +181,12 @@ This project adheres to the Contributor Covenant [code of conduct][]. By partici
 
 Finally, this project is licensed under the BSD 3-clause [license][].
 
-[`src`]: https://github.com/robrix/fused-effects/tree/master/src
-[`test`]: https://github.com/robrix/fused-effects/tree/master/test
-[`examples`]: https://github.com/robrix/fused-effects/tree/master/examples
-[`docs`]: https://github.com/robrix/fused-effects/tree/master/docs
-[code of conduct]: https://github.com/robrix/fused-effects/blob/master/CODE_OF_CONDUCT.md
-[license]: https://github.com/robrix/fused-effects/blob/master/LICENSE.md
+[`src`]: https://github.com/fused-effects/fused-effects/tree/master/src
+[`test`]: https://github.com/fused-effects/fused-effects/tree/master/test
+[`examples`]: https://github.com/fused-effects/fused-effects/tree/master/examples
+[`docs`]: https://github.com/fused-effects/fused-effects/tree/master/docs
+[code of conduct]: https://github.com/fused-effects/fused-effects/blob/master/CODE_OF_CONDUCT.md
+[license]: https://github.com/fused-effects/fused-effects/blob/master/LICENSE.md
 
 
 ### Development

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,7 +6,7 @@ This checklist is designed to help @robrix remember the steps involved in making
 - [ ] Make a branch with the name `version-x.y.z.w`.
 - [ ] Add a heading to the top of `ChangeLog.md` for the current version.
 - [ ] Change the version of the package in `fused-effects.cabal`.
-- [ ] Push the branch to GitHub and open a draft PR. Double-check the changes, comparing against a previous release PR, e.g. https://github.com/robrix/fused-effects/pull/80. When satisfied, mark the PR as ready for review, and request a review from a collaborator.
+- [ ] Push the branch to GitHub and open a draft PR. Double-check the changes, comparing against a previous release PR, e.g. https://github.com/fused-effects/fused-effects/pull/80. When satisfied, mark the PR as ready for review, and request a review from a collaborator.
 - [ ] Build locally using `cabal new-build`, then collect the sources and docs with `cabal new-sdist` and `cabal new-haddock --haddock-for-hackage`, respectively. Note the paths to the tarballs in the output of these commands.
 - [ ] Publish a candidate release to Hackage with `cabal upload dist-newstyle/sdist/fused-effects-x.y.z.w.tar.gz` and `cabal upload --documentation dist-newstyle/fused-effects-x.y.z.w-docs.tar.gz`. Add a link to the candidate release in a comment on the PR.
 - [ ] Once the PR has been approved and you’re satisfied with the candidate release, merge the PR. Publish the release to Hackage by running the above commands with the addition of `--publish`.

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -2,7 +2,7 @@ name:                fused-effects
 version:             0.2.0.1
 synopsis:            A fast, flexible, fused effect system.
 description:         A fast, flexible, fused effect system, à la Effect Handlers in Scope, Monad Transformers and Modular Algebraic Effects: What Binds Them Together, and Fusion for Free—Efficient Algebraic Effect Handlers.
-homepage:            https://github.com/robrix/fused-effects
+homepage:            https://github.com/fused-effects/fused-effects
 license:             BSD3
 license-file:        LICENSE
 author:              Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
@@ -97,4 +97,4 @@ benchmark benchmark
 
 source-repository head
   type:     git
-  location: https://github.com/robrix/fused-effects
+  location: https://github.com/fused-effects/fused-effects


### PR DESCRIPTION
Globally substitute `robrix/fused-effects` with `fused-effects/fused-effects`.