### PR TITLE
Improve haddocks a bit

### DIFF
--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Cull
-( Cull(..)
+( -- * Cull effect
+  Cull(..)
 , cull
+  -- * Cull carriers
 , runCull
 , CullC(..)
 , runNonDetOnce

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, LambdaCase, MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Cut
-( Cut(..)
+( -- * Cut effect
+  Cut(..)
 , cutfail
 , call
 , cut
+  -- * Cut carrier
 , runCut
 , runCutAll
 , CutC(..)

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Error
-( Error(..)
+( -- * Error effect
+  Error(..)
 , throwError
 , catchError
+  -- * Error carrier
 , runError
 , ErrorC(..)
 ) where

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleInstances, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fail
-( Fail(..)
-, MonadFail(..)
+( -- * Fail effect
+  Fail(..)
+  -- * Fail carrier
 , runFail
 , FailC(..)
+  -- * Re-exports
+, MonadFail(..)
 ) where
 
 import Control.Applicative (Alternative(..))

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Fresh
-( Fresh(..)
+( -- * Fresh effect
+  Fresh(..)
 , fresh
 , resetFresh
+  -- * Fresh carrier
 , runFresh
 , FreshC(..)
 ) where

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
 module Control.Effect.Lift
-( Lift(..)
+( -- * Lift effect
+  Lift(..)
 , sendM
+  -- * Lift carrier
 , runM
 , LiftC(..)
 ) where

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
-( NonDet(..)
-, Alternative(..)
+( -- * NonDet effect
+  NonDet(..)
+  -- * NonDet carrier
 , runNonDet
 , NonDetC(..)
+  -- * Re-exports
+, Alternative(..)
 ) where
 
 import Control.Applicative (Alternative(..))

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, EmptyCase, KindSignatures, MultiParamTypeClasses #-}
 module Control.Effect.Pure
-( Pure
+( -- * Pure effect
+  Pure
+  -- * Pure carrier
 , run
 , PureC(..)
 ) where

--- a/src/Control/Effect/Random.hs
+++ b/src/Control/Effect/Random.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, ScopedTypeVariables, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Random
-( Random(..)
+( -- * Random effect
+  Random(..)
+  -- * Random carrier
 , runRandom
 , evalRandom
 , execRandom
 , evalRandomIO
 , RandomC(..)
+  -- * Re-exports
 , MonadRandom(..)
 , MonadInterleave(..)
 ) where

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Reader
-( Reader(..)
+( -- * Reader effect
+  Reader(..)
 , ask
 , asks
 , local
+  -- * Reader carrier
 , runReader
 , ReaderC(..)
 ) where

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Resource
-( Resource(..)
+( -- * Resource effect
+  Resource(..)
 , bracket
 , bracketOnError
 , finally
 , onException
+  -- * Resource carrier
 , runResource
 , ResourceC(..)
 ) where

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveFunctor, DerivingStrategies, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Resumable
-( Resumable(..)
+( -- * Resumable effect
+  Resumable(..)
 , throwResumable
 , SomeError(..)
+  -- * Resumable carriers
 , runResumable
 , ResumableC(..)
 , runResumableWith

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -1,15 +1,17 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State.Lazy
-( State (..)
+( -- * Lazy state effect
+  State (..)
 , get
 , gets
 , put
 , modify
 , modifyLazy
-, StateC(..)
+  -- * Lazy state carrier
 , runState
 , evalState
 , execState
+, StateC(..)
 ) where
 
 import Control.Applicative (Alternative(..))

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -1,15 +1,17 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.State.Strict
-( State (..)
+( -- * Strict state effect
+  State (..)
 , get
 , gets
 , put
 , modify
 , modifyLazy
-, StateC(..)
+  -- * Strict state carrier
 , runState
 , evalState
 , execState
+, StateC(..)
 ) where
 
 import Control.Applicative (Alternative(..))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Trace
-( Trace(..)
+( -- * Trace effect
+  Trace(..)
 , trace
+  -- * Trace carriers
 , runTraceByPrinting
 , TraceByPrintingC(..)
 , runTraceByIgnoring

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, ScopedTypeVariables, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Writer
-( Writer(..)
+( -- * Writer effect
+  Writer(..)
 , tell
 , listen
 , listens
 , censor
+  -- * Writer carrier
 , runWriter
 , execWriter
 , WriterC(..)


### PR DESCRIPTION
This patch adds doc headers to separate effects from carrier(s). I also put re-exports at the bottom, so they are more out of the way (`Control.Effect.NonDet` for example currently has a large re-export of `Alternative` before listing carriers).