### PR TITLE
Remove potential for misuse of `runResource`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 # v0.5.0.0
 
+## Backwards-incompatible changes
+
 - Replaces `runResource` with an equivalent function that uses `MonadUnliftIO` to select the correct unlifting function (a la `withResource`, which is removed in favor of `runResource`).
 
 # v0.4.0.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# v0.5.0.0
+
+- Replaces `runResource` with an equivalent function that uses `MonadUnliftIO` to select the correct unlifting function (a la `withResource`, which is removed in favor of `runResource`).
+
 # v0.4.0.0
 
 ## Backwards-incompatible changes


### PR DESCRIPTION
As outlined in #180, misuse of the unlifting function that is passed
to `runResource` can lead to surprising behavior, such as silent
dropping of effects. While we could have used the forklift pattern to
perform the bracketing on a separate, IO-bound thread, a simpler
compromise is to make the `withResource` helper function the canonical
way to execute a `Resource` effect.

This is a breaking change, so it will entail that the next release be 0.5.0.0.