### PR TITLE
Add and INLINE inferred Applicative methods explicitly.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 # 0.3.1.0
 
+- Improved speed of `Reader`, `State`, `Writer`, and `Pure` effects by defining and inlining auxiliary `Applicative` methods.
 - Adds `runInterpret` & `runInterpretState` handlers in `Control.Effect.Interpret` as a convenient way to experiment with effect handlers without defining a new carrier type and `Carrier` instance. Such handlers are somewhat less efficient than custom `Carrier`s, but allow for a smooth upgrade path when more efficiency is required.
 
 

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -32,6 +32,9 @@ instance Functor PureC where
   fmap = coerce
   {-# INLINE fmap #-}
 
+  a <$ _ = pure a
+  {-# INLINE (<$) #-}
+
 instance Applicative PureC where
   pure = PureC
   {-# INLINE pure #-}

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -5,6 +5,7 @@ module Control.Effect.Pure
 , PureC(..)
 ) where
 
+import Control.Applicative
 import Control.Effect.Carrier
 import Data.Coerce
 
@@ -37,6 +38,15 @@ instance Applicative PureC where
 
   (<*>) = coerce
   {-# INLINE (<*>) #-}
+
+  liftA2 = coerce
+  {-# INLINE liftA2 #-}
+
+  _ *> b = b
+  {-# INLINE (*>) #-}
+
+  a <* _ = a
+  {-# INLINE (<*) #-}
 
 instance Monad PureC where
   return = pure

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -66,6 +66,10 @@ instance Applicative m => Applicative (ReaderC r m) where
   {-# INLINE pure #-}
   ReaderC f <*> ReaderC a = ReaderC (liftA2 (<*>) f a)
   {-# INLINE (<*>) #-}
+  ReaderC u *> ReaderC v = ReaderC $ \ r -> u r *> v r
+  {-# INLINE (*>) #-}
+  ReaderC u <* ReaderC v = ReaderC $ \ r -> u r <* v r
+  {-# INLINE (<*) #-}
 
 instance Alternative m => Alternative (ReaderC r m) where
   empty = ReaderC (const empty)

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -35,6 +35,8 @@ instance (Functor m, Monad m) => Applicative (StateC s m) where
     ~(s'', x) <- mx s'
     return (s'', f x)
   {-# INLINE (<*>) #-}
+  m *> k = m >>= \_ -> k
+  {-# INLINE (*>) #-}
 
 instance Monad m => Monad (StateC s m) where
   m >>= k  = StateC $ \ s -> do

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -30,6 +30,7 @@ instance Functor m => Functor (StateC s m) where
 
 instance (Functor m, Monad m) => Applicative (StateC s m) where
   pure a = StateC $ \ s -> pure (s, a)
+  {-# INLINE pure #-}
   StateC mf <*> StateC mx = StateC $ \ s -> do
     ~(s', f) <- mf s
     ~(s'', x) <- mx s'

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -52,6 +52,8 @@ instance Monad m => Applicative (StateC s m) where
     let fa = f' a'
     fa `seq` pure (s'', fa)
   {-# INLINE (<*>) #-}
+  m *> k = m >>= \_ -> k
+  {-# INLINE (*>) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
   empty = StateC (const empty)

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -46,6 +46,7 @@ newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance Monad m => Applicative (StateC s m) where
   pure a = StateC (\ s -> pure (s, a))
+  {-# INLINE pure #-}
   StateC f <*> StateC a = StateC $ \ s -> do
     (s', f') <- f s
     (s'', a') <- a s'


### PR DESCRIPTION
The default definition of these functions for Reader and State does a
little bit too much work (there is an avoidable fmap in both).
We can also define zero-cost `*>`, `<*`, and `liftA2` for Pure.

This cuts down the `StateC` standalone tests by a factor of 4.