### PR TITLE
Constrained effects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 # v0.5.0.0
 
+- Derives `Generic1` instances for all non-existentially-quantified effect datatypes.
+
 ## Backwards-incompatible changes
 
 - Replaces `runResource` with an equivalent function that uses `MonadUnliftIO` to select the correct unlifting function (a la `withResource`, which is removed in favor of `runResource`).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 
 - Changes the signature of `eff` from `sig m (m a) -> m a` to `sig m a -> m a`, requiring effects to hold `m k` in their continuation positions instead of merely `k`. This was done in order to improve interoperability with other presentations of higher-order syntax, e.g. `bound`; syntax used with `bound` can now be given `HFunctor` and `Carrier` instances.
 
+  To upgrade effects used with previous versions, change any continuations from `k` to `m k`. If no existential type variables appear in the effect, you can derive `Generic1`, and thence `HFunctor` & `Effect` instances. Otherwise, implement the required instances by hand. Since continuation positions now occur in `m`, `hmap` definitions will have to apply the higher-order function to these as well.
+
 - Adds `Functor` constraints to `hmap` and `Monad` constraints to `handle`, allowing a greater variety of instances to be defined (e.g. for recursively-nested syntax).
 
 - Replaces the default definitions of `hmap` and `handle` with derivations based on `Generic1` instead of `Coercible`. Therefore, first-order effects wishing to derive these instances will require `Generic1` instances, presumably derived using `-XDeriveGeneric`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,11 +8,11 @@
 
 - Changes the signature of `eff` from `sig m (m a) -> m a` to `sig m a -> m a`, requiring effects to hold `m k` in their continuation positions instead of merely `k`. This was done in order to improve interoperability with other presentations of higher-order syntax, e.g. `bound`; syntax used with `bound` can now be given `HFunctor` and `Carrier` instances.
 
-- Removes `fmap'`, as it is now obsolete.
-
 - Adds `Functor` constraints to `hmap` and `Monad` constraints to `handle`, allowing a greater variety of instances to be defined (e.g. for recursively-nested syntax).
 
 - Replaces the default definitions of `hmap` and `handle` with derivations based on `Generic1` instead of `Coercible`. Therefore, first-order effects wishing to derive these instances will require `Generic1` instances, presumably derived using `-XDeriveGeneric`.
+
+- Deprecates `fmap'` in favour of `fmap`.
 
 - Deprecates `handlePure` in favour of `hmap`.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@
 
 - Adds `Functor` constraints to `hmap` and `Monad` constraints to `handle`, allowing a greater variety of instances to be defined (e.g. for recursively-nested syntax).
 
+- Replaces the default definitions of `hmap` and `handle` with derivations based on `Generic1` instead of `Coercible`. Therefore, first-order effects wishing to derive these instances will require `Generic1` instances, presumably derived using `-XDeriveGeneric`.
+
 # v0.4.0.0
 
 ## Backwards-incompatible changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
 
 - Replaces the default definitions of `hmap` and `handle` with derivations based on `Generic1` instead of `Coercible`. Therefore, first-order effects wishing to derive these instances will require `Generic1` instances, presumably derived using `-XDeriveGeneric`.
 
+- Deprecates `handlePure` in favour of `hmap`.
+
 # v0.4.0.0
 
 ## Backwards-incompatible changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,12 @@
 
 - Replaces `runResource` with an equivalent function that uses `MonadUnliftIO` to select the correct unlifting function (a la `withResource`, which is removed in favor of `runResource`).
 
+- Changes the signature of `eff` from `sig m (m a) -> m a` to `sig m a -> m a`, requiring effects to hold `m k` in their continuation positions instead of merely `k`. This was done in order to improve interoperability with other presentations of higher-order syntax, e.g. `bound`; syntax used with `bound` can now be given `HFunctor` and `Carrier` instances.
+
+- Removes `fmap'`, as it is now obsolete.
+
+- Adds `Functor` constraints to `hmap` and `Monad` constraints to `handle`, allowing a greater variety of instances to be defined (e.g. for recursively-nested syntax).
+
 # v0.4.0.0
 
 ## Backwards-incompatible changes

--- a/README.md
+++ b/README.md
@@ -154,17 +154,18 @@ example4 = runM . runReader "hello" . runState 0 $ do
 
 ### Required compiler extensions
 
-To use effects, you'll need a relatively-uncontroversial set of extensions: `-XFlexibleContexts`, `-XFlexibleInstances`, and `-XMultiParamTypeClasses`.
+To use effects, you'll typically need `-XFlexibleContexts`.
 
-When defining your own effects, you'll need `-XTypeOperators` to declare a `Carrier` instance over (`:+:`), and `-XUndecidableInstances` to satisfy the coverage condition for this instance. You may need `-XKindSignatures` if GHC cannot correctly infer the type of your handler; see the [documentation on common errors][common] for more information about this case.
+When defining your own effects, you may need `-XKindSignatures` if GHC cannot correctly infer the type of your handler; see the [documentation on common errors][common] for more information about this case. `-XDeriveGeneric` can be used with many first-order effects to derive default implementations of `HFunctor` and `Effect`.
+
+When defining carriers, you'll need `-XTypeOperators` to declare a `Carrier` instance over (`:+:`), `-XFlexibleInstances` to loosen the conditions on the instance, `-XMultiParamTypeClasses` since `Carrier` takes two parameters, and `-XUndecidableInstances` to satisfy the coverage condition for this instance.
 
 [common]: https://github.com/fused-effects/fused-effects/blob/master/docs/common_errors.md
 
-The following invocation, taken from the teletype example, should suffice for any use or construction of effects:
+The following invocation, taken from the teletype example, should suffice for most use or construction of effects and carriers:
 
 ```haskell
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving,
-    KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 ```
 
 ### Defining new effects

--- a/docs/common_errors.md
+++ b/docs/common_errors.md
@@ -8,40 +8,38 @@ progress.)
 
 ## I'm getting kind errors when implementing a `Carrier` instance!
 
-Given a `Teletype` data type:
+Given an effect datatype that doesn’t use the `m` parameter:
 
 ```haskell
-data Teletype m k
-  = Read (String -> k)
-  | Write String k
+data Fail m k
+  = Fail String
   deriving (Functor)
 
-newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
+newtype FailC m a = FailC { runFailC :: m (Either String a) }
 ```
 
 Declaring a `Carrier` instance will fail:
 
 ```haskell
 instance (Carrier sig m, Effect sig)
-    => Carrier (Teletype :+: sig) (TeletypeIOC m) where…
+    => Carrier (Fail :+: sig) (FailC m) where…
 ```
 
 ```
 • Expected kind ‘(* -> *) -> * -> *’,
-    but ‘Teletype :+: sig’ has kind ‘* -> * -> *’
-• In the first argument of ‘Carrier’, namely ‘(Teletype :+: sig)’
+    but ‘Fail :+: sig’ has kind ‘* -> * -> *’
+• In the first argument of ‘Carrier’, namely ‘(Fail :+: sig)’
   In the instance declaration for
-    ‘Carrier (Teletype :+: sig) (TeletypeIOC m)
+    ‘Carrier (Fail :+: sig) (FailC m)
 ```
 
-This is because the `m` parameter to `Teletype` is inferred to be of kind `*`:
+This is because the `m` parameter to `Fail` is inferred to be of kind `*`:
 though `Carrier` expects an `m` of kind `* -> *`, `m` is never referenced in
-the definition of `Teletype`, so GHC makes an understandable but incorrect inference.
+the definition of `Fail`, so GHC makes an understandable but incorrect inference.
 An explicit kind annotation on `m` fixes the problem.
 
 ```haskell
-data Teletype (m :: * -> *) k
-  = Read (String -> k)
-  | Write String k
+data Fail (m :: * -> *) k
+  = Fail String
   deriving (Functor)
 ```

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DerivingStrategies, DeriveFoldable, DeriveFunctor, DeriveTraversable, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Parser
 ( spec
 ) where
@@ -74,9 +74,14 @@ spec = describe "parser" $ do
             replicateM m (vector n')
 
 
-data Symbol (m :: * -> *) k = Satisfy (Char -> Bool) (Char -> k)
-  deriving stock (Functor)
-  deriving anyclass (HFunctor, Effect)
+data Symbol m k = Satisfy (Char -> Bool) (Char -> m k)
+  deriving (Functor)
+
+instance HFunctor Symbol where
+  hmap f (Satisfy p k) = Satisfy p (f . k)
+
+instance Effect Symbol where
+  handle state handler (Satisfy p k) = Satisfy p (handler . (<$ state) . k)
 
 satisfy :: (Carrier sig m, Member Symbol sig) => (Char -> Bool) -> m Char
 satisfy p = send (Satisfy p pure)
@@ -97,7 +102,7 @@ parse input = (>>= exhaustive) . runState input . runParseC
         exhaustive _       = empty
 
 newtype ParseC m a = ParseC { runParseC :: StateC String m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad)
+  deriving (Alternative, Applicative, Functor, Monad)
 
 instance (Alternative m, Carrier sig m, Effect sig) => Carrier (Symbol :+: sig) (ParseC m) where
   eff (L (Satisfy p k)) = do

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -149,7 +149,7 @@ instance
         runLogStdout k
 
     R other ->
-      LogStdoutC (eff (handlePure runLogStdout other))
+      LogStdoutC (eff (hmap runLogStdout other))
 
 -- The 'LogStdoutC' runner.
 runLogStdout ::

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 module Teletype where
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -1,5 +1,5 @@
 name:                fused-effects
-version:             0.4.0.0
+version:             0.5.0.0
 synopsis:            A fast, flexible, fused effect system.
 description:         A fast, flexible, fused effect system, à la Effect Handlers in Scope, Monad Transformers and Modular Algebraic Effects: What Binds Them Together, and Fusion for Free—Efficient Algebraic Effect Handlers.
 homepage:            https://github.com/fused-effects/fused-effects

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -64,6 +64,7 @@ handleCoercible = hmap coerce
 {-# INLINE handleCoercible #-}
 
 
+-- | Generic implementation of 'HFunctor'.
 class GHFunctor m m' rep rep' where
   ghmap :: (Functor m, Functor m') => (forall x . m x -> m' x) -> (rep a -> rep' a)
 
@@ -96,6 +97,7 @@ instance HFunctor f => GHFunctor m m' (Rec1 (f m)) (Rec1 (f m')) where
   ghmap f = Rec1 . hmap f . unRec1
 
 
+-- | Generic implementation of 'Effect'.
 class GEffect m m' rep rep' where
   ghandle :: (Functor f, Monad m, Monad m')
           => f ()

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -111,6 +111,9 @@ instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :+: r) (l' :+
 instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :*: r) (l' :*: r') where
   ghandle state handler (l :*: r) = ghandle state handler l :*: ghandle state handler r
 
+instance GEffect m m' V1 V1 where
+  ghandle _ _ v = case v of {}
+
 instance GEffect m m' U1 U1 where
   ghandle _ _ = coerce
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -61,7 +61,6 @@ handleCoercible = hmap coerce
 {-# INLINE handleCoercible #-}
 
 
-
 class GHFunctor m m' rep rep' where
   ghmap :: (Functor m, Functor m') => (forall x . m x -> m' x) -> (rep a -> rep' a)
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -62,3 +62,6 @@ instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) 
 
 instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) (l' :*: r') where
   ghmap f (l :*: r) = ghmap f l :*: ghmap f r
+
+instance GHFunctor m m' (K1 R c) (K1 R c) where
+  ghmap _ = coerce

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -51,6 +51,7 @@ class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
 handlePure :: (HFunctor sig, Functor f, Functor g) => (forall x . f x -> g x) -> sig f a -> sig g a
 handlePure = hmap
 {-# INLINE handlePure #-}
+{-# DEPRECATED handlePure "handlePure has been subsumed by hmap." #-}
 
 -- | Thread a 'Coercible' carrier through an 'HFunctor'.
 --

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -13,6 +13,9 @@ module Control.Effect.Carrier
 import Data.Coerce
 import GHC.Generics
 
+-- | Higher-order functors of kind @(* -> *) -> (* -> *)@ map functors to functors.
+--
+--   All effects must be 'HFunctor's.
 class HFunctor h where
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
   --

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -80,34 +80,44 @@ class GHFunctor m m' rep rep' where
 
 instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') where
   ghmap f = M1 . ghmap f . unM1
+  {-# INLINE ghmap #-}
 
 instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) (l' :+: r') where
   ghmap f (L1 l) = L1 (ghmap f l)
   ghmap f (R1 r) = R1 (ghmap f r)
+  {-# INLINE ghmap #-}
 
 instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) (l' :*: r') where
   ghmap f (l :*: r) = ghmap f l :*: ghmap f r
+  {-# INLINE ghmap #-}
 
 instance GHFunctor m m' V1 V1 where
   ghmap _ v = case v of {}
+  {-# INLINE ghmap #-}
 
 instance GHFunctor m m' U1 U1 where
   ghmap _ = id
+  {-# INLINE ghmap #-}
 
 instance GHFunctor m m' (K1 R c) (K1 R c) where
   ghmap _ = coerce
+  {-# INLINE ghmap #-}
 
 instance GHFunctor m m' Par1 Par1 where
   ghmap _ = coerce
+  {-# INLINE ghmap #-}
 
 instance (Functor f, GHFunctor m m' g g') => GHFunctor m m' (f :.: g) (f :.: g') where
   ghmap f = Comp1 . fmap (ghmap f) . unComp1
+  {-# INLINE ghmap #-}
 
 instance GHFunctor m m' (Rec1 m) (Rec1 m') where
   ghmap f = Rec1 . f . unRec1
+  {-# INLINE ghmap #-}
 
 instance HFunctor f => GHFunctor m m' (Rec1 (f m)) (Rec1 (f m')) where
   ghmap f = Rec1 . hmap f . unRec1
+  {-# INLINE ghmap #-}
 
 
 -- | Generic implementation of 'Effect'.
@@ -121,31 +131,41 @@ class GEffect m m' rep rep' where
 
 instance GEffect m m' rep rep' => GEffect m m' (M1 i c rep) (M1 i c rep') where
   ghandle state handler = M1 . ghandle state handler . unM1
+  {-# INLINE ghandle #-}
 
 instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :+: r) (l' :+: r') where
   ghandle state handler (L1 l) = L1 (ghandle state handler l)
   ghandle state handler (R1 r) = R1 (ghandle state handler r)
+  {-# INLINE ghandle #-}
 
 instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :*: r) (l' :*: r') where
   ghandle state handler (l :*: r) = ghandle state handler l :*: ghandle state handler r
+  {-# INLINE ghandle #-}
 
 instance GEffect m m' V1 V1 where
   ghandle _ _ v = case v of {}
+  {-# INLINE ghandle #-}
 
 instance GEffect m m' U1 U1 where
   ghandle _ _ = coerce
+  {-# INLINE ghandle #-}
 
 instance GEffect m m' (K1 R c) (K1 R c) where
   ghandle _ _ = coerce
+  {-# INLINE ghandle #-}
 
 instance GEffect m m' Par1 Par1 where
   ghandle state _ = Par1 . (<$ state) . unPar1
+  {-# INLINE ghandle #-}
 
 instance (Functor f, GEffect m m' g g') => GEffect m m' (f :.: g) (f :.: g') where
   ghandle state handler = Comp1 . fmap (ghandle state handler) . unComp1
+  {-# INLINE ghandle #-}
 
 instance GEffect m m' (Rec1 m) (Rec1 m') where
   ghandle state handler = Rec1 . handler . (<$ state) . unRec1
+  {-# INLINE ghandle #-}
 
 instance Effect f => GEffect m m' (Rec1 (f m)) (Rec1 (f m')) where
   ghandle state handler = Rec1 . handle state handler . unRec1
+  {-# INLINE ghandle #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -138,6 +138,9 @@ instance GEffect m m' U1 U1 where
 instance GEffect m m' (K1 R c) (K1 R c) where
   ghandle _ _ = coerce
 
+instance GEffect m m' Par1 Par1 where
+  ghandle state _ = Par1 . (<$ state) . unPar1
+
 instance (Functor f, GEffect m m' g g') => GEffect m m' (f :.: g) (f :.: g') where
   ghandle state handler = Comp1 . fmap (ghandle state handler) . unComp1
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -56,7 +56,7 @@ handlePure = hmap
 --
 --   This is applicable whenever @f@ is 'Coercible' to @g@, e.g. simple @newtype@s.
 handleCoercible :: (HFunctor sig, Functor f, Functor g, Coercible f g) => sig f a -> sig g a
-handleCoercible = handlePure coerce
+handleCoercible = hmap coerce
 {-# INLINE handleCoercible #-}
 
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, DeriveFunctor, FlexibleContexts, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DefaultSignatures, DeriveFunctor, EmptyCase, FlexibleContexts, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Carrier
 ( HFunctor(..)
 , Effect(..)
@@ -74,6 +74,9 @@ instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) 
 
 instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) (l' :*: r') where
   ghmap f (l :*: r) = ghmap f l :*: ghmap f r
+
+instance GHFunctor m m' V1 V1 where
+  ghmap _ v = case v of {}
 
 instance GHFunctor m m' U1 U1 where
   ghmap _ = id

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -102,6 +102,9 @@ instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :+: r) (l' :+
 instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :*: r) (l' :*: r') where
   ghandle state handler (l :*: r) = ghandle state handler l :*: ghandle state handler r
 
+instance GEffect m m' U1 U1 where
+  ghandle _ _ = coerce
+
 instance GEffect m m' (K1 R c) (K1 R c) where
   ghandle _ _ = coerce
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -91,3 +91,6 @@ class GEffect m m' rep rep' where
           -> (forall x . f (m x) -> m' (f x))
           -> rep a
           -> rep' (f a)
+
+instance GEffect m m' rep rep' => GEffect m m' (M1 i c rep) (M1 i c rep') where
+  ghandle state handler = M1 . ghandle state handler . unM1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -10,70 +10,36 @@ module Control.Effect.Carrier
 import Data.Coerce
 
 class HFunctor h where
-  -- | Functor map. This is required to be 'fmap'.
-  --
-  --   This can go away once we have quantified constraints.
-  fmap' :: (a -> b) -> (h m a -> h m b)
-  default fmap' :: Functor (h m) => (a -> b) -> (h m a -> h m b)
-  fmap' = fmap
-  {-# INLINE fmap' #-}
-
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
-  -- A definition for 'hmap' over first-order effects can be derived automatically.
-  hmap :: (forall x . m x -> n x) -> (h m a -> h n a)
-
-  default hmap :: Coercible (h m a) (h n a)
-               => (forall x . m x -> n x)
-               -> (h m a -> h n a)
-  hmap _ = coerce
-  {-# INLINE hmap #-}
+  hmap :: (Functor m, Functor n) => (forall x . m x -> n x) -> (h m a -> h n a)
 
 
 -- | The class of effect types, which must:
 --
 --   1. Be functorial in their last two arguments, and
 --   2. Support threading effects in higher-order positions through using the carrier’s suspended state.
---
--- All first-order effects (those without recursive occurrences of @m@) admit a default definition
--- of 'handle'. The @-XDeriveAnyClass@ extension allows derivation of both 'HFunctor' and 'Effect':
---
--- @
---   data State s (m :: * -> *) k
---     = Get (s -> k)
---     | Put s k
---       deriving (Functor, HFunctor, Effect)
--- @
 class HFunctor sig => Effect sig where
   -- | Handle any effects in a signature by threading the carrier’s state all the way through to the continuation.
-  handle :: Functor f
+  handle :: (Functor f, Monad m, Monad n)
          => f ()
          -> (forall x . f (m x) -> n (f x))
-         -> sig m (m a)
-         -> sig n (n (f a))
-
-  default handle :: (Functor f, Coercible (sig m (n (f a))) (sig n (n (f a))))
-                 => f ()
-                 -> (forall x . f (m x) -> n (f x))
-                 -> sig m (m a)
-                 -> sig n (n (f a))
-  handle state handler = coerce . fmap' (handler . (<$ state))
-  {-# INLINE handle #-}
-
+         -> sig m a
+         -> sig n (f a)
 
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
 class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
-  eff :: sig m (m a) -> m a
+  eff :: sig m a -> m a
 
 -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.
-handlePure :: HFunctor sig => (forall x . f x -> g x) -> sig f (f a) -> sig g (g a)
-handlePure handler = hmap handler . fmap' handler
+handlePure :: (HFunctor sig, Functor f, Functor g) => (forall x . f x -> g x) -> sig f a -> sig g a
+handlePure handler = hmap handler
 {-# INLINE handlePure #-}
 
 -- | Thread a 'Coercible' carrier through an 'HFunctor'.
 --
 --   This is applicable whenever @f@ is 'Coercible' to @g@, e.g. simple @newtype@s.
-handleCoercible :: (HFunctor sig, Coercible f g) => sig f (f a) -> sig g (g a)
+handleCoercible :: (HFunctor sig, Functor f, Functor g, Coercible f g) => sig f a -> sig g a
 handleCoercible = handlePure coerce
 {-# INLINE handleCoercible #-}

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -5,6 +5,9 @@ module Control.Effect.Carrier
 , Carrier(..)
 , handlePure
 , handleCoercible
+-- * Generic deriving of 'HFunctor' & 'Effect' instances.
+, GHFunctor(..)
+, GEffect(..)
 ) where
 
 import Data.Coerce

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -113,3 +113,6 @@ instance (Functor f, GEffect m m' g g') => GEffect m m' (f :.: g) (f :.: g') whe
 
 instance GEffect m m' (Rec1 m) (Rec1 m') where
   ghandle state handler = Rec1 . handler . (<$ state) . unRec1
+
+instance Effect f => GEffect m m' (Rec1 (f m)) (Rec1 (f m')) where
+  ghandle state handler = Rec1 . handle state handler . unRec1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -74,3 +74,6 @@ instance (Functor f, GHFunctor m m' g g') => GHFunctor m m' (f :.: g) (f :.: g')
 
 instance GHFunctor m m' (Rec1 m) (Rec1 m') where
   ghmap f = Rec1 . f . unRec1
+
+instance HFunctor f => GHFunctor m m' (Rec1 (f m)) (Rec1 (f m')) where
+  ghmap f = Rec1 . hmap f . unRec1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -17,6 +17,11 @@ import GHC.Generics
 --
 --   All effects must be 'HFunctor's.
 class HFunctor h where
+  -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.
+  fmap' :: Functor (h f) => (a -> b) -> h f a -> h f b
+  fmap' = fmap
+  {-# INLINE fmap' #-}
+
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
   --
   -- A definition for 'hmap' over first-order effects can be derived automatically provided a 'Generic1' instance is available.
@@ -25,6 +30,7 @@ class HFunctor h where
   hmap f = to1 . ghmap f . from1
   {-# INLINE hmap #-}
 
+{-# DEPRECATED fmap' "fmap' has been subsumed by fmap." #-}
 
 -- | The class of effect types, which must:
 --

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -98,3 +98,6 @@ instance GEffect m m' rep rep' => GEffect m m' (M1 i c rep) (M1 i c rep') where
 instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :+: r) (l' :+: r') where
   ghandle state handler (L1 l) = L1 (ghandle state handler l)
   ghandle state handler (R1 r) = R1 (ghandle state handler r)
+
+instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :*: r) (l' :*: r') where
+  ghandle state handler (l :*: r) = ghandle state handler l :*: ghandle state handler r

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -94,3 +94,7 @@ class GEffect m m' rep rep' where
 
 instance GEffect m m' rep rep' => GEffect m m' (M1 i c rep) (M1 i c rep') where
   ghandle state handler = M1 . ghandle state handler . unM1
+
+instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :+: r) (l' :+: r') where
+  ghandle state handler (L1 l) = L1 (ghandle state handler l)
+  ghandle state handler (R1 r) = R1 (ghandle state handler r)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -50,7 +50,7 @@ handleCoercible = handlePure coerce
 
 
 
-class GHFunctor m m' rep rep' | rep -> m, rep' -> m' where
+class GHFunctor m m' rep rep' where
   ghmap :: (Functor m, Functor m') => (forall x . m x -> m' x) -> (rep a -> rep' a)
 
 instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') where

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, DeriveFunctor, FlexibleContexts, FlexibleInstances, FunctionalDependencies, RankNTypes, UndecidableInstances #-}
+{-# LANGUAGE DefaultSignatures, DeriveFunctor, FlexibleContexts, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Carrier
 ( HFunctor(..)
 , Effect(..)
@@ -55,3 +55,7 @@ class GHFunctor m m' rep rep' | rep -> m, rep' -> m' where
 
 instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') where
   ghmap f = M1 . ghmap f . unM1
+
+instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) (l' :+: r') where
+  ghmap f (L1 l) = L1 (ghmap f l)
+  ghmap f (R1 r) = R1 (ghmap f r)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -65,3 +65,6 @@ instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) 
 
 instance GHFunctor m m' (K1 R c) (K1 R c) where
   ghmap _ = coerce
+
+instance (Functor f, GHFunctor m m' g g') => GHFunctor m m' (f :.: g) (f :.: g') where
+  ghmap f = Comp1 . fmap (ghmap f) . unComp1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -49,7 +49,7 @@ class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
 
 -- | Apply a handler specified as a natural transformation to both higher-order and continuation positions within an 'HFunctor'.
 handlePure :: (HFunctor sig, Functor f, Functor g) => (forall x . f x -> g x) -> sig f a -> sig g a
-handlePure handler = hmap handler
+handlePure = hmap
 {-# INLINE handlePure #-}
 
 -- | Thread a 'Coercible' carrier through an 'HFunctor'.

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -35,6 +35,7 @@ class HFunctor sig => Effect sig where
                  -> sig m a
                  -> sig n (f a)
   handle state handler = to1 . ghandle state handler . from1
+  {-# INLINE handle #-}
 
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -59,3 +59,6 @@ instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') wh
 instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) (l' :+: r') where
   ghmap f (L1 l) = L1 (ghmap f l)
   ghmap f (R1 r) = R1 (ghmap f r)
+
+instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) (l' :*: r') where
+  ghmap f (l :*: r) = ghmap f l :*: ghmap f r

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -12,6 +12,8 @@ import GHC.Generics
 
 class HFunctor h where
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
+  --
+  -- A definition for 'hmap' over first-order effects can be derived automatically provided a 'Generic1' instance is available.
   hmap :: (Functor m, Functor n) => (forall x . m x -> n x) -> (h m a -> h n a)
   default hmap :: (Functor m, Functor n, Generic1 (h m), Generic1 (h n), GHFunctor m n (Rep1 (h m)) (Rep1 (h n))) => (forall x . m x -> n x) -> (h m a -> h n a)
   hmap f = to1 . ghmap f . from1
@@ -22,6 +24,8 @@ class HFunctor h where
 --
 --   1. Be functorial in their last two arguments, and
 --   2. Support threading effects in higher-order positions through using the carrier’s suspended state.
+--
+-- All first-order effects (those without existential occurrences of @m@) admit a default definition of 'handle' provided a 'Generic1' instance is available for the effect.
 class HFunctor sig => Effect sig where
   -- | Handle any effects in a signature by threading the carrier’s state all the way through to the continuation.
   handle :: (Functor f, Monad m, Monad n)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -29,6 +29,12 @@ class HFunctor sig => Effect sig where
          -> (forall x . f (m x) -> n (f x))
          -> sig m a
          -> sig n (f a)
+  default handle :: (Functor f, Monad m, Monad n, Generic1 (sig m), Generic1 (sig n), GEffect m n (Rep1 (sig m)) (Rep1 (sig n)))
+                 => f ()
+                 -> (forall x . f (m x) -> n (f x))
+                 -> sig m a
+                 -> sig n (f a)
+  handle state handler = to1 . ghandle state handler . from1
 
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
@@ -77,3 +83,11 @@ instance GHFunctor m m' (Rec1 m) (Rec1 m') where
 
 instance HFunctor f => GHFunctor m m' (Rec1 (f m)) (Rec1 (f m')) where
   ghmap f = Rec1 . hmap f . unRec1
+
+
+class GEffect m m' rep rep' where
+  ghandle :: (Functor f, Monad m, Monad m')
+          => f ()
+          -> (forall x . f (m x) -> m' (f x))
+          -> rep a
+          -> rep' (f a)

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -101,3 +101,6 @@ instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :+: r) (l' :+
 
 instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :*: r) (l' :*: r') where
   ghandle state handler (l :*: r) = ghandle state handler l :*: ghandle state handler r
+
+instance GEffect m m' (K1 R c) (K1 R c) where
+  ghandle _ _ = coerce

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -97,6 +97,9 @@ instance GHFunctor m m' U1 U1 where
 instance GHFunctor m m' (K1 R c) (K1 R c) where
   ghmap _ = coerce
 
+instance GHFunctor m m' Par1 Par1 where
+  ghmap _ = coerce
+
 instance (Functor f, GHFunctor m m' g g') => GHFunctor m m' (f :.: g) (f :.: g') where
   ghmap f = Comp1 . fmap (ghmap f) . unComp1
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -63,6 +63,9 @@ instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) 
 instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) (l' :*: r') where
   ghmap f (l :*: r) = ghmap f l :*: ghmap f r
 
+instance GHFunctor m m' U1 U1 where
+  ghmap _ = id
+
 instance GHFunctor m m' (K1 R c) (K1 R c) where
   ghmap _ = coerce
 

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -66,6 +66,7 @@ handleCoercible = hmap coerce
 
 -- | Generic implementation of 'HFunctor'.
 class GHFunctor m m' rep rep' where
+  -- | Generic implementation of 'hmap'.
   ghmap :: (Functor m, Functor m') => (forall x . m x -> m' x) -> (rep a -> rep' a)
 
 instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') where
@@ -99,6 +100,7 @@ instance HFunctor f => GHFunctor m m' (Rec1 (f m)) (Rec1 (f m')) where
 
 -- | Generic implementation of 'Effect'.
 class GEffect m m' rep rep' where
+  -- | Generic implementation of 'handle'.
   ghandle :: (Functor f, Monad m, Monad m')
           => f ()
           -> (forall x . f (m x) -> m' (f x))

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -52,3 +52,6 @@ handleCoercible = handlePure coerce
 
 class GHFunctor m m' rep rep' | rep -> m, rep' -> m' where
   ghmap :: (Functor m, Functor m') => (forall x . m x -> m' x) -> (rep a -> rep' a)
+
+instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') where
+  ghmap f = M1 . ghmap f . unM1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -68,3 +68,6 @@ instance GHFunctor m m' (K1 R c) (K1 R c) where
 
 instance (Functor f, GHFunctor m m' g g') => GHFunctor m m' (f :.: g) (f :.: g') where
   ghmap f = Comp1 . fmap (ghmap f) . unComp1
+
+instance GHFunctor m m' (Rec1 m) (Rec1 m') where
+  ghmap f = Rec1 . f . unRec1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -107,3 +107,6 @@ instance GEffect m m' (K1 R c) (K1 R c) where
 
 instance (Functor f, GEffect m m' g g') => GEffect m m' (f :.: g) (f :.: g') where
   ghandle state handler = Comp1 . fmap (ghandle state handler) . unComp1
+
+instance GEffect m m' (Rec1 m) (Rec1 m') where
+  ghandle state handler = Rec1 . handler . (<$ state) . unRec1

--- a/src/Control/Effect/Carrier.hs
+++ b/src/Control/Effect/Carrier.hs
@@ -104,3 +104,6 @@ instance (GEffect m m' l l', GEffect m m' r r') => GEffect m m' (l :*: r) (l' :*
 
 instance GEffect m m' (K1 R c) (K1 R c) where
   ghandle _ _ = coerce
+
+instance (Functor f, GEffect m m' g g') => GEffect m m' (f :.: g) (f :.: g') where
+  ghandle state handler = Comp1 . fmap (ghandle state handler) . unComp1

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -21,12 +21,12 @@ import Prelude hiding (fail)
 
 -- | 'Cull' effects are used with 'NonDet' to provide control over branching.
 data Cull m k
-  = forall a . Cull (m a) (a -> k)
+  = forall a . Cull (m a) (a -> m k)
 
-deriving instance Functor (Cull m)
+deriving instance Functor m => Functor (Cull m)
 
 instance HFunctor Cull where
-  hmap f (Cull m k) = Cull (f m) k
+  hmap f (Cull m k) = Cull (f m) (f . k)
   {-# INLINE hmap #-}
 
 instance Effect Cull where

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -22,13 +22,13 @@ import Prelude hiding (fail)
 -- | 'Cut' effects are used with 'NonDet' to provide control over backtracking.
 data Cut m k
   = Cutfail
-  | forall a . Call (m a) (a -> k)
+  | forall a . Call (m a) (a -> m k)
 
-deriving instance Functor (Cut m)
+deriving instance Functor m => Functor (Cut m)
 
 instance HFunctor Cut where
   hmap _ Cutfail    = Cutfail
-  hmap f (Call m k) = Call (f m) k
+  hmap f (Call m k) = Call (f m) (f . k)
   {-# INLINE hmap #-}
 
 instance Effect Cut where

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -18,13 +18,13 @@ import Prelude hiding (fail)
 
 data Error exc m k
   = Throw exc
-  | forall b . Catch (m b) (exc -> m b) (b -> k)
+  | forall b . Catch (m b) (exc -> m b) (b -> m k)
 
-deriving instance Functor (Error exc m)
+deriving instance Functor m => Functor (Error exc m)
 
 instance HFunctor (Error exc) where
   hmap _ (Throw exc)   = Throw exc
-  hmap f (Catch m h k) = Catch (f m) (f . h) k
+  hmap f (Catch m h k) = Catch (f m) (f . h) (f . k)
 
 instance Effect (Error exc) where
   handle _     _       (Throw exc)   = Throw exc

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DerivingStrategies, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fail
 ( Fail(..)
 , MonadFail(..)
@@ -14,11 +14,17 @@ import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Data.Coerce
 import Prelude hiding (fail)
 
 newtype Fail (m :: * -> *) k = Fail String
-  deriving stock Functor
-  deriving anyclass (HFunctor, Effect)
+  deriving Functor
+
+instance HFunctor Fail where
+  hmap _ = coerce
+
+instance Effect Fail where
+  handle _ _ = coerce
 
 -- | Run a 'Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
 --
@@ -27,7 +33,7 @@ runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => MonadFail (FailC m) where
   fail s = FailC (throwError s)

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -18,7 +18,7 @@ import Data.Coerce
 import Prelude hiding (fail)
 
 newtype Fail (m :: * -> *) k = Fail String
-  deriving Functor
+  deriving (Functor)
 
 instance HFunctor Fail where
   hmap _ = coerce

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -14,16 +14,12 @@ import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Data.Coerce
 import GHC.Generics (Generic1)
 import Prelude hiding (fail)
 
 newtype Fail (m :: * -> *) k = Fail String
   deriving stock (Functor, Generic1)
-  deriving anyclass (HFunctor)
-
-instance Effect Fail where
-  handle _ _ = coerce
+  deriving anyclass (HFunctor, Effect)
 
 -- | Run a 'Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
 --

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fail
 ( Fail(..)
 , MonadFail(..)
@@ -15,13 +15,12 @@ import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Coerce
+import GHC.Generics (Generic1)
 import Prelude hiding (fail)
 
 newtype Fail (m :: * -> *) k = Fail String
-  deriving (Functor)
-
-instance HFunctor Fail where
-  hmap _ = coerce
+  deriving stock (Functor, Generic1)
+  deriving anyclass (HFunctor)
 
 instance Effect Fail where
   handle _ _ = coerce
@@ -33,7 +32,7 @@ runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadIO, MonadPlus, MonadTrans)
+  deriving newtype (Alternative, Applicative, Functor, Monad, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => MonadFail (FailC m) where
   fail s = FailC (throwError s)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -17,14 +17,14 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 data Fresh m k
-  = Fresh (Int -> k)
-  | forall b . Reset (m b) (b -> k)
+  = Fresh (Int -> m k)
+  | forall b . Reset (m b) (b -> m k)
 
-deriving instance Functor (Fresh m)
+deriving instance Functor m => Functor (Fresh m)
 
 instance HFunctor Fresh where
-  hmap _ (Fresh   k) = Fresh k
-  hmap f (Reset m k) = Reset (f m) k
+  hmap f (Fresh   k) = Fresh       (f . k)
+  hmap f (Reset m k) = Reset (f m) (f . k)
 
 instance Effect Fresh where
   handle state handler (Fresh   k) = Fresh (handler . (<$ state) . k)

--- a/src/Control/Effect/Interpose.hs
+++ b/src/Control/Effect/Interpose.hs
@@ -35,14 +35,14 @@ instance MonadTrans (InterposeC eff) where
 newtype Handler eff m = Handler (forall x . eff m x -> m x)
 
 runHandler :: (HFunctor eff, Functor m) => Handler eff m -> eff (ReaderC (Handler eff m) m) a -> m a
-runHandler h@(Handler handler) = handler . handlePure (runReader h)
+runHandler h@(Handler handler) = handler . hmap (runReader h)
 
 instance (HFunctor eff, Carrier sig m, Member eff sig) => Carrier sig (InterposeC eff m) where
   eff (op :: sig (InterposeC eff m) a)
     | Just (op' :: eff (InterposeC eff m) a) <- prj op = do
       handler <- InterposeC ask
       lift (runHandler handler (handleCoercible op'))
-    | otherwise = InterposeC (ReaderC (\ handler -> eff (handlePure (runReader handler . runInterposeC) op)))
+    | otherwise = InterposeC (ReaderC (\ handler -> eff (hmap (runReader handler . runInterposeC) op)))
 
 -- $setup
 -- >>> :seti -XFlexibleContexts

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -36,7 +36,7 @@ instance MonadTrans (InterpretC eff) where
 newtype Handler eff m = Handler (forall x . eff m x -> m x)
 
 runHandler :: (HFunctor eff, Functor m) => Handler eff m -> eff (InterpretC eff m) a -> m a
-runHandler h@(Handler handler) = handler . handlePure (runReader h . runInterpretC)
+runHandler h@(Handler handler) = handler . hmap (runReader h . runInterpretC)
 
 instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff m) where
   eff (L op) = do
@@ -66,7 +66,7 @@ instance MonadTrans (InterpretStateC eff s) where
 newtype HandlerState eff s m = HandlerState (forall x . eff (StateC s m) x -> StateC s m x)
 
 runHandlerState :: (HFunctor eff, Functor m) => HandlerState eff s m -> eff (InterpretStateC eff s m) a -> StateC s m a
-runHandlerState h@(HandlerState handler) = handler . handlePure (runReader h . runInterpretStateC)
+runHandlerState h@(HandlerState handler) = handler . hmap (runReader h . runInterpretStateC)
 
 instance (HFunctor eff, Carrier sig m, Effect sig) => Carrier (eff :+: sig) (InterpretStateC eff s m) where
   eff (L op) = do

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -18,10 +18,7 @@ import GHC.Generics
 
 newtype Lift sig m k = Lift { unLift :: sig (m k) }
   deriving stock (Functor, Generic1)
-  deriving anyclass (HFunctor)
-
-instance Functor sig => Effect (Lift sig) where
-  handle state handler (Lift op) = Lift (handler . (<$ state) <$> op)
+  deriving anyclass (HFunctor, Effect)
 
 -- | Extract a 'Lift'ed 'Monad'ic action from an effectful computation.
 runM :: LiftC m a -> m a

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
 ( NonDet(..)
 , Alternative(..)
@@ -15,10 +15,18 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Prelude hiding (fail)
 
-data NonDet (m :: * -> *) k
+data NonDet m k
   = Empty
-  | Choose (Bool -> k)
-  deriving (Functor, HFunctor, Effect)
+  | Choose (Bool -> m k)
+  deriving (Functor)
+
+instance HFunctor NonDet where
+  hmap _ Empty      = Empty
+  hmap f (Choose k) = Choose (f . k)
+
+instance Effect NonDet where
+  handle _     _       Empty      = Empty
+  handle state handler (Choose k) = Choose (handler . (<$ state) . k)
 
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -20,11 +20,7 @@ data NonDet m k
   = Empty
   | Choose (Bool -> m k)
   deriving stock (Functor, Generic1)
-  deriving anyclass (HFunctor)
-
-instance Effect NonDet where
-  handle _     _       Empty      = Empty
-  handle state handler (Choose k) = Choose (handler . (<$ state) . k)
+  deriving anyclass (HFunctor, Effect)
 
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
 ( NonDet(..)
 , Alternative(..)
@@ -13,16 +13,14 @@ import Control.Monad (MonadPlus(..))
 import Control.Monad.Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import GHC.Generics (Generic1)
 import Prelude hiding (fail)
 
 data NonDet m k
   = Empty
   | Choose (Bool -> m k)
-  deriving (Functor)
-
-instance HFunctor NonDet where
-  hmap _ Empty      = Empty
-  hmap f (Choose k) = Choose (f . k)
+  deriving stock (Functor, Generic1)
+  deriving anyclass (HFunctor)
 
 instance Effect NonDet where
   handle _     _       Empty      = Empty
@@ -43,7 +41,7 @@ newtype NonDetC m a = NonDetC
   { -- | A higher-order function receiving two parameters: a function to combine each solution with the rest of the solutions, and an action to run when no results are produced.
     runNonDetC :: forall b . (a -> m b -> m b) -> m b -> m b
   }
-  deriving (Functor)
+  deriving stock (Functor)
 
 instance Applicative (NonDetC m) where
   pure a = NonDetC (\ cons -> cons a)

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, EmptyCase, KindSignatures, MultiParamTypeClasses #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, EmptyCase, KindSignatures, MultiParamTypeClasses #-}
 module Control.Effect.Pure
 ( Pure
 , run
@@ -8,13 +8,11 @@ module Control.Effect.Pure
 import Control.Applicative
 import Control.Effect.Carrier
 import Data.Coerce
+import GHC.Generics (Generic1)
 
 data Pure (m :: * -> *) k
-  deriving (Functor)
-
-instance HFunctor Pure where
-  hmap _ v = case v of {}
-  {-# INLINE hmap #-}
+  deriving stock (Functor, Generic1)
+  deriving anyclass (HFunctor)
 
 instance Effect Pure where
   handle _ _ v = case v of {}

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -12,12 +12,7 @@ import GHC.Generics (Generic1)
 
 data Pure (m :: * -> *) k
   deriving stock (Functor, Generic1)
-  deriving anyclass (HFunctor)
-
-instance Effect Pure where
-  handle _ _ v = case v of {}
-  {-# INLINE handle #-}
-
+  deriving anyclass (HFunctor, Effect)
 
 -- | Run an action exhausted of effects to produce its final result value.
 run :: PureC a -> a

--- a/src/Control/Effect/Random.hs
+++ b/src/Control/Effect/Random.hs
@@ -22,21 +22,21 @@ import Control.Monad.Trans.Class
 import qualified System.Random as R (Random(..), RandomGen(..), StdGen, newStdGen)
 
 data Random m k
-  = forall a . R.Random a => Random (a -> k)
-  | forall a . R.Random a => RandomR (a, a) (a -> k)
-  | forall a . Interleave (m a) (a -> k)
+  = forall a . R.Random a => Random (a -> m k)
+  | forall a . R.Random a => RandomR (a, a) (a -> m k)
+  | forall a . Interleave (m a) (a -> m k)
 
-deriving instance Functor (Random m)
+deriving instance Functor m => Functor (Random m)
 
 instance HFunctor Random where
-  hmap _ (Random k) = Random k
-  hmap _ (RandomR r k) = RandomR r k
-  hmap f (Interleave m k) = Interleave (f m) k
+  hmap f (Random       k) = Random           (f . k)
+  hmap f (RandomR r    k) = RandomR r        (f . k)
+  hmap f (Interleave m k) = Interleave (f m) (f . k)
   {-# INLINE hmap #-}
 
 instance Effect Random where
-  handle state handler (Random    k) = Random    (handler . (<$ state) . k)
-  handle state handler (RandomR r k) = RandomR r (handler . (<$ state) . k)
+  handle state handler (Random       k) = Random                            (handler . (<$ state) . k)
+  handle state handler (RandomR r    k) = RandomR r                         (handler . (<$ state) . k)
   handle state handler (Interleave m k) = Interleave (handler (m <$ state)) (handler . fmap k)
 
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -19,14 +19,14 @@ import Control.Monad.Trans.Class
 import Prelude hiding (fail)
 
 data Reader r m k
-  = Ask (r -> k)
-  | forall b . Local (r -> r) (m b) (b -> k)
+  = Ask (r -> m k)
+  | forall b . Local (r -> r) (m b) (b -> m k)
 
-deriving instance Functor (Reader r m)
+deriving instance Functor m => Functor (Reader r m)
 
 instance HFunctor (Reader r) where
-  hmap _ (Ask k)       = Ask k
-  hmap f (Local g m k) = Local g (f m) k
+  hmap f (Ask k)       = Ask           (f . k)
+  hmap f (Local g m k) = Local g (f m) (f . k)
 
 instance Effect (Reader r) where
   handle state handler (Ask k)       = Ask (handler . (<$ state) . k)

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -105,7 +105,7 @@ instance MonadUnliftIO m => MonadUnliftIO (ReaderC r m) where
 instance Carrier sig m => Carrier (Reader r :+: sig) (ReaderC r m) where
   eff (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))
   eff (L (Local f m k)) = ReaderC (\ r -> runReader (f r) m) >>= k
-  eff (R other)         = ReaderC (\ r -> eff (handlePure (runReader r) other))
+  eff (R other)         = ReaderC (\ r -> eff (hmap (runReader r) other))
   {-# INLINE eff #-}
 
 

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -21,14 +21,14 @@ import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Class
 
 data Resource m k
-  = forall resource any output . Resource (m resource) (resource -> m any) (resource -> m output) (output -> k)
-  | forall resource any output . OnError  (m resource) (resource -> m any) (resource -> m output) (output -> k)
+  = forall resource any output . Resource (m resource) (resource -> m any) (resource -> m output) (output -> m k)
+  | forall resource any output . OnError  (m resource) (resource -> m any) (resource -> m output) (output -> m k)
 
-deriving instance Functor (Resource m)
+deriving instance Functor m => Functor (Resource m)
 
 instance HFunctor Resource where
-  hmap f (Resource acquire release use k) = Resource (f acquire) (f . release) (f . use) k
-  hmap f (OnError acquire release use k)  = OnError  (f acquire) (f . release) (f . use) k
+  hmap f (Resource acquire release use k) = Resource (f acquire) (f . release) (f . use) (f . k)
+  hmap f (OnError acquire release use k)  = OnError  (f acquire) (f . release) (f . use) (f . k)
 
 instance Effect Resource where
   handle state handler (Resource acquire release use k) = Resource (handler (acquire <$ state)) (handler . fmap release) (handler . fmap use) (handler . fmap k)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, DerivingStrategies, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Resumable
 ( Resumable(..)
 , throwResumable
@@ -86,7 +86,7 @@ runResumable :: ResumableC err m a -> m (Either (SomeError err) a)
 runResumable = runError . runResumableC
 
 newtype ResumableC err m a = ResumableC { runResumableC :: ErrorC (SomeError err) m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   eff (L (Resumable err _)) = ResumableC (throwError (SomeError err))
@@ -108,7 +108,7 @@ runResumableWith :: (forall x . err x -> m x)
 runResumableWith with = runReader (Handler with) . runResumableWithC
 
 newtype ResumableWithC err m a = ResumableWithC { runResumableWithC :: ReaderC (Handler err m) m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus)
+  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadIO, MonadPlus)
 
 instance MonadTrans (ResumableWithC err) where
   lift = ResumableWithC . lift

--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State.Internal
 ( State(..)
 , get
@@ -10,16 +10,14 @@ module Control.Effect.State.Internal
 
 import Control.Effect.Carrier
 import Control.Effect.Sum
+import GHC.Generics (Generic1)
 import Prelude hiding (fail)
 
 data State s m k
   = Get (s -> m k)
   | Put s (m k)
-  deriving (Functor)
-
-instance HFunctor (State s) where
-  hmap f (Get k)   = Get   (f . k)
-  hmap f (Put s k) = Put s (f   k)
+  deriving stock (Functor, Generic1)
+  deriving anyclass (HFunctor)
 
 instance Effect (State s) where
   handle state handler (Get   k) = Get   (handler . (<$ state) . k)

--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -17,11 +17,7 @@ data State s m k
   = Get (s -> m k)
   | Put s (m k)
   deriving stock (Functor, Generic1)
-  deriving anyclass (HFunctor)
-
-instance Effect (State s) where
-  handle state handler (Get   k) = Get   (handler . (<$ state) . k)
-  handle state handler (Put s k) = Put s (handler (k <$ state))
+  deriving anyclass (HFunctor, Effect)
 
 -- | Get the current state value.
 --

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State.Lazy
 ( State (..)
 , get

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State.Strict
 ( State (..)
 , get

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member(..)
@@ -6,17 +6,15 @@ module Control.Effect.Sum
 ) where
 
 import Control.Effect.Carrier
+import GHC.Generics (Generic1)
 
 data (f :+: g) (m :: * -> *) k
   = L (f m k)
   | R (g m k)
-  deriving (Eq, Functor, Ord, Show)
+  deriving stock (Eq, Functor, Generic1, Ord, Show)
+  deriving anyclass (HFunctor)
 
 infixr 4 :+:
-
-instance (HFunctor l, HFunctor r) => HFunctor (l :+: r) where
-  hmap f (L l) = L (hmap f l)
-  hmap f (R r) = R (hmap f r)
 
 instance (Effect l, Effect r) => Effect (l :+: r) where
   handle state handler (L l) = L (handle state handler l)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -18,9 +18,6 @@ instance (HFunctor l, HFunctor r) => HFunctor (l :+: r) where
   hmap f (L l) = L (hmap f l)
   hmap f (R r) = R (hmap f r)
 
-  fmap' f (L l) = L (fmap' f l)
-  fmap' f (R r) = R (fmap' f r)
-
 instance (Effect l, Effect r) => Effect (l :+: r) where
   handle state handler (L l) = L (handle state handler l)
   handle state handler (R r) = R (handle state handler r)
@@ -45,6 +42,6 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
-send :: (Member effect sig, Carrier sig m) => effect m (m a) -> m a
+send :: (Member effect sig, Carrier sig m) => effect m a -> m a
 send = eff . inj
 {-# INLINE send #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -12,13 +12,9 @@ data (f :+: g) (m :: * -> *) k
   = L (f m k)
   | R (g m k)
   deriving stock (Eq, Functor, Generic1, Ord, Show)
-  deriving anyclass (HFunctor)
+  deriving anyclass (HFunctor, Effect)
 
 infixr 4 :+:
-
-instance (Effect l, Effect r) => Effect (l :+: r) where
-  handle state handler (L l) = L (handle state handler l)
-  handle state handler (R r) = R (handle state handler r)
 
 class Member (sub :: (* -> *) -> (* -> *)) sup where
   inj :: sub m a -> sup m a

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -27,11 +27,7 @@ data Trace (m :: * -> *) k = Trace
   , traceCont    :: m k
   }
   deriving stock (Functor, Generic1)
-  deriving anyclass (HFunctor)
-
-instance Effect Trace where
-  handle state handler (Trace m k) = Trace m (handler (k <$ state))
-
+  deriving anyclass (HFunctor, Effect)
 
 -- | Append a message to the trace log.
 trace :: (Member Trace sig, Carrier sig m) => String -> m ()

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Trace
 ( Trace(..)
 , trace
@@ -22,7 +22,7 @@ import Data.Bifunctor (first)
 import GHC.Generics (Generic1)
 import System.IO
 
-data Trace (m :: * -> *) k = Trace
+data Trace m k = Trace
   { traceMessage :: String
   , traceCont    :: m k
   }

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -20,16 +20,16 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 data Writer w m k
-  = Tell w k
-  | forall a . Listen (m a) (w -> a -> k)
-  | forall a . Censor (w -> w) (m a) (a -> k)
+  = Tell w (m k)
+  | forall a . Listen (m a) (w -> a -> m k)
+  | forall a . Censor (w -> w) (m a) (a -> m k)
 
-deriving instance Functor (Writer w m)
+deriving instance Functor m => Functor (Writer w m)
 
 instance HFunctor (Writer w) where
-  hmap _ (Tell w     k) = Tell w         k
-  hmap f (Listen   m k) = Listen   (f m) k
-  hmap f (Censor g m k) = Censor g (f m) k
+  hmap f (Tell w     k) = Tell w         (f       k)
+  hmap f (Listen   m k) = Listen   (f m) ((f .) . k)
+  hmap f (Censor g m k) = Censor g (f m) (f     . k)
   {-# INLINE hmap #-}
 
 instance Effect (Writer w) where


### PR DESCRIPTION
This PR changes the signature of `eff` from `sig m (m a) -> m a` to `sig m a -> m a`, bringing it closer into line with the presentations in the literature, and making `eff` much more obviously a `sig`-algebra, and enabling interoperation with e.g. `bound` and higher-order free monads in general.

- [x] Simplifies the types of `eff`, `send` and all the effect constructors to allow for much simpler algebraic usage and enable integration with other presentations of free monads (e.g. syntax à la `bound`).
- [x] Adds constraints to `hmap` and `handle` to enable more defining instances.
- [x] ~~Removes~~ _Deprecates_ `fmap'`. (cf #156.) I got cold feet, so deprecated it instead of deleting it.
- [x] Deprecates `handlePure`.
- [x] Bumps the package version to 0.5 to match the changelog (so I can select this version unambiguously in some local experiments even before pushing to hackage).
- [x] Replaces the default definitions of `hmap` and `handle` with generically-derived ones (since coercion is no longer possible).