### PR TITLE
Combat cubic-caller problem with MonadUnliftIO instances

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 - Improved speed of `Reader`, `State`, `Writer`, and `Pure` effects by defining and inlining auxiliary `Applicative` methods.
 - Adds `runInterpret` & `runInterpretState` handlers in `Control.Effect.Interpret` as a convenient way to experiment with effect handlers without defining a new carrier type and `Carrier` instance. Such handlers are somewhat less efficient than custom `Carrier`s, but allow for a smooth upgrade path when more efficiency is required.
+- Added `unliftio-core` as a dependency so as to provide a blessed API for unlift-style effects and a solution to the cubic-caller problem.
 
 
 # 0.3.0.0

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -45,6 +45,7 @@ library
   build-depends:       base >=4.9 && <4.13
                      , deepseq >=1.4.3 && <1.5
                      , MonadRandom >=0.5 && <0.6
+                     , unliftio-core >= 0.1.2
                      , random
                      , transformers
   hs-source-dirs:      src

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -12,6 +12,7 @@ import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 import Data.Coerce
 
@@ -44,3 +45,9 @@ instance MonadTrans LiftC where
 
 instance Monad m => Carrier (Lift m) (LiftC m) where
   eff = LiftC . (>>= runLiftC) . unLift
+
+instance MonadUnliftIO m => MonadUnliftIO (LiftC m) where
+  askUnliftIO = LiftC $ withUnliftIO $ \u -> return (UnliftIO (unliftIO u . runLiftC))
+  {-# INLINE askUnliftIO #-}
+  withRunInIO inner = LiftC $ withRunInIO $ \run -> inner (run . runLiftC)
+  {-# INLINE withRunInIO #-}

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -14,6 +14,7 @@ import Control.Effect.Sum
 import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 import Prelude hiding (fail)
 
@@ -90,6 +91,12 @@ instance (Alternative m, Monad m) => MonadPlus (ReaderC r m)
 instance MonadTrans (ReaderC r) where
   lift = ReaderC . const
   {-# INLINE lift #-}
+
+instance MonadUnliftIO m => MonadUnliftIO (ReaderC r m) where
+  askUnliftIO = ReaderC $ \r -> withUnliftIO $ \u -> pure (UnliftIO (\(ReaderC x) -> unliftIO u (x r)))
+  {-# INLINE askUnliftIO #-}
+  withRunInIO inner = ReaderC $ \r -> withRunInIO $ \go -> inner (go . runReader r)
+  {-# INLINE withRunInIO #-}
 
 instance Carrier sig m => Carrier (Reader r :+: sig) (ReaderC r m) where
   eff (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -6,7 +6,7 @@ module Control.Effect.Resource
 , finally
 , onException
 , runResource
-, unliftResource
+, withResource
 , ResourceC(..)
 ) where
 
@@ -82,10 +82,10 @@ runResource handler = runReader (Handler handler) . runResourceC
 
 -- | A helper for 'runResource' that uses 'withRunInIO' to automatically
 -- select a correct unlifting function.
-unliftResource :: MonadUnliftIO m
+withResource :: MonadUnliftIO m
                => ResourceC m a
                -> m a
-unliftResource r = withRunInIO (\f -> runHandler (Handler f) r)
+withResource r = withRunInIO (\f -> runHandler (Handler f) r)
 
 newtype ResourceC m a = ResourceC { runResourceC :: ReaderC (Handler m) m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus)


### PR DESCRIPTION
Thanks to a long and fruitful conversation in #155 with @mitchellwrosen and a [tweet thread](https://twitter.com/haskell_cat/status/1119317660087484418) from @gelisam, I’ve come to the conclusion that `MonadBaseControl` is indeed an unsafe abstraction, and it’s not responsible of us to provide built-in `MonadBaseControl` instances for the carriers. (However, we will provide a package with orphan `MBC` instances to enable use of `fused-effects` to consumers locked into the `MBC` ecosystem, with appropriate ☠️ DANGER ☠️ signs around it.)

I initially dismissed the `unliftio-core` package, and I was wrong to do so – 🎩 to @mitchellwrosen for pointing it out initially. Though it is significantly less powerful than `MonadBaseControl`, it is not possible to hold incorrectly, and it solves what I refer to as the “cubic-caller” problem: the fact that carrier invocation functions such as `runResource`, of the form

```haskell
runResource :: (forall x . m x -> IO x) -- ^ "unlifting" function to run the carrier in 'IO'
            -> ResourceC m a
            -> m a
```

become an ergonomics disaster when three or more such functions are combined:

```haskell
runM 
  . runResource runM
  . runCatch (runM . runResource runM)
  . runTimeout (runM . runResource runM . runCatch (runM . runResource runM))
  . runAsync (runM . runResource runM . runCatch (runM . runResource runM) . runTimeout (runM . runResource runM . runCatch (runM . runResource runM)))
```

Each `runFoo` function must have its unlifting function manually specified by composing all the prior unlifting functions, resulting in O(n³) total unlifting-function calls. I’ve encountered this in production and it’s really, really painful. 

The critical insight that passed me by here was that the `Handler` type used internally in the implementation of `ResourceT`, `TimeoutT`, etc. is identical to the `UnliftIO` type provided by `MonadUnliftIO`:

```haskell
newtype UnliftIO m = UnliftIO { unliftIO :: forall a. m a -> IO a }
```

Because we can define lawful `MonadUnliftIO` instances for `LiftC` and `ReaderC`, and `ResourceC` and all other unlifting effects all use a `Handler` internally, we can define a valid `MonadUnliftIO` instance for `ResourceC`, _and a generalized, ergonomic version of runResource_, as follows:

``` haskell
instance MonadUnliftIO m => MonadUnliftIO (ResourceC m) where
  askUnliftIO = ResourceC . ReaderC $ \(Handler h) ->
    withUnliftIO $ \u -> pure (UnliftIO $ \r -> unliftIO u (runResource h r))

unliftResource :: MonadUnliftIO m
               => ResourceC m a
               -> m a
unliftResource r = withRunInIO (\f -> runHandler (Handler f) r)
```

This means that the above cubic-caller code becomes:
```
runM 
  . unliftResource
  . unliftCatch
  . unliftAsync
  $ go
```

Which is a huge ergonomic improvement.

In addition, `unliftio-core` has fewer dependencies than does `monad-control`.