### PR TITLE
Inline the runState family of functions.

### DIFF
--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -31,12 +31,14 @@ instance Effect (State s) where
 --   prop> snd (run (runState a get)) == a
 get :: (Member (State s) sig, Carrier sig m) => m s
 get = send (Get pure)
+{-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) == applyFun f a
 gets :: (Member (State s) sig, Carrier sig m) => (s -> a) -> m a
 gets f = send (Get (pure . f))
+{-# INLINEABLE gets #-}
 
 -- | Replace the state value with a new value.
 --
@@ -45,6 +47,7 @@ gets f = send (Get (pure . f))
 --   prop> snd (run (runState a (put b *> get))) == b
 put :: (Member (State s) sig, Carrier sig m) => s -> m ()
 put s = send (Put s (pure ()))
+{-# INLINEABLE put #-}
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is strict in the new state.
@@ -54,11 +57,13 @@ modify :: (Member (State s) sig, Carrier sig m) => (s -> s) -> m ()
 modify f = do
   a <- get
   put $! f a
+{-# INLINEABLE modify #-}
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
 modifyLazy :: (Member (State s) sig, Carrier sig m) => (s -> s) -> m ()
 modifyLazy f = get >>= put . f
+{-# INLINEABLE modifyLazy #-}
 
 -- $setup
 -- >>> :seti -XFlexibleContexts

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -79,18 +79,21 @@ instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) w
 --   prop> take 5 . snd . run $ runState () (traverse pure [1..]) == [1,2,3,4,5]
 runState :: s -> StateC s m a -> m (s, a)
 runState s c = runStateC c s
+{-# INLINE[3] runState #-}
 
 -- | Run a lazy 'State' effect, yielding the result value and discarding the final state.
 --
 --   prop> run (evalState a (pure b)) == b
 evalState :: forall s m a . Functor m => s -> StateC s m a -> m a
 evalState s = fmap snd . runState s
+{-# INLINE[3] evalState #-}
 
 -- | Run a lazy 'State' effect, yielding the final state and discarding the return value.
 --
 --   prop> run (execState a (pure b)) == a
 execState :: forall s m a . Functor m => s -> StateC s m a -> m s
 execState s = fmap fst . runState s
+{-# INLINE[3] execState #-}
 
 -- $setup
 -- >>> :seti -XFlexibleContexts

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -26,19 +26,22 @@ import Prelude hiding (fail)
 --
 --   prop> run (runState a (pure b)) == (a, b)
 runState :: s -> StateC s m a -> m (s, a)
-runState = flip runStateC
+runState s x = runStateC x s
+{-# INLINE[3] runState #-}
 
 -- | Run a 'State' effect, yielding the result value and discarding the final state.
 --
 --   prop> run (evalState a (pure b)) == b
 evalState :: forall s m a . Functor m => s -> StateC s m a -> m a
 evalState s = fmap snd . runState s
+{-# INLINE[3] evalState #-}
 
 -- | Run a 'State' effect, yielding the final state and discarding the return value.
 --
 --   prop> run (execState a (pure b)) == a
 execState :: forall s m a . Functor m => s -> StateC s m a -> m s
 execState s = fmap fst . runState s
+{-# INLINE[3] execState #-}
 
 
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -73,14 +73,14 @@ censor f m = send (Censor f m pure)
 --   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
 runWriter :: Monoid w => WriterC w m a -> m (w, a)
 runWriter = runState mempty . runWriterC
-{-# INLINE runWriter #-}
+{-# INLINE[3] runWriter #-}
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
 --   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
 execWriter :: (Monoid w, Functor m) => WriterC w m a -> m w
 execWriter = fmap fst . runWriter
-{-# INLINE execWriter #-}
+{-# INLINE[3] execWriter #-}
 
 
 -- | A space-efficient carrier for 'Writer' effects.

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -73,14 +73,14 @@ censor f m = send (Censor f m pure)
 --   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
 runWriter :: Monoid w => WriterC w m a -> m (w, a)
 runWriter = runState mempty . runWriterC
-{-# INLINE[3] runWriter #-}
+{-# INLINE runWriter #-}
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
 --   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
 execWriter :: (Monoid w, Functor m) => WriterC w m a -> m w
 execWriter = fmap fst . runWriter
-{-# INLINE[3] execWriter #-}
+{-# INLINE execWriter #-}
 
 
 -- | A space-efficient carrier for 'Writer' effects.


### PR DESCRIPTION
Prior testing (during the implementation of #129) revealed that
applying INLINE pragmas to the `runState` family of functions yielded
slowdowns (though this was not true of `runWriter`, due to `Writer`
being a newtype). The inliner is a very tricky thing. While reading
the `polysemy` source, I found out that its state type inlines
`runState` only at stage 3 and afterwards. It's not clear to me *why*
this produces performance improvements, but it does.

Before:

|        | 100     | 1000   | 10000   |
|--------|---------|--------|---------|
| Writer | 65.58ns | 569ns  | 5500ns |
| State  | 68.39ns | 565ns  | 5628ns |

After:

|        | 100     | 1000   | 10000   |
|--------|---------|--------|---------|
| Writer | 64.93ns | 540ns  | 5225ns  |
| State  | 63.89ns | 540ns  | 5421ns  |

This makes for a roughly 7% performance game under
`-O2`. (Interestingly enough, the performance gains under `-O1` are,
proportionally, much greater.)