### PR TITLE
Add MonadBase, MonadTransControl, and MonadBaseControl instances for carriers.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+- Adds `MonadBase` instances to all carriers and `MonadTransControl`/`MonadBaseControl` instances for carriers that support them. This provides compatibility with the `monad-control` ecosystem.
+
 # 0.3.1.0
 
 - Adds `runInterpret` & `runInterpretState` handlers in `Control.Effect.Interpret` as a convenient way to experiment with effect handlers without defining a new carrier type and `Carrier` instance. Such handlers are somewhat less efficient than custom `Carrier`s, but allow for a smooth upgrade path when more efficiency is required.

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,6 @@
-import Distribution.Simple
-main = defaultMain
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctest"

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -19,6 +19,12 @@ tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.2
 
+custom-setup
+  setup-depends:
+      base
+    , Cabal
+    , cabal-doctest  >=1 && <1.1
+
 library
   exposed-modules:     Control.Effect
                      , Control.Effect.Carrier
@@ -57,12 +63,6 @@ library
   if (impl(ghc >= 8.6))
     ghc-options:       -Wno-star-is-type
 
-custom-setup
-  setup-depends:
-      base
-    , Cabal
-    , cabal-doctest  >=1 && <1.1
-
 test-suite examples
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
@@ -72,7 +72,6 @@ test-suite examples
                      , fused-effects
                      , hspec >=2.4.1
                      , QuickCheck >= 2.7 && < 3
-                     , monad-control
   hs-source-dirs:      examples
   default-language:    Haskell2010
 
@@ -85,7 +84,6 @@ test-suite test
                      , fused-effects
                      , hspec >=2.4.1
                      , inspection-testing >= 0.4 && <1
-                     , monad-control
   hs-source-dirs:      test
   default-language:    Haskell2010
 
@@ -95,8 +93,9 @@ test-suite doctest
   build-depends:       base >=4.9 && <4.13
                      , doctest >=0.7 && <1.0
                      , fused-effects
+                     , QuickCheck
+                     , template-haskell
                      , transformers-base
-                     , monad-control
   hs-source-dirs:      test
   default-language:    Haskell2010
 
@@ -107,7 +106,6 @@ benchmark benchmark
   build-depends:      base >=4.9 && <4.13
                     , criterion
                     , fused-effects
-                    , monad-control
   hs-source-dirs:     benchmark
   default-language:   Haskell2010
   ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -45,8 +45,10 @@ library
   build-depends:       base >=4.9 && <4.13
                      , deepseq >=1.4.3 && <1.5
                      , MonadRandom >=0.5 && <0.6
+                     , monad-control >=1 && <2
                      , random
                      , transformers
+                     , transformers-base >= 0.4.4 && <0.5
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Weverything -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-name-shadowing -Wno-monomorphism-restriction -Wno-missed-specialisations -Wno-all-missed-specialisations
@@ -64,6 +66,7 @@ test-suite examples
   build-depends:       base >=4.9 && <4.13
                      , fused-effects
                      , hspec >=2.4.1
+                     , transformers-base
                      , QuickCheck >= 2.7 && < 3
   hs-source-dirs:      examples
   default-language:    Haskell2010
@@ -86,6 +89,7 @@ test-suite doctest
   build-depends:       base >=4.9 && <4.13
                      , doctest >=0.7 && <1.0
                      , fused-effects
+                     , transformers-base
   hs-source-dirs:      test
   default-language:    Haskell2010
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -13,17 +13,15 @@ build-type:          Custom
 extra-source-files:
   README.md
   ChangeLog.md
-cabal-version:       1.12
+cabal-version:       >=1.10
 
 tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.2
 
 custom-setup
-  setup-depends:
-      base
-    , Cabal
-    , cabal-doctest  >=1 && <1.1
+  setup-depends:       base
+                     , cabal-doctest  >=1 && <1.1
 
 library
   exposed-modules:     Control.Effect

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -9,11 +9,11 @@ author:              Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 maintainer:          robrix@github.com
 copyright:           2018-2019 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 category:            Control
-build-type:          Simple
+build-type:          Custom
 extra-source-files:
   README.md
   ChangeLog.md
-cabal-version:       >=1.10
+cabal-version:       1.12
 
 tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
@@ -57,6 +57,11 @@ library
   if (impl(ghc >= 8.6))
     ghc-options:       -Wno-star-is-type
 
+custom-setup
+  setup-depends:
+      base
+    , Cabal
+    , cabal-doctest  >=1 && <1.1
 
 test-suite examples
   type:                exitcode-stdio-1.0
@@ -66,8 +71,8 @@ test-suite examples
   build-depends:       base >=4.9 && <4.13
                      , fused-effects
                      , hspec >=2.4.1
-                     , transformers-base
                      , QuickCheck >= 2.7 && < 3
+                     , monad-control
   hs-source-dirs:      examples
   default-language:    Haskell2010
 
@@ -80,6 +85,7 @@ test-suite test
                      , fused-effects
                      , hspec >=2.4.1
                      , inspection-testing >= 0.4 && <1
+                     , monad-control
   hs-source-dirs:      test
   default-language:    Haskell2010
 
@@ -90,6 +96,7 @@ test-suite doctest
                      , doctest >=0.7 && <1.0
                      , fused-effects
                      , transformers-base
+                     , monad-control
   hs-source-dirs:      test
   default-language:    Haskell2010
 
@@ -100,6 +107,7 @@ benchmark benchmark
   build-depends:      base >=4.9 && <4.13
                     , criterion
                     , fused-effects
+                    , monad-control
   hs-source-dirs:     benchmark
   default-language:   Haskell2010
   ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -14,6 +14,7 @@ import Control.Effect.NonDet
 import Control.Effect.Reader
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
+import Control.Monad.Base
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -49,7 +50,7 @@ runCull :: Alternative m => CullC m a -> m a
 runCull (CullC m) = runNonDetC (runReader False m) ((<|>) . pure) empty
 
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
-  deriving (Applicative, Functor, Monad, MonadFail, MonadIO)
+  deriving (Applicative, Functor, Monad, MonadBase b, MonadFail, MonadIO)
 
 instance Alternative (CullC m) where
   empty = CullC empty

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -14,6 +14,7 @@ import Control.Effect.Carrier
 import Control.Effect.NonDet
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
+import Control.Monad.Base
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -110,6 +111,10 @@ instance MonadPlus (CutC m)
 instance MonadTrans CutC where
   lift m = CutC (\ cons nil _ -> m >>= flip cons nil)
   {-# INLINE lift #-}
+
+instance MonadBase b m => MonadBase b (CutC m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
 
 instance (Carrier sig m, Effect sig) => Carrier (Cut :+: NonDet :+: sig) (CutC m) where
   eff (L Cutfail)    = CutC $ \ _    _   fail -> fail

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -7,6 +7,7 @@ module Control.Effect.Fail
 ) where
 
 import Control.Applicative (Alternative(..))
+import Control.Monad.Base
 import Control.Effect.Carrier
 import Control.Effect.Error
 import Control.Effect.Sum
@@ -14,6 +15,7 @@ import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Control
 import Data.Coerce
 import Prelude hiding (fail)
 
@@ -36,7 +38,7 @@ runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, MonadBase b, MonadIO, MonadPlus, MonadTrans, MonadTransControl)
 
 instance (Carrier sig m, Effect sig) => MonadFail (FailC m) where
   fail s = FailC (throwError s)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -8,6 +8,7 @@ module Control.Effect.Fresh
 ) where
 
 import Control.Applicative (Alternative(..))
+import Control.Monad.Base
 import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Effect.Sum
@@ -15,6 +16,7 @@ import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Control
 
 data Fresh m k
   = Fresh (Int -> k)
@@ -51,7 +53,7 @@ runFresh :: Functor m => FreshC m a -> m a
 runFresh = evalState 0 . runFreshC
 
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, MonadBase b, MonadFail, MonadIO, MonadPlus, MonadTrans, MonadTransControl)
 
 instance (Carrier sig m, Effect sig) => Carrier (Fresh :+: sig) (FreshC m) where
   eff (L (Fresh   k)) = FreshC $ do

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, RankNTypes, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
 ( NonDet(..)
 , Alternative(..)
@@ -7,6 +7,7 @@ module Control.Effect.NonDet
 ) where
 
 import Control.Applicative (Alternative(..))
+import Control.Monad.Base
 import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
@@ -77,6 +78,10 @@ instance MonadPlus (NonDetC m)
 instance MonadTrans NonDetC where
   lift m = NonDetC (\ cons nil -> m >>= flip cons nil)
   {-# INLINE lift #-}
+
+instance MonadBase b m => MonadBase b (NonDetC m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
 
 instance (Carrier sig m, Effect sig) => Carrier (NonDet :+: sig) (NonDetC m) where
   eff (L Empty)      = empty

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -6,6 +6,7 @@ module Control.Effect.Pure
 ) where
 
 import Control.Effect.Carrier
+import Control.Monad.Base
 import Data.Coerce
 
 data Pure (m :: * -> *) k
@@ -48,3 +49,5 @@ instance Monad PureC where
 instance Carrier Pure PureC where
   eff v = case v of {}
   {-# INLINE eff #-}
+
+instance MonadBase PureC PureC where liftBase = id

--- a/src/Control/Effect/Random.hs
+++ b/src/Control/Effect/Random.hs
@@ -15,10 +15,12 @@ import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
+import Control.Monad.Base
 import Control.Monad.Fail
 import Control.Monad.Random.Class (MonadInterleave(..), MonadRandom(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Control
 import qualified System.Random as R (Random(..), RandomGen(..), StdGen, newStdGen)
 
 data Random m k
@@ -63,7 +65,7 @@ evalRandomIO :: MonadIO m => RandomC R.StdGen m a -> m a
 evalRandomIO m = liftIO R.newStdGen >>= flip evalRandom m
 
 newtype RandomC g m a = RandomC { runRandomC :: StateC g m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, MonadBase b, MonadFail, MonadIO, MonadPlus, MonadTrans, MonadTransControl)
 
 instance (Carrier sig m, Effect sig, R.RandomGen g) => MonadRandom (RandomC g m) where
   getRandom = RandomC $ do

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -44,6 +44,11 @@ instance Effect Resource where
 -- if @op@ throws an exception.
 --
 -- 'bracket' is safe in the presence of asynchronous exceptions.
+--
+-- If all the carrier types in your effect stack are instances of
+-- 'MonadBaseControl', you may not need 'Resource', as the @lifted-base@
+-- package provides APIs equivalent in power. The 'Resource' effect is
+-- useful when working with non-@MBC@ carriers such as 'NonDet'.
 bracket :: (Member Resource sig, Carrier sig m)
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -1,4 +1,21 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-|
+The 'Resource' effect provides functions that enable safe acquisition
+and relinquishment of resources, using the 'bracket' pattern as specified
+by 'Control.Exception'.
+
+If all the carrier types in your effect stack are instances of
+'MonadBaseControl', you may not need 'Resource', as the @lifted-base@
+package provides a more complete interface. Be aware, however, that it
+is possible to misuse the 'MonadBaseControl' interface to produce
+unexpected results with certain carrier types. The 'Resource' effect
+is not subject to these limitations, and also works for carriers without
+a 'MonadBaseControl' instance, such as 'NonDet'. For more information
+about correct 'MonadBaseControl' use, consult Edward Yang's post:
+<http://blog.ezyang.com/2012/01/monadbasecontrol-is-unsound/>
+-}
+-- {}
+
 module Control.Effect.Resource
 ( Resource(..)
 , bracket
@@ -44,11 +61,6 @@ instance Effect Resource where
 -- if @op@ throws an exception.
 --
 -- 'bracket' is safe in the presence of asynchronous exceptions.
---
--- If all the carrier types in your effect stack are instances of
--- 'MonadBaseControl', you may not need 'Resource', as the @lifted-base@
--- package provides APIs equivalent in power. The 'Resource' effect is
--- useful when working with non-@MBC@ carriers such as 'NonDet'.
 bracket :: (Member Resource sig, Carrier sig m)
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -15,6 +15,7 @@ import           Control.Effect.Reader
 import           Control.Effect.Sum
 import qualified Control.Exception as Exc
 import           Control.Monad (MonadPlus(..))
+import           Control.Monad.Base
 import           Control.Monad.Fail
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
@@ -83,6 +84,10 @@ newtype ResourceC m a = ResourceC { runResourceC :: ReaderC (Handler m) m a }
 
 instance MonadTrans ResourceC where
   lift = ResourceC . lift
+
+instance MonadBase b m => MonadBase b (ResourceC m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
 
 newtype Handler m = Handler (forall x . m x -> IO x)
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -116,6 +116,10 @@ newtype ResumableWithC err m a = ResumableWithC { runResumableWithC :: ReaderC (
 
 newtype Handler err m = Handler { runHandler :: forall x . err x -> m x }
 
+instance MonadTrans (ResumableWithC err) where
+  lift = ResumableWithC . lift
+  {-# INLINE lift #-}
+
 instance Carrier sig m => Carrier (Resumable err :+: sig) (ResumableWithC err m) where
   eff (L (Resumable err k)) = ResumableWithC (ReaderC (\ handler -> runHandler handler err)) >>= k
   eff (R other)             = ResumableWithC (eff (R (handleCoercible other)))

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State.Lazy
 ( State (..)
 , get
@@ -16,10 +16,12 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.Sum
 import Control.Effect.State.Internal
-import Control.Monad (MonadPlus(..))
+import Control.Monad (MonadPlus(..), liftM)
+import Control.Monad.Base
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Control
 import Prelude hiding (fail)
 
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
@@ -61,6 +63,24 @@ instance (Alternative m, Monad m) => MonadPlus (StateC s m)
 instance MonadTrans (StateC s) where
   lift m = StateC (\ s -> (,) s <$> m)
   {-# INLINE lift #-}
+
+instance MonadBase b m => MonadBase b (StateC e m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
+
+instance MonadTransControl (StateC s) where
+  type StT (StateC s) a = (s, a)
+  liftWith f = StateC $ \s -> liftM (\a -> (s, a)) (f (runState s))
+  restoreT   = StateC . const
+  {-# INLINABLE liftWith #-}
+  {-# INLINABLE restoreT #-}
+
+instance MonadBaseControl b m => MonadBaseControl b (StateC s m) where
+  type StM (StateC s m) a = ComposeSt (StateC s) m a
+  liftBaseWith = defaultLiftBaseWith
+  restoreM     = defaultRestoreM
+  {-# INLINABLE liftBaseWith #-}
+  {-# INLINABLE restoreM #-}
 
 instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) where
   eff (L (Get   k)) = StateC (\ s -> runState s (k s))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Trace
 ( Trace(..)
 , trace
@@ -15,9 +15,11 @@ import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
+import Control.Monad.Base
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Control
 import Data.Bifunctor (first)
 import Data.Coerce
 import System.IO
@@ -51,6 +53,24 @@ instance MonadTrans TraceByPrintingC where
   lift = TraceByPrintingC
   {-# INLINE lift #-}
 
+instance MonadBase b m => MonadBase b (TraceByPrintingC m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
+
+instance MonadTransControl TraceByPrintingC where
+  type StT TraceByPrintingC a = a
+  liftWith f = TraceByPrintingC $ f runTraceByPrinting
+  restoreT   = TraceByPrintingC
+  {-# INLINABLE liftWith #-}
+  {-# INLINABLE restoreT #-}
+
+instance MonadBaseControl b m => MonadBaseControl b (TraceByPrintingC m) where
+  type StM (TraceByPrintingC m) a = ComposeSt TraceByPrintingC m a
+  liftBaseWith = defaultLiftBaseWith
+  restoreM     = defaultRestoreM
+  {-# INLINABLE liftBaseWith #-}
+  {-# INLINABLE restoreM #-}
+
 instance (MonadIO m, Carrier sig m) => Carrier (Trace :+: sig) (TraceByPrintingC m) where
   eff (L (Trace s k)) = liftIO (hPutStrLn stderr s) *> k
   eff (R other)       = TraceByPrintingC (eff (handleCoercible other))
@@ -70,6 +90,24 @@ instance MonadTrans TraceByIgnoringC where
   lift = TraceByIgnoringC
   {-# INLINE lift #-}
 
+instance MonadBase b m => MonadBase b (TraceByIgnoringC m) where
+  liftBase = liftBaseDefault
+  {-# INLINE liftBase #-}
+
+instance MonadTransControl TraceByIgnoringC where
+  type StT TraceByIgnoringC a = a
+  liftWith f = TraceByIgnoringC $ f runTraceByIgnoring
+  restoreT   = TraceByIgnoringC
+  {-# INLINABLE liftWith #-}
+  {-# INLINABLE restoreT #-}
+
+instance MonadBaseControl b m => MonadBaseControl b (TraceByIgnoringC m) where
+  type StM (TraceByIgnoringC m) a = ComposeSt TraceByIgnoringC m a
+  liftBaseWith = defaultLiftBaseWith
+  restoreM     = defaultRestoreM
+  {-# INLINABLE liftBaseWith #-}
+  {-# INLINABLE restoreM #-}
+
 instance Carrier sig m => Carrier (Trace :+: sig) (TraceByIgnoringC m) where
   eff (L trace) = traceCont trace
   eff (R other) = TraceByIgnoringC (eff (handleCoercible other))
@@ -83,7 +121,7 @@ runTraceByReturning :: Functor m => TraceByReturningC m a -> m ([String], a)
 runTraceByReturning = fmap (first reverse) . runState [] . runTraceByReturningC
 
 newtype TraceByReturningC m a = TraceByReturningC { runTraceByReturningC :: StateC [String] m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, MonadBase b, MonadFail, MonadIO, MonadPlus, MonadTrans, MonadTransControl)
 
 instance (Carrier sig m, Effect sig) => Carrier (Trace :+: sig) (TraceByReturningC m) where
   eff (L (Trace m k)) = TraceByReturningC (modify (m :)) *> k

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -15,9 +15,11 @@ import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
+import Control.Monad.Base
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Control
 
 data Writer w m k
   = Tell w k
@@ -87,7 +89,7 @@ execWriter = fmap fst . runWriter
 --
 --   This is based on a post Gabriel Gonzalez made to the Haskell mailing list: https://mail.haskell.org/pipermail/libraries/2013-March/019528.html
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, MonadBase b, MonadFail, MonadIO, MonadPlus, MonadTrans, MonadTransControl)
 
 instance (Monoid w, Carrier sig m, Effect sig) => Carrier (Writer w :+: sig) (WriterC w m) where
   eff (L (Tell w     k)) = WriterC $ do

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -2,6 +2,7 @@ module Main
 ( main
 ) where
 
+import Control.Monad.Base
 import System.Environment
 import Test.DocTest
 

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -2,7 +2,6 @@ module Main
 ( main
 ) where
 
-import Control.Monad.Base
 import System.Environment
 import Test.DocTest
 

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -2,10 +2,14 @@ module Main
 ( main
 ) where
 
+import Control.Monad.Base
 import System.Environment
 import Test.DocTest
+import Build_doctests (Component (..), components)
+import Data.Foldable
 
 main :: IO ()
-main = do
+main = for_ components $ \(Component name flags pkgs sources) -> do
   args <- getArgs
-  doctest ("-isrc" : "--fast" : if null args then ["src"] else args)
+  let args = "--fast" : flags ++ pkgs ++ sources
+  doctest args


### PR DESCRIPTION
This patch introduces dependencies on `monad-control` to provide
`MonadBase`, `MonadTransControl`, and `MonadBaseControl` instances for
the carriers that support it. Carriers that contain state carriers
containing recursive (scoped) occurrencies of their base monad seem
not to admit a `MonadTransControl` instance, as the `StT` type cannot
be fully expressed.

This enables compatibility with the `monad-control` ecosystem, which opens
us up for use with a number of exciting libraries such as `streamly`.

As this adds instances, it is a minor version bump. I vote we put this into 0.3.1.