### PR TITLE
Generic effect interpreter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# 0.3.1.0
+
+- Adds `runInterpret` & `runInterpretState` handlers in `Control.Effect.Interpret` as a convenient way to experiment with effect handlers without defining a new carrier type and `Carrier` instance. Such handlers are somewhat less efficient than custom `Carrier`s, but allow for a smooth upgrade path when more efficiency is required.
+
+
 # 0.3.0.0
 
 ## Backwards-incompatible changes

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Finally, thanks to the fusion and inlining of carriers, `fused-effects` is appro
 
 Like [`freer-simple`][], `fused-effects` uses an initial encoding of library- and user-defined effects as syntax which can then be given different interpretations. In `freer-simple`, this is done with a family of interpreter functions (which cover a variety of needs, and which can be extended for more bespoke needs), whereas in `fused-effects` this is done with `Carrier` instances for `newtype`s.
 
-(Technically, it is possible to define handlers like `freer-simple`’s `interpret` using `fused-effects`, but passing handlers in as higher-order functions defeats the fusion and inlining of `Carrier` instances which makes `fused-effects` so efficient.)
+(Tho note that as of `fused-effects` 0.3.1, it is possible to define handlers using `runInterpret` in a manner analogous to `freer-simple`’s `interpret`, with the caveat that its use of higher-order functions defeats the fusion and inlining of `Carrier` instances which makes `fused-effects` so efficient.)
 
 Unlike `fused-effects`, in `freer-simple`, scoped operations like `catchError` and `local` are implemented as interpreters, and can therefore not be given new interpretations.
 

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -15,27 +15,27 @@ main = defaultMain
   [
     bgroup "WriterC"
     [ bgroup "Cod"
-      [ bench "100"       $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 100
-      , bench "1000"    $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 1000
+      [ bench "100"   $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 100
+      , bench "1000"  $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 1000
       , bench "10000" $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 10000
       ]
     , bgroup "standalone"
-      [ bench "100"       $ whnf (run . execWriter @(Sum Int) . tellLoop) 100
-      , bench "1000"    $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
+      [ bench "100"   $ whnf (run . execWriter @(Sum Int) . tellLoop) 100
+      , bench "1000"  $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
       , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
       ]
     ]
   ,
     bgroup "Strict StateC"
     [ bgroup "Cod"
-      [ bench "100"       $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 100
-      , bench "1000"    $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 1000
-      , bench "10000" $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 10000
+      [ bench "100"   $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 100
+      , bench "1000"  $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 1000
+      , bench "10000" $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 10000
       ]
     , bgroup "standalone"
-      [ bench "100"       $ whnf (run . execState @(Sum Int) 0 . modLoop) 100
-      , bench "1000"    $ whnf (run . execState @(Sum Int) 0 . modLoop) 1000
-      , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
+      [ bench "100"   $ whnf (run . execState @(Sum Int) 0 . modLoop) 100
+      , bench "1000"  $ whnf (run . execState @(Sum Int) 0 . modLoop) 1000
+      , bench "10000" $ whnf (run . execState @(Sum Int) 0 . modLoop) 10000
       ]
     ]
   ]

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -40,21 +40,13 @@ main = defaultMain
       ]
     ]
   ,
-    bgroup "InterpretC vs StateC"
+    bgroup "InterpretC vs InterpretStateC vs StateC"
     [ bgroup "InterpretC"
       [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 100
       , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 1000
       , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 10000
       ]
-    , bgroup "StateC"
-      [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . modLoop) 100
-      , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . modLoop) 1000
-      , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . modLoop) 10000
-      ]
-    ]
-  ,
-    bgroup "InterpretStateC vs StateC"
-    [ bgroup "InterpretStateC"
+    , bgroup "InterpretStateC"
       [ bench "100"   $ whnf (run . runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 . modLoop) 100
       , bench "1000"  $ whnf (run . runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 . modLoop) 1000
       , bench "10000" $ whnf (run . runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 . modLoop) 10000

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -52,6 +52,19 @@ main = defaultMain
       , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . modLoop) 10000
       ]
     ]
+  ,
+    bgroup "InterpretStateC vs StateC"
+    [ bgroup "InterpretStateC"
+      [ bench "100"   $ whnf (run . runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 . modLoop) 100
+      , bench "1000"  $ whnf (run . runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 . modLoop) 1000
+      , bench "10000" $ whnf (run . runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 . modLoop) 10000
+      ]
+    , bgroup "StateC"
+      [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . modLoop) 100
+      , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . modLoop) 1000
+      , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . modLoop) 10000
+      ]
+    ]
   ]
 
 tellLoop :: (Applicative m, Carrier sig m, Member (Writer (Sum Int)) sig) => Int -> m ()

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -42,9 +42,9 @@ main = defaultMain
   ,
     bgroup "InterpretC vs StateC"
     [ bgroup "InterpretC"
-      [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . runInterpret @(State (Sum Int)) (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 100
-      , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . runInterpret @(State (Sum Int)) (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 1000
-      , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . runInterpret @(State (Sum Int)) (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 10000
+      [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 100
+      , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 1000
+      , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 10000
       ]
     , bgroup "StateC"
       [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . modLoop) 100

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Main where
 
 import Control.Effect
 import Control.Effect.Carrier
+import Control.Effect.Interpret
 import Control.Effect.Pure
 import Control.Effect.Writer
 import Control.Effect.State
@@ -36,6 +37,19 @@ main = defaultMain
       [ bench "100"   $ whnf (run . execState @(Sum Int) 0 . modLoop) 100
       , bench "1000"  $ whnf (run . execState @(Sum Int) 0 . modLoop) 1000
       , bench "10000" $ whnf (run . execState @(Sum Int) 0 . modLoop) 10000
+      ]
+    ]
+  ,
+    bgroup "InterpretC vs StateC"
+    [ bgroup "InterpretC"
+      [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . runInterpret @(State (Sum Int)) (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 100
+      , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . runInterpret @(State (Sum Int)) (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 1000
+      , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . runInterpret @(State (Sum Int)) (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) . modLoop) 10000
+      ]
+    , bgroup "StateC"
+      [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . modLoop) 100
+      , bench "1000"  $ whnf (run . evalState @(Sum Int) 0 . modLoop) 1000
+      , bench "10000" $ whnf (run . evalState @(Sum Int) 0 . modLoop) 10000
       ]
     ]
   ]

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -27,6 +27,7 @@ library
                      , Control.Effect.Error
                      , Control.Effect.Fail
                      , Control.Effect.Fresh
+                     , Control.Effect.Interpret
                      , Control.Effect.Lift
                      , Control.Effect.NonDet
                      , Control.Effect.Pure

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -44,6 +44,11 @@ instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff 
   eff (R other) = InterpretC (eff (R (handleCoercible other)))
 
 
+-- | Interpret an effect using a higher-order function with some state variable.
+--
+--   This involves a great deal less boilerplate than defining a custom 'Carrier' instance, at the expense of somewhat less performance. It’s a reasonable starting point for new interpretations, and if more performance or flexibility is required, it’s straightforward to “graduate” by replacing the relevant 'runInterpretState' handlers with specialized 'Carrier' instances for the effects.
+--
+--   At time of writing, a simple use of 'runInterpretState' to handle a 'State' effect is about four times slower than using 'StateC' directly.
 runInterpretState :: (forall x . s -> eff (StateC s m) (StateC s m x) -> m (s, x)) -> s -> InterpretStateC eff s m a -> m (s, a)
 runInterpretState handler state = runState state . runReader (HandlerState (\ eff -> StateC (\ s -> handler s eff))) . runInterpretStateC
 

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -20,6 +20,8 @@ import Control.Monad.Trans.Class
 --
 --   This involves a great deal less boilerplate than defining a custom 'Carrier' instance, at the expense of somewhat less performance. It’s a reasonable starting point for new interpretations, and if more performance or flexibility is required, it’s straightforward to “graduate” by replacing the relevant 'runInterpret' handlers with specialized 'Carrier' instances for the effects.
 --
+--   At time of writing, a simple passthrough use of 'runInterpret' to handle a 'State' effect is about five times slower than using 'StateC' directly.
+--
 --   prop> run (runInterpret (\ op -> case op of { Get k -> k a ; Put _ k -> k }) get) == a
 runInterpret :: (forall x . eff m (m x) -> m x) -> InterpretC eff m a -> m a
 runInterpret handler = runReader (Handler handler) . runInterpretC

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -1,0 +1,1 @@
+module Control.Effect.Interpret where

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -16,6 +16,8 @@ import Control.Monad.Trans.Class
 -- | Interpret an effect using a higher-order function.
 --
 --   This involves a great deal less boilerplate than defining a custom 'Carrier' instance, at the expense of somewhat less performance. It’s a reasonable starting point for new interpretations, and if more performance or flexibility is required, it’s straightforward to “graduate” by replacing the relevant 'runInterpret' handlers with specialized 'Carrier' instances for the effects.
+--
+--   prop> run (runInterpret (\ op -> case op of { Get k -> k a ; Put _ k -> k }) get) == a
 runInterpret :: (forall x . eff m (m x) -> m x) -> InterpretC eff m a -> m a
 runInterpret handler = runReader (Handler handler) . runInterpretC
 
@@ -35,3 +37,9 @@ instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff 
     handler <- InterpretC ask
     lift (runHandler handler op)
   eff (R other) = InterpretC (eff (R (handleCoercible other)))
+
+
+-- $setup
+-- >>> import Test.QuickCheck
+-- >>> import Control.Effect.Pure
+-- >>> import Control.Effect.State

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -13,6 +13,9 @@ import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
+-- | Interpret an effect using a higher-order function.
+--
+--   This involves a great deal less boilerplate than defining a custom 'Carrier' instance, at the expense of somewhat less performance. It’s a reasonable starting point for new interpretations, and if more performance or flexibility is required, it’s straightforward to “graduate” by replacing the relevant 'runInterpret' handlers with specialized 'Carrier' instances for the effects.
 runInterpret :: (forall x . eff m (m x) -> m x) -> InterpretC eff m a -> m a
 runInterpret handler = runReader (Handler handler) . runInterpretC
 

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -31,6 +31,7 @@ newtype InterpretC eff m a = InterpretC { runInterpretC :: ReaderC (Handler eff 
 
 instance MonadTrans (InterpretC eff) where
   lift = InterpretC . lift
+  {-# INLINE lift #-}
 
 newtype Handler eff m = Handler (forall x . eff m (m x) -> m x)
 
@@ -42,6 +43,7 @@ instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff 
     handler <- InterpretC ask
     lift (runHandler handler op)
   eff (R other) = InterpretC (eff (R (handleCoercible other)))
+  {-# INLINE eff #-}
 
 
 -- | Interpret an effect using a higher-order function with some state variable.
@@ -59,6 +61,7 @@ newtype InterpretStateC eff s m a = InterpretStateC { runInterpretStateC :: Read
 
 instance MonadTrans (InterpretStateC eff s) where
   lift = InterpretStateC . lift . lift
+  {-# INLINE lift #-}
 
 newtype HandlerState eff s m = HandlerState (forall x . eff (StateC s m) (StateC s m x) -> StateC s m x)
 
@@ -70,6 +73,7 @@ instance (HFunctor eff, Carrier sig m, Effect sig) => Carrier (eff :+: sig) (Int
     handler <- InterpretStateC ask
     InterpretStateC (lift (runHandlerState handler op))
   eff (R other) = InterpretStateC (eff (R (R (handleCoercible other))))
+  {-# INLINE eff #-}
 
 
 -- $setup

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -49,6 +49,8 @@ instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff 
 --   This involves a great deal less boilerplate than defining a custom 'Carrier' instance, at the expense of somewhat less performance. It’s a reasonable starting point for new interpretations, and if more performance or flexibility is required, it’s straightforward to “graduate” by replacing the relevant 'runInterpretState' handlers with specialized 'Carrier' instances for the effects.
 --
 --   At time of writing, a simple use of 'runInterpretState' to handle a 'State' effect is about four times slower than using 'StateC' directly.
+--
+--   prop> run (runInterpretState (\ s op -> case op of { Get k -> runState s (k s) ; Put s' k -> runState s' k }) a get) == a
 runInterpretState :: (forall x . s -> eff (StateC s m) (StateC s m x) -> m (s, x)) -> s -> InterpretStateC eff s m a -> m (s, a)
 runInterpretState handler state = runState state . runReader (HandlerState (\ eff -> StateC (\ s -> handler s eff))) . runInterpretStateC
 

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -1,1 +1,34 @@
-module Control.Effect.Interpret where
+{-# LANGUAGE GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+module Control.Effect.Interpret
+( runInterpret
+, InterpretC(..)
+) where
+
+import Control.Applicative (Alternative(..))
+import Control.Effect.Carrier
+import Control.Effect.Reader
+import Control.Effect.Sum
+import Control.Monad (MonadPlus(..))
+import Control.Monad.Fail
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
+
+runInterpret :: (forall x . eff m (m x) -> m x) -> InterpretC eff m a -> m a
+runInterpret handler = runReader (Handler handler) . runInterpretC
+
+newtype InterpretC eff m a = InterpretC { runInterpretC :: ReaderC (Handler eff m) m a }
+  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus)
+
+instance MonadTrans (InterpretC eff) where
+  lift = InterpretC . lift
+
+newtype Handler eff m = Handler (forall x . eff m (m x) -> m x)
+
+runHandler :: HFunctor eff => Handler eff m -> eff (InterpretC eff m) (InterpretC eff m a) -> m a
+runHandler h@(Handler handler) = handler . handlePure (runReader h . runInterpretC)
+
+instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff m) where
+  eff (L op) = do
+    handler <- InterpretC ask
+    lift (runHandler handler op)
+  eff (R other) = InterpretC (eff (R (handleCoercible other)))

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -51,32 +51,41 @@ instance Monad m => Applicative (StateC s m) where
     (s'', a') <- a s'
     let fa = f' a'
     fa `seq` pure (s'', fa)
+  {-# INLINE (<*>) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
   empty = StateC (const empty)
+  {-# INLINE empty #-}
   StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
+  {-# INLINE (<|>) #-}
 
 instance Monad m => Monad (StateC s m) where
   StateC m >>= f = StateC $ \ s -> do
     (s', a) <- m s
     let fa = f a
     fa `seq` runState s' fa
+  {-# INLINE (>>=) #-}
 
 instance MonadFail m => MonadFail (StateC s m) where
   fail s = StateC (const (fail s))
+  {-# INLINE fail #-}
 
 instance MonadIO m => MonadIO (StateC s m) where
   liftIO io = StateC (\ s -> (,) s <$> liftIO io)
+  {-# INLINE liftIO #-}
 
 instance (Alternative m, Monad m) => MonadPlus (StateC s m)
 
 instance MonadTrans (StateC s) where
   lift m = StateC (\ s -> (,) s <$> m)
+  {-# INLINE lift #-}
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   eff (L (Get   k)) = StateC (\ s -> runState s (k s))
   eff (L (Put s k)) = StateC (\ _ -> runState s k)
   eff (R other)     = StateC (\ s -> eff (handle (s, ()) (uncurry runState) other))
+  {-# INLINE eff #-}
+
 
 -- $setup
 -- >>> :seti -XFlexibleContexts


### PR DESCRIPTION
This PR defines a generic, stateless `runInterpret` handler for arbitrary effects.

- [x] `runInterpret`.
- [x] 📝.
- [x] Test.
- [x] Benchmark.
- [x] Fixes #132.