### PR TITLE
Remove APIs deprecated in 0.3.0.0.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## Backwards-incompatible changes
+
+- Removes APIs deprecated in 0.3.0.0, including `Eff`, `interpret`, `ret`, and the `handle*` family of helper functions.
+
 # 0.3.0.0
 
 ## Backwards-incompatible changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,6 @@
 - Improved speed of `Reader`, `State`, `Writer`, and `Pure` effects by defining and inlining auxiliary `Applicative` methods.
 - Adds `runInterpret` & `runInterpretState` handlers in `Control.Effect.Interpret` as a convenient way to experiment with effect handlers without defining a new carrier type and `Carrier` instance. Such handlers are somewhat less efficient than custom `Carrier`s, but allow for a smooth upgrade path when more efficiency is required.
 - Added `unliftio-core` as a dependency so as to provide a blessed API for unlift-style effects and a solution to the cubic-caller problem.
->>>>>>> origin/master
 
 # 0.3.0.0
 

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -1,6 +1,5 @@
 module Control.Effect
 ( module X
-, Eff
 ) where
 
 import Control.Effect.Carrier   as X (Carrier, Effect)
@@ -20,6 +19,3 @@ import Control.Effect.State     as X (State, StateC)
 import Control.Effect.Sum       as X ((:+:), Member, send)
 import Control.Effect.Trace     as X (Trace, TraceByPrintingC, TraceByIgnoringC, TraceByReturningC)
 import Control.Effect.Writer    as X (Writer, WriterC)
-
-type Eff m = m
-{-# DEPRECATED Eff "Carriers are now monads; use @m@ instead of @Eff m@." #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -5,14 +5,8 @@ module Control.Effect.Carrier
 , Carrier(..)
 , handlePure
 , handleCoercible
-, handleReader
-, handleState
-, handleEither
-, handleTraversable
-, interpret
 ) where
 
-import Control.Monad (join)
 import Data.Coerce
 
 class HFunctor h where
@@ -46,12 +40,6 @@ class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   eff :: sig m (m a) -> m a
 
-  -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
-  ret :: a -> m a
-  ret = pure
-
-{-# DEPRECATED ret "Use 'pure' instead; 'ret' is a historical alias and will be removed in future versions" #-}
-
 -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.
 handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g a)
 handlePure handler = hmap handler . fmap' handler
@@ -63,31 +51,3 @@ handlePure handler = hmap handler . fmap' handler
 handleCoercible :: (HFunctor sig, Coercible f g) => sig f (f a) -> sig g (g a)
 handleCoercible = handlePure coerce
 {-# INLINE handleCoercible #-}
-
-{-# DEPRECATED handleReader, handleState, handleEither, handleTraversable
-  "Compose carrier types from other carriers and define 'eff' with handleCoercible instead" #-}
-
--- | Thread a @Reader@-like carrier through an 'HFunctor'.
-handleReader :: HFunctor sig => r -> (forall x . f x -> r -> g x) -> sig f (f a) -> sig g (g a)
-handleReader r run = handlePure (flip run r)
-{-# INLINE handleReader #-}
-
--- | Thread a @State@-like carrier through an 'Effect'.
-handleState :: Effect sig => s -> (forall x . f x -> s -> g (s, x)) -> sig f (f a) -> sig g (g (s, a))
-handleState s run = handle (s, ()) (uncurry (flip run))
-{-# INLINE handleState #-}
-
--- | Thread a carrier producing 'Either's through an 'Effect'.
-handleEither :: (Carrier sig g, Effect sig) => (forall x . f x -> g (Either e x)) -> sig f (f a) -> sig g (g (Either e a))
-handleEither run = handle (Right ()) (either (pure . Left) run)
-{-# INLINE handleEither #-}
-
--- | Thread a carrier producing values in a 'Traversable' 'Monad' (e.g. '[]') through an 'Effect'.
-handleTraversable :: (Effect sig, Applicative g, Monad m, Traversable m) => (forall x . f x -> g (m x)) -> sig f (f a) -> sig g (g (m a))
-handleTraversable run = handle (pure ()) (fmap join . traverse run)
-{-# INLINE handleTraversable #-}
-
--- | A backwards-compatibility shim, equivalent to 'id'.
-interpret :: carrier a -> carrier a
-interpret = id
-{-# DEPRECATED interpret "Not necessary with monadic carriers; remove or replace with 'id'." #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -43,6 +43,7 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
   prj (R g) = prj g
   prj _     = Nothing
 
+
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: (Member effect sig, Carrier sig m) => effect m (m a) -> m a
 send = eff . inj

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
-, handleSum
 , Member(..)
 , send
 ) where
@@ -26,17 +25,6 @@ instance (Effect l, Effect r) => Effect (l :+: r) where
   handle state handler (L l) = L (handle state handler l)
   handle state handler (R r) = R (handle state handler r)
 
--- | Lift algebras for either side of a sum into a single algebra on sums.
---
---   Note that the order of the functions is the opposite of members of the sum. This is more convenient for defining effect handlers as lambdas (especially using @-XLambdaCase@) on the right, enabling better error messaging when using typed holes than would be the case with a binding in a where clause.
-{-# DEPRECATED handleSum "Carriers are now monads, so handleSum is obsolete: define handlers with do-notation and pattern-matching on L and R" #-}
-handleSum :: (          sig2  m a -> b)
-          -> ( sig1           m a -> b)
-          -> ((sig1 :+: sig2) m a -> b)
-handleSum alg1 _    (R op) = alg1 op
-handleSum _    alg2 (L op) = alg2 op
-{-# INLINE handleSum #-}
-
 class Member (sub :: (* -> *) -> (* -> *)) sup where
   inj :: sub m a -> sup m a
   prj :: sup m a -> Maybe (sub m a)
@@ -54,7 +42,6 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
   inj = R . inj
   prj (R g) = prj g
   prj _     = Nothing
-
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: (Member effect sig, Carrier sig m) => effect m (m a) -> m a


### PR DESCRIPTION
Deletes `Eff`, `interpret`, and all the other functions that we
obsoleted with the carriers-as-monads proposal. This is
backwards-incompatible, but we provided adequate warning with the
previous release.