### PR TITLE
Simplified eliminators

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,12 @@
 
 - Removes the re-export of `Member` from all carrier modules, re-exporting `Has` in its place. `Has` constraints should generally be used instead, and specialist cases can import `Control.Effect.Sum` for `Member`. ([#217](https://github.com/fused-effects/fused-effects/pull/217))
 
+- Redesigns & renames the handlers for church-encoded nondeterminism carriers to standardize naming and usage patterns. ([#207](https://github.com/fused-effects/fused-effects/pull/207))
+  - The primary handlers (`runChoose`, `runNonDet`, `runCut`, `runCull`) take multiple continuations.
+  - Handlers which return an `Alternative` are suffixed with `A`, e.g. `runNonDetA`.
+  - Handlers which return a `Monoid` are suffixed with `M`, e.g. `runNonDetM`.
+  - Handlers which return a `Semigroup` are suffixed with `S`, e.g. `runChooseS`.
+
 # v0.5.0.1
 
 - Adds support for ghc 8.8.1.

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -46,7 +46,7 @@ queens :: (Alternative m, Monad m) => Int -> m Board
 queens n = foldl' (>>=) (pure empty) (replicate n (addOne n))
 
 runQueens :: Int -> [Board]
-runQueens = run . runNonDet . queens
+runQueens = run . runNonDetA . queens
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "N-queens problem"

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -19,50 +19,50 @@ spec :: Spec
 spec = describe "parser" $ do
   describe "parse" $ do
     prop "returns pure values at the end of input" $
-      \ a -> run (runNonDet (parse "" (pure a))) == [a :: Integer]
+      \ a -> run (runNonDetA (parse "" (pure a))) == [a :: Integer]
 
     prop "fails if input remains" $
-      \ c cs a -> run (runNonDet (parse (c:cs) (pure (a :: Integer)))) == []
+      \ c cs a -> run (runNonDetA (parse (c:cs) (pure (a :: Integer)))) == []
 
   describe "satisfy" $ do
     prop "matches with a predicate" $
-      \ c f -> run (runNonDet (parse [c] (satisfy (applyFun f)))) == if applyFun f c then [c] else []
+      \ c f -> run (runNonDetA (parse [c] (satisfy (applyFun f)))) == if applyFun f c then [c] else []
 
     prop "fails at end of input" $
-      \ f -> run (runNonDet (parse "" (satisfy (applyFun f)))) == []
+      \ f -> run (runNonDetA (parse "" (satisfy (applyFun f)))) == []
 
     prop "fails if input remains" $
-      \ c1 c2 f -> run (runNonDet (parse [c1, c2] (satisfy (applyFun f)))) == []
+      \ c1 c2 f -> run (runNonDetA (parse [c1, c2] (satisfy (applyFun f)))) == []
 
     prop "consumes input" $
-      \ c1 c2 f -> run (runNonDet (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then [(c1, c2)] else []
+      \ c1 c2 f -> run (runNonDetA (parse [c1, c2] ((,) <$> satisfy (applyFun f) <*> satisfy (applyFun f)))) == if applyFun f c1 && applyFun f c2 then [(c1, c2)] else []
 
   describe "factor" $ do
     prop "matches positive integers" $
-      \ a -> run (runNonDet (runCut (parse (show (abs a)) factor))) == [abs a]
+      \ a -> run (runCutA (parse (show (abs a)) factor)) == [abs a]
 
     prop "matches parenthesized expressions" . forAll (sized arbNested) $
-      \ as -> run (runNonDet (runCut (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor))) == [sum (map (product . map abs) as)]
+      \ as -> run (runCutA (parse ('(' : intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as) ++ ")") factor)) == [sum (map (product . map abs) as)]
 
   describe "term" $ do
     prop "matches factors" $
-      \ a -> run (runNonDet (runCut (parse (show (abs a)) term))) == [abs a]
+      \ a -> run (runCutA (parse (show (abs a)) term)) == [abs a]
 
     prop "matches multiplication" $
-      \ as -> run (runNonDet (runCut (parse (intercalate "*" (show . abs <$> 1:as)) term))) == [product (map abs as)]
+      \ as -> run (runCutA (parse (intercalate "*" (show . abs <$> 1:as)) term)) == [product (map abs as)]
 
   describe "expr" $ do
     prop "matches factors" $
-      \ a -> run (runNonDet (runCut (parse (show (abs a)) expr))) == [abs a]
+      \ a -> run (runCutA (parse (show (abs a)) expr)) == [abs a]
 
     prop "matches multiplication" $
-      \ as -> run (runNonDet (runCut (parse (intercalate "*" (show . abs <$> 1:as)) expr))) == [product (map abs as)]
+      \ as -> run (runCutA (parse (intercalate "*" (show . abs <$> 1:as)) expr)) == [product (map abs as)]
 
     prop "matches addition" $
-      \ as -> run (runNonDet (runCut (parse (intercalate "+" (show . abs <$> 0:as)) expr))) == [sum (map abs as)]
+      \ as -> run (runCutA (parse (intercalate "+" (show . abs <$> 0:as)) expr)) == [sum (map abs as)]
 
     prop "respects order of operations" . forAll (sized arbNested) $
-      \ as -> run (runNonDet (runCut (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr))) == [sum (map (product . map abs) as)]
+      \ as -> run (runCutA (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr)) == [sum (map (product . map abs) as)]
 
     where arbNested :: Arbitrary a => Int -> Gen [[a]]
           arbNested 0 = pure []

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -24,6 +24,7 @@ import Data.Maybe (fromJust)
 import qualified Data.Semigroup as S
 import Prelude hiding (fail)
 
+-- | Run a 'Choose' effect, passing branches and results to the supplied continuations.
 runChoose :: (m b -> m b -> m b) -> (a -> m b) -> ChooseC m a -> m b
 runChoose fork leaf m = runChooseC m fork leaf
 

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -28,6 +28,7 @@ import Prelude hiding (fail)
 runChoose :: (m b -> m b -> m b) -> (a -> m b) -> ChooseC m a -> m b
 runChoose fork leaf m = runChooseC m fork leaf
 
+-- | Run a 'Choose' effect, passing results to the supplied function, and merging branches together using 'S.<>'.
 runChooseS :: (Applicative m, S.Semigroup b) => (a -> m b) -> ChooseC m a -> m b
 runChooseS leaf = runChoose (liftA2 (S.<>)) leaf
 

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -21,13 +21,14 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Maybe (fromJust)
+import qualified Data.Semigroup as S
 import Prelude hiding (fail)
 
 runChoose :: (m b -> m b -> m b) -> (a -> m b) -> ChooseC m a -> m b
 runChoose fork leaf m = runChooseC m fork leaf
 
-runChooseS :: (Applicative m, Semigroup b) => (a -> m b) -> ChooseC m a -> m b
-runChooseS leaf = runChoose (liftA2 (<>)) leaf
+runChooseS :: (Applicative m, S.Semigroup b) => (a -> m b) -> ChooseC m a -> m b
+runChooseS leaf = runChoose (liftA2 (S.<>)) leaf
 
 -- | A carrier for 'Choose' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype ChooseC m a = ChooseC

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -4,6 +4,7 @@ module Control.Carrier.Choose.Church
   module Control.Effect.Choose
   -- * Choose carrier
 , runChoose
+, runChooseS
 , ChooseC(..)
   -- * Re-exports
 , Carrier
@@ -24,6 +25,9 @@ import Prelude hiding (fail)
 
 runChoose :: (m b -> m b -> m b) -> (a -> m b) -> ChooseC m a -> m b
 runChoose fork leaf m = runChooseC m fork leaf
+
+runChooseS :: (Applicative m, Semigroup b) => (a -> m b) -> ChooseC m a -> m b
+runChooseS leaf = runChoose (liftA2 (<>)) leaf
 
 -- | A carrier for 'Choose' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype ChooseC m a = ChooseC

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -45,7 +45,7 @@ instance Applicative (ChooseC m) where
 
 instance Monad (ChooseC m) where
   ChooseC a >>= f = ChooseC $ \ fork leaf ->
-    a fork (\ a' -> runChooseC (f a') fork leaf)
+    a fork (runChoose fork leaf . f)
   {-# INLINE (>>=) #-}
 
 instance MonadFail m => MonadFail (ChooseC m) where
@@ -54,9 +54,10 @@ instance MonadFail m => MonadFail (ChooseC m) where
 
 instance MonadFix m => MonadFix (ChooseC m) where
   mfix f = ChooseC $ \ fork leaf ->
-    mfix (\ a -> runChooseC (f (fromJust (fold (<|>) Just a)))
+    mfix (runChoose
       (liftA2 Fork)
-      (pure . Leaf))
+      (pure . Leaf)
+      . f . fromJust . fold (<|>) Just)
     >>= fold fork leaf
   {-# INLINE mfix #-}
 

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -61,6 +61,5 @@ instance (Carrier sig m, Effect sig) => Carrier (Cull :+: NonDet :+: sig) (CullC
 -- $setup
 -- >>> :seti -XFlexibleContexts
 -- >>> import Control.Applicative (liftA2)
--- >>> import Control.Carrier.NonDet.Church
 -- >>> import Control.Carrier.Pure
 -- >>> import Test.QuickCheck

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -7,6 +7,7 @@ module Control.Carrier.Cull.Church
   -- * Cull carrier
 , runCull
 , runCullA
+, runCullM
 , CullC(..)
   -- * Re-exports
 , Carrier
@@ -34,6 +35,9 @@ runCull fork leaf nil = runNonDet fork leaf nil . runReader False . runCullC
 
 runCullA :: (Alternative f, Applicative m) => CullC m a -> m (f a)
 runCullA = runCull (liftA2 (<|>)) (pure . pure) (pure empty)
+
+runCullM :: (Applicative m, Monoid b) => (a -> b) -> CullC m a -> m b
+runCullM leaf = runCull (liftA2 (<>)) (pure . leaf) (pure mempty)
 
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -69,5 +69,4 @@ instance (Carrier sig m, Effect sig) => Carrier (Cull :+: NonDet :+: sig) (CullC
 
 -- $setup
 -- >>> :seti -XFlexibleContexts
--- >>> import Control.Carrier.Pure
 -- >>> import Test.QuickCheck

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -37,7 +37,7 @@ runCullA :: (Alternative f, Applicative m) => CullC m a -> m (f a)
 runCullA = runCull (liftA2 (<|>)) (pure . pure) (pure empty)
 
 runCullM :: (Applicative m, Monoid b) => (a -> b) -> CullC m a -> m b
-runCullM leaf = runCull (liftA2 (<>)) (pure . leaf) (pure mempty)
+runCullM leaf = runCull (liftA2 mappend) (pure . leaf) (pure mempty)
 
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -9,7 +9,7 @@ module Control.Carrier.Cut.Church
 , runCutA
 , runCutM
 , CutC(..)
--- * Re-exports
+  -- * Re-exports
 , Carrier
 , Has
 , run

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -7,6 +7,7 @@ module Control.Carrier.Cut.Church
   -- * Cut carrier
 , runCut
 , runCutA
+, runCutM
 , CutC(..)
 -- * Re-exports
 , Carrier
@@ -33,6 +34,9 @@ runCut cons nil fail m = runCutC m cons nil fail
 -- | Run a 'Cut' effect, returning all its results in an 'Alternative' collection.
 runCutA :: (Alternative f, Applicative m) => CutC m a -> m (f a)
 runCutA (CutC m) = m (fmap . (<|>) . pure) (pure empty) (pure empty)
+
+runCutM :: (Applicative m, Monoid b) => (a -> b) -> CutC m a -> m b
+runCutM leaf = runCut (fmap . (<>) . leaf) (pure mempty) (pure mempty)
 
 newtype CutC m a = CutC
   { -- | A higher-order function receiving three parameters: a function to combine each solution with the rest of the solutions, an action to run when no results are produced (e.g. on 'empty'), and an action to run when no results are produced and backtrcking should not be attempted (e.g. on 'cutfail').

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -36,7 +36,7 @@ runCutA :: (Alternative f, Applicative m) => CutC m a -> m (f a)
 runCutA = runCut (fmap . (<|>) . pure) (pure empty) (pure empty)
 
 runCutM :: (Applicative m, Monoid b) => (a -> b) -> CutC m a -> m b
-runCutM leaf = runCut (fmap . (<>) . leaf) (pure mempty) (pure mempty)
+runCutM leaf = runCut (fmap . mappend . leaf) (pure mempty) (pure mempty)
 
 newtype CutC m a = CutC
   { -- | A higher-order function receiving three parameters: a function to combine each solution with the rest of the solutions, an action to run when no results are produced (e.g. on 'empty'), and an action to run when no results are produced and backtrcking should not be attempted (e.g. on 'cutfail').

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -98,4 +98,3 @@ instance (Carrier sig m, Effect sig) => Carrier (Cut :+: NonDet :+: sig) (CutC m
 -- >>> :seti -XFlexibleContexts
 -- >>> import Test.QuickCheck
 -- >>> import Control.Carrier.NonDet.Church
--- >>> import Control.Carrier.Pure

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -33,7 +33,7 @@ runCut cons nil fail m = runCutC m cons nil fail
 
 -- | Run a 'Cut' effect, returning all its results in an 'Alternative' collection.
 runCutA :: (Alternative f, Applicative m) => CutC m a -> m (f a)
-runCutA (CutC m) = m (fmap . (<|>) . pure) (pure empty) (pure empty)
+runCutA = runCut (fmap . (<|>) . pure) (pure empty) (pure empty)
 
 runCutM :: (Applicative m, Monoid b) => (a -> b) -> CutC m a -> m b
 runCutM leaf = runCut (fmap . (<>) . leaf) (pure mempty) (pure mempty)

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -24,11 +24,11 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Prelude hiding (fail)
 
--- | Run a 'Cut' effect within an underlying 'Alternative' instance (typically another 'Carrier' for 'Choose' & 'Empty' effects).
+-- | Run a 'Cut' effect with the supplied continuations for 'pure'/'<|>', 'empty', and 'cutfail'.
 --
---   prop> run (runNonDet (runCut (pure a))) === Just a
-runCut :: Alternative m => CutC m a -> m a
-runCut m = runCutC m ((<|>) . pure) empty empty
+--   prop> run (runCut (fmap . (:)) (pure []) (pure []) (pure a)) === [a]
+runCut :: (a -> m b -> m b) -> m b -> m b -> CutC m a -> m b
+runCut cons nil fail m = runCutC m cons nil fail
 
 -- | Run a 'Cut' effect, returning all its results in an 'Alternative' collection.
 runCutA :: (Alternative f, Applicative m) => CutC m a -> m (f a)

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -63,7 +63,12 @@ instance Fail.MonadFail m => Fail.MonadFail (CutC m) where
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (CutC m) where
-  mfix f = CutC (\ cons nil _ -> mfix (\ a -> runCutC (f (head a)) (fmap . (:)) (pure []) (pure [])) >>= foldr cons nil)
+  mfix f = CutC (\ cons nil _ ->
+    mfix (runCut
+      (fmap . (:))
+      (pure [])
+      (pure [])
+      . f . head) >>= foldr cons nil)
   {-# INLINE mfix #-}
 
 instance MonadIO m => MonadIO (CutC m) where

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -33,8 +33,8 @@ runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 --
 --   Using @[]@ as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unlike 'Control.Effect.Cull.runNonDetOnce', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
 --
---   prop> run (runNonDet (pure a)) === [a]
---   prop> run (runNonDet (pure a)) === Just a
+--   prop> run (runNonDetAlt (pure a)) === [a]
+--   prop> run (runNonDetAlt (pure a)) === Just a
 runNonDetAlt :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDetAlt = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
 
@@ -46,8 +46,8 @@ newtype NonDetC m a = NonDetC
   deriving (Functor)
 
 -- $
---   prop> run (runNonDet (pure a *> pure b)) === Just b
---   prop> run (runNonDet (pure a <* pure b)) === Just a
+--   prop> run (runNonDetAlt (pure a *> pure b)) === Just b
+--   prop> run (runNonDetAlt (pure a <* pure b)) === Just a
 instance Applicative (NonDetC m) where
   pure a = NonDetC (\ _ pure _ -> pure a)
   {-# INLINE pure #-}
@@ -56,8 +56,8 @@ instance Applicative (NonDetC m) where
   {-# INLINE (<*>) #-}
 
 -- $
---   prop> run (runNonDet (pure a <|> (pure b <|> pure c))) === Fork (Leaf a) (Fork (Leaf b) (Leaf c))
---   prop> run (runNonDet ((pure a <|> pure b) <|> pure c)) === Fork (Fork (Leaf a) (Leaf b)) (Leaf c)
+--   prop> run (runNonDetAlt (pure a <|> (pure b <|> pure c))) === Fork (Leaf a) (Fork (Leaf b) (Leaf c))
+--   prop> run (runNonDetAlt ((pure a <|> pure b) <|> pure c)) === Fork (Fork (Leaf a) (Leaf b)) (Leaf c)
 instance Alternative (NonDetC m) where
   empty = NonDetC (\ _ _ empty -> empty)
   {-# INLINE empty #-}

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -4,7 +4,7 @@ module Control.Carrier.NonDet.Church
   module Control.Effect.Choose
 , module Control.Effect.Empty
   -- * NonDet carrier
-, runNonDet
+, runNonDetAlt
 , NonDetC(..)
   -- * Re-exports
 , Alternative(..)
@@ -31,8 +31,8 @@ import Prelude hiding (fail)
 --
 --   prop> run (runNonDet (pure a)) === [a]
 --   prop> run (runNonDet (pure a)) === Just a
-runNonDet :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
-runNonDet (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
+runNonDetAlt :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
+runNonDetAlt (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype NonDetC m a = NonDetC
@@ -91,7 +91,7 @@ instance MonadTrans NonDetC where
 instance (Carrier sig m, Effect sig) => Carrier (Empty :+: Choose :+: sig) (NonDetC m) where
   eff (L Empty)          = empty
   eff (R (L (Choose k))) = k True <|> k False
-  eff (R (R other))      = NonDetC $ \ fork leaf nil -> eff (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil
+  eff (R (R other))      = NonDetC $ \ fork leaf nil -> eff (handle (Leaf ()) (fmap join . traverse runNonDetAlt) other) >>= fold fork leaf nil
   {-# INLINE eff #-}
 
 

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -36,7 +36,7 @@ runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 --   prop> run (runNonDet (pure a)) === [a]
 --   prop> run (runNonDet (pure a)) === Just a
 runNonDetAlt :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
-runNonDetAlt (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
+runNonDetAlt = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype NonDetC m a = NonDetC

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -6,6 +6,7 @@ module Control.Carrier.NonDet.Church
   -- * NonDet carrier
 , runNonDet
 , runNonDetAlt
+, runNonDetM
 , NonDetC(..)
   -- * Re-exports
 , Alternative(..)
@@ -37,6 +38,9 @@ runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 --   prop> run (runNonDetAlt (pure a)) === Just a
 runNonDetAlt :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDetAlt = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
+
+runNonDetM :: (Applicative m, Monoid b) => (a -> b) -> NonDetC m a -> m b
+runNonDetM leaf = runNonDet (liftA2 (<>)) (pure . leaf) (pure mempty)
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype NonDetC m a = NonDetC

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -28,7 +28,7 @@ runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.
 --
---   Using @[]@ as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unlike 'Control.Effect.Cull.runNonDetOnce', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
+--   Using @[]@ as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unless used with 'Control.Effect.Cull.cull', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
 --
 --   prop> run (runNonDetA (pure a)) === [a]
 --   prop> run (runNonDetA (pure a)) === Just a

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -36,7 +36,7 @@ runNonDetA :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDetA = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
 
 runNonDetM :: (Applicative m, Monoid b) => (a -> b) -> NonDetC m a -> m b
-runNonDetM leaf = runNonDet (liftA2 (<>)) (pure . leaf) (pure mempty)
+runNonDetM leaf = runNonDet (liftA2 mappend) (pure . leaf) (pure mempty)
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype NonDetC m a = NonDetC

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -4,6 +4,7 @@ module Control.Carrier.NonDet.Church
   module Control.Effect.Choose
 , module Control.Effect.Empty
   -- * NonDet carrier
+, runNonDet
 , runNonDetAlt
 , NonDetC(..)
   -- * Re-exports
@@ -24,6 +25,9 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Maybe (fromJust)
 import Prelude hiding (fail)
+
+runNonDet :: (m b -> m b -> m b) -> (a -> m b) -> m b -> NonDetC m a -> m b
+runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.
 --

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -5,7 +5,7 @@ module Control.Carrier.Trace.Ignoring
   -- * Trace carrier
 , runTrace
 , TraceC(..)
--- * Re-exports
+  -- * Re-exports
 , Carrier
 , Has
 , run

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -5,7 +5,7 @@ module Control.Carrier.Trace.Printing
   -- * Trace carrier
 , runTrace
 , TraceC(..)
--- * Re-exports
+  -- * Re-exports
 , Carrier
 , Has
 , run

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -5,7 +5,7 @@ module Control.Carrier.Trace.Returning
   -- * Trace carrier
 , runTrace
 , TraceC(..)
--- * Re-exports
+  -- * Re-exports
 , Carrier
 , Has
 , run

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -36,5 +36,4 @@ cull m = send (Cull m pure)
 -- >>> import Test.QuickCheck
 -- >>> import Control.Carrier.Cull.Church
 -- >>> import Control.Carrier.NonDet.Church
--- >>> import Control.Carrier.Pure
 -- >>> import Data.Foldable (asum)

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -59,4 +59,3 @@ cut = pure () <|> cutfail
 -- >>> import Test.QuickCheck
 -- >>> import Control.Carrier.Cut.Church
 -- >>> import Control.Carrier.NonDet.Church
--- >>> import Control.Carrier.Pure

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -39,6 +39,5 @@ resetFresh m = send (Reset m pure)
 -- >>> :seti -XFlexibleContexts
 -- >>> import Test.QuickCheck
 -- >>> import Control.Carrier.Fresh.Strict
--- >>> import Control.Carrier.Pure
 -- >>> import Control.Monad (replicateM)
 -- >>> import Data.List (nub)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -62,5 +62,4 @@ modifyLazy f = get >>= put . f
 -- $setup
 -- >>> :seti -XFlexibleContexts
 -- >>> import Test.QuickCheck
--- >>> import Control.Carrier.Pure
 -- >>> import Control.Carrier.State.Strict

--- a/test/Control/Effect/NonDet/Spec.hs
+++ b/test/Control/Effect/NonDet/Spec.hs
@@ -11,13 +11,13 @@ spec :: Spec
 spec = do
   describe "interactions" $ do
     it "collects results of effects run before it" $
-      run (runNonDet (runState 'a' (pure 'z' <|> put 'b' *> get <|> get))) `shouldBe` [('a', 'z'), ('b', 'b'), ('a', 'a')]
+      run (runNonDetA (runState 'a' (pure 'z' <|> put 'b' *> get <|> get))) `shouldBe` [('a', 'z'), ('b', 'b'), ('a', 'a')]
 
     it "collapses results of effects run after it" $
-      run (runState 'a' (runNonDet (pure 'z' <|> put 'b' *> get <|> get))) `shouldBe` ('b', "zbb")
+      run (runState 'a' (runNonDetA (pure 'z' <|> put 'b' *> get <|> get))) `shouldBe` ('b', "zbb")
 
     it "collects results from higher-order effects run before it" $
-      run (runNonDet (runError ((pure 'z' <|> throwError 'a') `catchError` pure))) `shouldBe` [Right 'z', Right 'a' :: Either Char Char]
+      run (runNonDetA (runError ((pure 'z' <|> throwError 'a') `catchError` pure))) `shouldBe` [Right 'z', Right 'a' :: Either Char Char]
 
     it "collapses results of higher-order effects run after it" $
-      run (runError (runNonDet ((pure 'z' <|> throwError 'a') `catchError` pure))) `shouldBe` (Right "a" :: Either Char String)
+      run (runError (runNonDetA ((pure 'z' <|> throwError 'a') `catchError` pure))) `shouldBe` (Right "a" :: Either Char String)


### PR DESCRIPTION
This PR simplifies the `NonDetC` handler, and adds a couple of extra ones.

- [x] Fixes #157.
- [x] Depends on #196.
- [x] Depends on #197.
- [x] Depends on #198.
- [x] Depends on #199.
- [x] Depends on #200.
- [x] Depends on #204.
- [x] Depends on #205.
- [x] Depends on #219.