### PR TITLE
Proposal: Remove HFunctor's fmap' with GHCs supporting QuantifiedConstraints.

### DIFF
--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
+{-# LANGUAGE CPP, DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , handleSum
@@ -19,8 +19,10 @@ instance (HFunctor l, HFunctor r) => HFunctor (l :+: r) where
   hmap f (L l) = L (hmap f l)
   hmap f (R r) = R (hmap f r)
 
+#if __GLASGOW_HASKELL__ <= 861
   fmap' f (L l) = L (fmap' f l)
   fmap' f (R r) = R (fmap' f r)
+#endif
 
 instance (Effect l, Effect r) => Effect (l :+: r) where
   handle state handler (L l) = L (handle state handler l)


### PR DESCRIPTION
As was mentioned in the `HFunctor` documentation, we can eliminate the
vestigial `fmap'` method with QuantifiedConstraints. This implementation
is provided by Bottu et al.'s _Quantified Class Constraints_.

The advantage of this patch is that it expresses the nature of
`HFunctor` in a more direct manner, rather than with the
dummy-function workaround. The disadvantage is that only GHC 8.6
supports QuantifiedConstraints, so we have to use CPP to define the
polyfill (as it were) to handle it.

This changes the `HFunctor` interface but should maintain
compatibility, as `fmap'` was never implemented by hand outside of `Sum`.