### PR TITLE
Replace ResourceC's Handler type with that from MonadUnliftIO.

### DIFF
--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -80,7 +80,7 @@ onException act end = bracketOnError (pure ()) (const end) (const act)
 unliftResource :: (forall x . m x -> IO x) -- ^ "unlifting" function to run the carrier in 'IO'
             -> ResourceC m a
             -> m a
-unliftResource handler = runReader (Handler handler) . runResourceC
+unliftResource handler = runReader (UnliftIO handler) . runResourceC
 
 -- | Executes a 'Resource' effect. Because this runs using 'MonadUnliftIO',
 -- invocations of 'runResource' must happen at the "bottom" of a stack of
@@ -96,36 +96,34 @@ unliftResource handler = runReader (Handler handler) . runResourceC
 runResource :: MonadUnliftIO m
             => ResourceC m a
             -> m a
-runResource r = withRunInIO (\f -> runHandler (Handler f) r)
+runResource r = withRunInIO (\f -> runUnlifting (UnliftIO f) r)
 
-newtype ResourceC m a = ResourceC { runResourceC :: ReaderC (Handler m) m a }
+newtype ResourceC m a = ResourceC { runResourceC :: ReaderC (UnliftIO m) m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadUnliftIO m => MonadUnliftIO (ResourceC m) where
-  askUnliftIO = ResourceC . ReaderC $ \(Handler h) ->
+  askUnliftIO = ResourceC . ReaderC $ \(UnliftIO h) ->
     withUnliftIO $ \u -> pure (UnliftIO $ \r -> unliftIO u (unliftResource h r))
 
 instance MonadTrans ResourceC where
   lift = ResourceC . lift
 
-newtype Handler m = Handler (forall x . m x -> IO x)
-
-runHandler :: Handler m -> ResourceC m a -> IO a
-runHandler h@(Handler handler) = handler . runReader h . runResourceC
+runUnlifting :: UnliftIO m -> ResourceC m a -> IO a
+runUnlifting h@(UnliftIO handler) = handler . runReader h . runResourceC
 
 instance (Carrier sig m, MonadIO m) => Carrier (Resource :+: sig) (ResourceC m) where
   eff (L (Resource acquire release use k)) = do
     handler <- ResourceC ask
     a <- liftIO (Exc.bracket
-      (runHandler handler acquire)
-      (runHandler handler . release)
-      (runHandler handler . use))
+      (runUnlifting handler acquire)
+      (runUnlifting handler . release)
+      (runUnlifting handler . use))
     k a
   eff (L (OnError  acquire release use k)) = do
     handler <- ResourceC ask
     a <- liftIO (Exc.bracketOnError
-      (runHandler handler acquire)
-      (runHandler handler . release)
-      (runHandler handler . use))
+      (runUnlifting handler acquire)
+      (runUnlifting handler . release)
+      (runUnlifting handler . use))
     k a
-  eff (R other)                            = ResourceC (eff (R (handleCoercible other)))
+  eff (R other) = ResourceC (eff (R (handleCoercible other)))


### PR DESCRIPTION
Since we use the `MonadUnliftIO` interface, we might as well get rid
of the `Handler` data type that clones the `UnliftIO` data type
provided by `MonadUnliftIO.`

Unfortunately, we can't use this to write a `MonadUnliftIO` instance
for `ReaderC (UnliftIO m) m` and then use `-XGeneralizedNewtypeDeriving`
to derive `MonadUnliftIO` instances for all effects that need it, as
we run into a role-related representation issue:

```
src/Control/Effect/Resource.hs:98:96: error:
    • Couldn't match representation of type ‘m (UnliftIO
                                                  (ResourceC m))’
                               with that of ‘m (UnliftIO (UnliftC m))’
        arising from the coercion of the method ‘askUnliftIO’
          from type ‘UnliftC m (UnliftIO (UnliftC m))’
            to type ‘ResourceC m (UnliftIO (ResourceC m))’
      NB: We cannot know what roles the parameters to ‘m’ have;
        we must assume that the role is nominal
    • When deriving the instance for (MonadUnliftIO (ResourceC m))
```

Doing so would require exposing an unsafe function, though, which
isn't great, so it's not an unmitigated tragedy.

This patch has no effect on backwards compatibility.