### PR TITLE
Use === for all the doctests to improve their failure messages.

### DIFF
--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -35,16 +35,16 @@ instance Effect Cull where
 
 -- | Cull nondeterminism in the argument, returning at most one result.
 --
---   prop> run (runNonDet (runCull (cull (pure a <|> pure b)))) == [a]
---   prop> run (runNonDet (runCull (cull (pure a <|> pure b) <|> pure c))) == [a, c]
---   prop> run (runNonDet (runCull (cull (asum (map pure (repeat a)))))) == [a]
+--   prop> run (runNonDet (runCull (cull (pure a <|> pure b)))) === [a]
+--   prop> run (runNonDet (runCull (cull (pure a <|> pure b) <|> pure c))) === [a, c]
+--   prop> run (runNonDet (runCull (cull (asum (map pure (repeat a)))))) === [a]
 cull :: (Carrier sig m, Member Cull sig) => m a -> m a
 cull m = send (Cull m pure)
 
 
 -- | Run a 'Cull' effect. Branches outside of any 'cull' block will not be pruned.
 --
---   prop> run (runNonDet (runCull (pure a <|> pure b))) == [a, b]
+--   prop> run (runNonDet (runCull (pure a <|> pure b))) === [a, b]
 runCull :: Alternative m => CullC m a -> m a
 runCull (CullC m) = runNonDetC (runReader False m) ((<|>) . pure) empty
 
@@ -78,8 +78,8 @@ instance (Carrier sig m, Effect sig) => Carrier (Cull :+: NonDet :+: sig) (CullC
 --
 --   Unlike 'runNonDet', this will terminate immediately upon finding a solution.
 --
---   prop> run (runNonDetOnce (asum (map pure (repeat a)))) == [a]
---   prop> run (runNonDetOnce (asum (map pure (repeat a)))) == Just a
+--   prop> run (runNonDetOnce (asum (map pure (repeat a)))) === [a]
+--   prop> run (runNonDetOnce (asum (map pure (repeat a)))) === Just a
 runNonDetOnce :: (Alternative f, Carrier sig m, Effect sig) => OnceC m a -> m (f a)
 runNonDetOnce = runNonDet . runCull . cull . runOnceC
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -40,24 +40,24 @@ instance Effect Cut where
 --
 --   Contrast with 'empty', which fails the current branch but allows backtracking.
 --
---   prop> run (runNonDet (runCut (cutfail <|> pure a))) == []
---   prop> run (runNonDet (runCut (pure a <|> cutfail))) == [a]
+--   prop> run (runNonDet (runCut (cutfail <|> pure a))) === []
+--   prop> run (runNonDet (runCut (pure a <|> cutfail))) === [a]
 cutfail :: (Carrier sig m, Member Cut sig) => m a
 cutfail = send Cutfail
 {-# INLINE cutfail #-}
 
 -- | Delimit the effect of 'cutfail's, allowing backtracking to resume.
 --
---   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) == [b]
+--   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) === [b]
 call :: (Carrier sig m, Member Cut sig) => m a -> m a
 call m = send (Call m pure)
 {-# INLINE call #-}
 
 -- | Commit to the current branch, preventing backtracking within the nearest enclosing 'call' (if any) on failure.
 --
---   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) == [a, b]
---   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) == [a]
---   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) == []
+--   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) === [a, b]
+--   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) === [a]
+--   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) === []
 cut :: (Alternative m, Carrier sig m, Member Cut sig) => m ()
 cut = pure () <|> cutfail
 {-# INLINE cut #-}
@@ -65,7 +65,7 @@ cut = pure () <|> cutfail
 
 -- | Run a 'Cut' effect within an underlying 'Alternative' instance (typically another 'Carrier' for a 'NonDet' effect).
 --
---   prop> run (runNonDetOnce (runCut (pure a))) == Just a
+--   prop> run (runNonDetOnce (runCut (pure a))) === Just a
 runCut :: Alternative m => CutC m a -> m a
 runCut m = runCutC m ((<|>) . pure) empty empty
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -32,7 +32,7 @@ instance Effect (Error exc) where
 
 -- | Throw an error, escaping the current computation up to the nearest 'catchError' (if any).
 --
---   prop> run (runError (throwError a)) == Left @Int @Int a
+--   prop> run (runError (throwError a)) === Left @Int @Int a
 throwError :: (Member (Error exc) sig, Carrier sig m) => exc -> m a
 throwError = send . Throw
 
@@ -44,16 +44,16 @@ throwError = send . Throw
 -- consider if 'Control.Effect.Resource' fits your use case; if not, use 'liftIO' with
 -- 'Control.Exception.try' or use 'Control.Exception.Catch' from outside the effect invocation.
 --
---   prop> run (runError (pure a `catchError` pure)) == Right a
---   prop> run (runError (throwError a `catchError` pure)) == Right @Int @Int a
---   prop> run (runError (throwError a `catchError` (throwError @Int))) == Left @Int @Int a
+--   prop> run (runError (pure a `catchError` pure)) === Right a
+--   prop> run (runError (throwError a `catchError` pure)) === Right @Int @Int a
+--   prop> run (runError (throwError a `catchError` (throwError @Int))) === Left @Int @Int a
 catchError :: (Member (Error exc) sig, Carrier sig m) => m a -> (exc -> m a) -> m a
 catchError m h = send (Catch m h pure)
 
 
 -- | Run an 'Error' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
 --
---   prop> run (runError (pure a)) == Right @Int @Int a
+--   prop> run (runError (pure a)) === Right @Int @Int a
 runError :: ErrorC exc m a -> m (Either exc a)
 runError = runErrorC
 

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -23,7 +23,7 @@ newtype Fail (m :: * -> *) k = Fail String
 
 -- | Run a 'Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
 --
---   prop> run (runFail (pure a)) == Right a
+--   prop> run (runFail (pure a)) === Right a
 runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -32,21 +32,21 @@ instance Effect Fresh where
 
 -- | Produce a fresh (i.e. unique) 'Int'.
 --
---   prop> run (runFresh (replicateM n fresh)) == nub (run (runFresh (replicateM n fresh)))
+--   prop> run (runFresh (replicateM n fresh)) === nub (run (runFresh (replicateM n fresh)))
 fresh :: (Member Fresh sig, Carrier sig m) => m Int
 fresh = send (Fresh pure)
 
 -- | Reset the fresh counter after running a computation.
 --
---   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) == run (runFresh (replicateM n fresh))
+--   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) === run (runFresh (replicateM n fresh))
 resetFresh :: (Member Fresh sig, Carrier sig m) => m a -> m a
 resetFresh m = send (Reset m pure)
 
 
 -- | Run a 'Fresh' effect counting up from 0.
 --
---   prop> run (runFresh (replicateM n fresh)) == [0..pred n]
---   prop> run (runFresh (replicateM n fresh *> pure b)) == b
+--   prop> run (runFresh (replicateM n fresh)) === [0..pred n]
+--   prop> run (runFresh (replicateM n fresh *> pure b)) === b
 runFresh :: Functor m => FreshC m a -> m a
 runFresh = evalState 0 . runFreshC
 

--- a/src/Control/Effect/Interpose.hs
+++ b/src/Control/Effect/Interpose.hs
@@ -21,7 +21,7 @@ import Control.Monad.Trans.Class
 -- the intercepted effect, and you can pass the effect on to the original handler
 -- using 'send'.
 --
---   prop> run . evalState @Int a . runInterpose @(State Int) (\op -> modify @Int (+b) *> send op) $ modify @Int (+b) == a + b + b
+--   prop> run . evalState @Int a . runInterpose @(State Int) (\op -> modify @Int (+b) *> send op) $ modify @Int (+b) === a + b + b
 --
 runInterpose :: (forall x . eff m x -> m x) -> InterposeC eff m a -> m a
 runInterpose handler = runReader (Handler handler) . runInterposeC

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -22,7 +22,7 @@ import Control.Monad.Trans.Class
 --
 --   At time of writing, a simple passthrough use of 'runInterpret' to handle a 'State' effect is about five times slower than using 'StateC' directly.
 --
---   prop> run (runInterpret (\ op -> case op of { Get k -> k a ; Put _ k -> k }) get) == a
+--   prop> run (runInterpret (\ op -> case op of { Get k -> k a ; Put _ k -> k }) get) === a
 runInterpret :: (forall x . eff m x -> m x) -> InterpretC eff m a -> m a
 runInterpret handler = runReader (Handler handler) . runInterpretC
 
@@ -52,7 +52,7 @@ instance (HFunctor eff, Carrier sig m) => Carrier (eff :+: sig) (InterpretC eff 
 --
 --   At time of writing, a simple use of 'runInterpretState' to handle a 'State' effect is about four times slower than using 'StateC' directly.
 --
---   prop> run (runInterpretState (\ s op -> case op of { Get k -> runState s (k s) ; Put s' k -> runState s' k }) a get) == a
+--   prop> run (runInterpretState (\ s op -> case op of { Get k -> runState s (k s) ; Put s' k -> runState s' k }) a get) === a
 runInterpretState :: (forall x . s -> eff (StateC s m) x -> m (s, x)) -> s -> InterpretStateC eff s m a -> m (s, a)
 runInterpretState handler state = runState state . runReader (HandlerState (\ eff -> StateC (\ s -> handler s eff))) . runInterpretStateC
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -27,8 +27,8 @@ data NonDet m k
 --
 --   Using '[]' as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unlike 'runNonDetOnce', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
 --
---   prop> run (runNonDet (pure a)) == [a]
---   prop> run (runNonDet (pure a)) == Just a
+--   prop> run (runNonDet (pure a)) === [a]
+--   prop> run (runNonDet (pure a)) === Just a
 runNonDet :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDet (NonDetC m) = m (fmap . (<|>) . pure) (pure empty)
 

--- a/src/Control/Effect/Random.hs
+++ b/src/Control/Effect/Random.hs
@@ -42,19 +42,19 @@ instance Effect Random where
 
 -- | Run a random computation starting from a given generator.
 --
---   prop> run (runRandom (PureGen a) (pure b)) == (PureGen a, b)
+--   prop> run (runRandom (PureGen a) (pure b)) === (PureGen a, b)
 runRandom :: g -> RandomC g m a -> m (g, a)
 runRandom g = runState g . runRandomC
 
 -- | Run a random computation starting from a given generator and discarding the final generator.
 --
---   prop> run (evalRandom (PureGen a) (pure b)) == b
+--   prop> run (evalRandom (PureGen a) (pure b)) === b
 evalRandom :: Functor m => g -> RandomC g m a -> m a
 evalRandom g = fmap snd . runRandom g
 
 -- | Run a random computation starting from a given generator and discarding the final result.
 --
---   prop> run (execRandom (PureGen a) (pure b)) == PureGen a
+--   prop> run (execRandom (PureGen a) (pure b)) === PureGen a
 execRandom :: Functor m => g -> RandomC g m a -> m g
 execRandom g = fmap fst . runRandom g
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -34,27 +34,27 @@ instance Effect (Reader r) where
 
 -- | Retrieve the environment value.
 --
---   prop> run (runReader a ask) == a
+--   prop> run (runReader a ask) === a
 ask :: (Member (Reader r) sig, Carrier sig m) => m r
 ask = send (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
---   prop> snd (run (runReader a (asks (applyFun f)))) == applyFun f a
+--   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
 asks :: (Member (Reader r) sig, Carrier sig m) => (r -> a) -> m a
 asks f = send (Ask (pure . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
---   prop> run (runReader a (local (applyFun f) ask)) == applyFun f a
---   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) == (a, applyFun f a, a)
+--   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
+--   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
 local :: (Member (Reader r) sig, Carrier sig m) => (r -> r) -> m a -> m a
 local f m = send (Local f m pure)
 
 
 -- | Run a 'Reader' effect with the passed environment value.
 --
---   prop> run (runReader a (pure b)) == b
+--   prop> run (runReader a (pure b)) === b
 runReader :: r -> ReaderC r m a -> m a
 runReader r c = runReaderC c r
 {-# INLINE runReader #-}

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -35,7 +35,7 @@ instance Effect (Resumable err) where
 
 -- | Throw an error which can be resumed with a value of its result type.
 --
---   prop> run (runResumable (throwResumable (Identity a))) == Left (SomeError (Identity a))
+--   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
 throwResumable :: (Member (Resumable err) sig, Carrier sig m) => err a -> m a
 throwResumable err = send (Resumable err pure)
 
@@ -48,8 +48,8 @@ data SomeError err
 --
 --   Note that since we can’t tell whether the type indices are equal, let alone what 'Eq' instance to use for them, the comparator passed to 'liftEq' always returns 'True'. Thus, 'SomeError' is best used with type-indexed GADTs for the error type.
 --
---   prop> SomeError (Identity a) == SomeError (Identity b)
---   prop> (SomeError (Const a) == SomeError (Const b)) == (a == b)
+--   prop> SomeError (Identity a) === SomeError (Identity b)
+--   prop> (SomeError (Const a) === SomeError (Const b)) == (a == b)
 instance Eq1 err => Eq (SomeError err) where
   SomeError exc1 == SomeError exc2 = liftEq (const (const True)) exc1 exc2
 
@@ -57,8 +57,8 @@ instance Eq1 err => Eq (SomeError err) where
 --
 --   Note that since we can’t tell whether the type indices are equal, let alone what 'Ord' instance to use for them, the comparator passed to 'liftCompare' always returns 'EQ'. Thus, 'SomeError' is best used with type-indexed GADTs for the error type.
 --
---   prop> (SomeError (Identity a) `compare` SomeError (Identity b)) == EQ
---   prop> (SomeError (Const a) `compare` SomeError (Const b)) == (a `compare` b)
+--   prop> (SomeError (Identity a) `compare` SomeError (Identity b)) === EQ
+--   prop> (SomeError (Const a) `compare` SomeError (Const b)) === (a `compare` b)
 instance Ord1 err => Ord (SomeError err) where
   SomeError exc1 `compare` SomeError exc2 = liftCompare (const (const EQ)) exc1 exc2
 
@@ -66,8 +66,8 @@ instance Ord1 err => Ord (SomeError err) where
 --
 --   Note that since we can’t tell what 'Show' instance to use for the type index, the functions passed to 'liftShowsPrec' always return the empty 'ShowS'. Thus, 'SomeError' is best used with type-indexed GADTs for the error type.
 --
---   prop> show (SomeError (Identity a)) == "SomeError (Identity )"
---   prop> show (SomeError (Const a)) == ("SomeError (Const " ++ showsPrec 11 a ")")
+--   prop> show (SomeError (Identity a)) === "SomeError (Identity )"
+--   prop> show (SomeError (Const a)) === ("SomeError (Const " ++ showsPrec 11 a ")")
 instance Show1 err => Show (SomeError err) where
   showsPrec d (SomeError err) = showsUnaryWith (liftShowsPrec (const (const id)) (const id)) "SomeError" d err
 
@@ -81,7 +81,7 @@ instance NFData1 err => NFData (SomeError err) where
 
 -- | Run a 'Resumable' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
 --
---   prop> run (runResumable (pure a)) == Right @(SomeError Identity) @Int a
+--   prop> run (runResumable (pure a)) === Right @(SomeError Identity) @Int a
 runResumable :: ResumableC err m a -> m (Either (SomeError err) a)
 runResumable = runError . runResumableC
 
@@ -100,8 +100,8 @@ instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (Resumab
 --
 --   >>> data Err a where Err :: Int -> Err Int
 --
---   prop> run (runResumableWith (\ (Err b) -> pure (1 + b)) (pure a)) == a
---   prop> run (runResumableWith (\ (Err b) -> pure (1 + b)) (throwResumable (Err a))) == 1 + a
+--   prop> run (runResumableWith (\ (Err b) -> pure (1 + b)) (pure a)) === a
+--   prop> run (runResumableWith (\ (Err b) -> pure (1 + b)) (throwResumable (Err a))) === 1 + a
 runResumableWith :: (forall x . err x -> m x)
                  -> ResumableWithC err m a
                  -> m a

--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -21,23 +21,23 @@ data State s m k
 
 -- | Get the current state value.
 --
---   prop> snd (run (runState a get)) == a
+--   prop> snd (run (runState a get)) === a
 get :: (Member (State s) sig, Carrier sig m) => m s
 get = send (Get pure)
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
---   prop> snd (run (runState a (gets (applyFun f)))) == applyFun f a
+--   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
 gets :: (Member (State s) sig, Carrier sig m) => (s -> a) -> m a
 gets f = send (Get (pure . f))
 {-# INLINEABLE gets #-}
 
 -- | Replace the state value with a new value.
 --
---   prop> fst (run (runState a (put b))) == b
---   prop> snd (run (runState a (get <* put b))) == a
---   prop> snd (run (runState a (put b *> get))) == b
+--   prop> fst (run (runState a (put b))) === b
+--   prop> snd (run (runState a (get <* put b))) === a
+--   prop> snd (run (runState a (put b *> get))) === b
 put :: (Member (State s) sig, Carrier sig m) => s -> m ()
 put s = send (Put s (pure ()))
 {-# INLINEABLE put #-}
@@ -45,7 +45,7 @@ put s = send (Put s (pure ()))
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is strict in the new state.
 --
---   prop> fst (run (runState a (modify (+1)))) == (1 + a :: Integer)
+--   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
 modify :: (Member (State s) sig, Carrier sig m) => (s -> s) -> m ()
 modify f = do
   a <- get

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -75,22 +75,22 @@ instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) w
 --   More programs terminate with lazy state than strict state, but injudicious
 --   use of lazy state may lead to thunk buildup.
 --
---   prop> run (runState a (pure b)) == (a, b)
---   prop> take 5 . snd . run $ runState () (traverse pure [1..]) == [1,2,3,4,5]
+--   prop> run (runState a (pure b)) === (a, b)
+--   prop> take 5 . snd . run $ runState () (traverse pure [1..]) === [1,2,3,4,5]
 runState :: s -> StateC s m a -> m (s, a)
 runState s c = runStateC c s
 {-# INLINE[3] runState #-}
 
 -- | Run a lazy 'State' effect, yielding the result value and discarding the final state.
 --
---   prop> run (evalState a (pure b)) == b
+--   prop> run (evalState a (pure b)) === b
 evalState :: forall s m a . Functor m => s -> StateC s m a -> m a
 evalState s = fmap snd . runState s
 {-# INLINE[3] evalState #-}
 
 -- | Run a lazy 'State' effect, yielding the final state and discarding the return value.
 --
---   prop> run (execState a (pure b)) == a
+--   prop> run (execState a (pure b)) === a
 execState :: forall s m a . Functor m => s -> StateC s m a -> m s
 execState s = fmap fst . runState s
 {-# INLINE[3] execState #-}

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -24,21 +24,21 @@ import Prelude hiding (fail)
 
 -- | Run a 'State' effect starting from the passed value.
 --
---   prop> run (runState a (pure b)) == (a, b)
+--   prop> run (runState a (pure b)) === (a, b)
 runState :: s -> StateC s m a -> m (s, a)
 runState s x = runStateC x s
 {-# INLINE[3] runState #-}
 
 -- | Run a 'State' effect, yielding the result value and discarding the final state.
 --
---   prop> run (evalState a (pure b)) == b
+--   prop> run (evalState a (pure b)) === b
 evalState :: forall s m a . Functor m => s -> StateC s m a -> m a
 evalState s = fmap snd . runState s
 {-# INLINE[3] evalState #-}
 
 -- | Run a 'State' effect, yielding the final state and discarding the return value.
 --
---   prop> run (execState a (pure b)) == a
+--   prop> run (execState a (pure b)) === a
 execState :: forall s m a . Functor m => s -> StateC s m a -> m s
 execState s = fmap fst . runState s
 {-# INLINE[3] execState #-}

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -53,7 +53,7 @@ instance (MonadIO m, Carrier sig m) => Carrier (Trace :+: sig) (TraceByPrintingC
 
 -- | Run a 'Trace' effect, ignoring all traces.
 --
---   prop> run (runTraceByIgnoring (trace a *> pure b)) == b
+--   prop> run (runTraceByIgnoring (trace a *> pure b)) === b
 runTraceByIgnoring :: TraceByIgnoringC m a -> m a
 runTraceByIgnoring = runTraceByIgnoringC
 
@@ -72,7 +72,7 @@ instance Carrier sig m => Carrier (Trace :+: sig) (TraceByIgnoringC m) where
 
 -- | Run a 'Trace' effect, returning all traces as a list.
 --
---   prop> run (runTraceByReturning (trace a *> trace b *> pure c)) == ([a, b], c)
+--   prop> run (runTraceByReturning (trace a *> trace b *> pure c)) === ([a, b], c)
 runTraceByReturning :: Functor m => TraceByReturningC m a -> m ([String], a)
 runTraceByReturning = fmap (first reverse) . runState [] . runTraceByReturningC
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -40,29 +40,29 @@ instance Effect (Writer w) where
 
 -- | Write a value to the log.
 --
---   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) == foldMap Sum ws
+--   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) === foldMap Sum ws
 tell :: (Member (Writer w) sig, Carrier sig m) => w -> m ()
 tell w = send (Tell w (pure ()))
 {-# INLINE tell #-}
 
 -- | Run a computation, returning the pair of its output and its result.
 --
---   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) == (Sum a <> Sum b, Sum b)
+--   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) === (Sum a <> Sum b, Sum b)
 listen :: (Member (Writer w) sig, Carrier sig m) => m a -> m (w, a)
 listen m = send (Listen m (curry pure))
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
---   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) == (Sum a <> Sum b, applyFun f (Sum b))
+--   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) === (Sum a <> Sum b, applyFun f (Sum b))
 listens :: (Member (Writer w) sig, Carrier sig m) => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry pure . f))
 {-# INLINE listens #-}
 
 -- | Run a computation, modifying its output with the passed function.
 --
---   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) == applyFun f (Sum a)
---   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) == (Sum a <> applyFun f (Sum b) <> Sum c)
+--   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) === applyFun f (Sum a)
+--   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) === (Sum a <> applyFun f (Sum b) <> Sum c)
 censor :: (Member (Writer w) sig, Carrier sig m) => (w -> w) -> m a -> m a
 censor f m = send (Censor f m pure)
 {-# INLINE censor #-}
@@ -70,14 +70,14 @@ censor f m = send (Censor f m pure)
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.
 --
---   prop> run (runWriter (tell (Sum a) *> pure b)) == (Sum a, b)
+--   prop> run (runWriter (tell (Sum a) *> pure b)) === (Sum a, b)
 runWriter :: Monoid w => WriterC w m a -> m (w, a)
 runWriter = runState mempty . runWriterC
 {-# INLINE runWriter #-}
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
 --
---   prop> run (execWriter (tell (Sum a) *> pure b)) == Sum a
+--   prop> run (execWriter (tell (Sum a) *> pure b)) === Sum a
 execWriter :: (Monoid w, Functor m) => WriterC w m a -> m w
 execWriter = fmap fst . runWriter
 {-# INLINE execWriter #-}


### PR DESCRIPTION
- [x] Depends on #184.
- [x] Fixes #136:

    ```
    src/Control/Effect/Fresh.hs:35: failure in expression `run (runFresh (replicateM n fresh)) === nub (succ <$> run (runFresh (replicateM n fresh)))'
    *** Failed! Falsified (after 2 tests):
    1
    [0] /= [1]
    ```