### PR TITLE
ghc 8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.8.1"
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.2"
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# v0.5.0.1
+
+- Adds support for ghc 8.8.1.
+
 # v0.5.0.0
 
 - Derives `Generic1` instances for all non-existentially-quantified effect datatypes.

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -8,9 +8,9 @@ import Control.Effect.Interpret
 import Control.Effect.Writer
 import Control.Effect.State
 import Control.Monad (ap, replicateM_)
-import Criterion.Main
 import Data.Functor.Identity
 import Data.Monoid (Sum(..))
+import Gauge
 
 main :: IO ()
 main = defaultMain

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.2
 
 name:                fused-effects
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            A fast, flexible, fused effect system.
 description:         A fast, flexible, fused effect system, à la Effect Handlers in Scope, Monad Transformers and Modular Algebraic Effects: What Binds Them Together, and Fusion for Free—Efficient Algebraic Effect Handlers.
 homepage:            https://github.com/fused-effects/fused-effects

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -54,10 +54,10 @@ library
                      , Control.Effect.Sum
                      , Control.Effect.Trace
                      , Control.Effect.Writer
-  build-depends:       base >=4.9 && <4.14
-                     , deepseq >=1.4.3 && <1.5
-                     , MonadRandom >=0.5 && <0.6
-                     , unliftio-core >= 0.1.2
+  build-depends:       base          ^>= 4.9
+                     , deepseq       ^>= 1.4.3
+                     , MonadRandom   ^>= 0.5
+                     , unliftio-core ^>= 0.1.2
                      , random
                      , transformers
   hs-source-dirs:      src
@@ -70,10 +70,10 @@ test-suite examples
   other-modules:       Parser
                      , ReinterpretLog
                      , Teletype
-  build-depends:       base >=4.9 && <4.14
+  build-depends:       base       ^>= 4.9
                      , fused-effects
-                     , hspec >=2.4.1
-                     , QuickCheck >= 2.7 && < 3
+                     , hspec      ^>= 2.4.1
+                     , QuickCheck ^>= 2.7
                      , transformers
   hs-source-dirs:      examples
 
@@ -83,18 +83,18 @@ test-suite test
   main-is:             Spec.hs
   other-modules:       Control.Effect.Spec
                      , Control.Effect.NonDet.Spec
-  build-depends:       base >=4.9 && <4.14
+  build-depends:       base               ^>= 4.9
                      , fused-effects
-                     , hspec >=2.4.1
-                     , inspection-testing >= 0.4 && <1
+                     , hspec              ^>= 2.4.1
+                     , inspection-testing ^>= 0.4
   hs-source-dirs:      test
 
 test-suite doctest
   import:              common
   type:                exitcode-stdio-1.0
   main-is:             Doctest.hs
-  build-depends:       base >=4.9 && <4.14
-                     , doctest >=0.7 && <1.0
+  build-depends:       base    ^>= 4.9
+                     , doctest ^>= 0.7
                      , fused-effects
   hs-source-dirs:      test
 
@@ -103,7 +103,7 @@ benchmark benchmark
   import:             common
   type:               exitcode-stdio-1.0
   main-is:            Bench.hs
-  build-depends:      base >=4.9 && <4.14
+  build-depends:      base ^>= 4.9
                     , fused-effects
                     , gauge
   hs-source-dirs:     benchmark

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -72,8 +72,8 @@ test-suite examples
                      , Teletype
   build-depends:       base        >= 4.9 && < 4.14
                      , fused-effects
-                     , hspec      ^>= 2.4.1
-                     , QuickCheck ^>= 2.7
+                     , hspec      ^>= 2.7
+                     , QuickCheck ^>= 2.13
                      , transformers
   hs-source-dirs:      examples
 
@@ -85,7 +85,7 @@ test-suite test
                      , Control.Effect.NonDet.Spec
   build-depends:       base                >= 4.9 && < 4.14
                      , fused-effects
-                     , hspec              ^>= 2.4.1
+                     , hspec              ^>= 2.7
                      , inspection-testing ^>= 0.4
   hs-source-dirs:      test
 
@@ -94,7 +94,7 @@ test-suite doctest
   type:                exitcode-stdio-1.0
   main-is:             Doctest.hs
   build-depends:       base     >= 4.9 && < 4.14
-                     , doctest ^>= 0.7
+                     , doctest ^>= 0.16
                      , fused-effects
   hs-source-dirs:      test
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -26,6 +26,8 @@ common common
   ghc-options:         -Weverything -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-name-shadowing -Wno-monomorphism-restriction -Wno-missed-specialisations -Wno-all-missed-specialisations
   if (impl(ghc >= 8.6))
     ghc-options:       -Wno-star-is-type
+  if (impl(ghc >= 8.8))
+    ghc-options:       -Wno-missing-deriving-strategies
 
 library
   import:              common

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -54,7 +54,7 @@ library
                      , Control.Effect.Sum
                      , Control.Effect.Trace
                      , Control.Effect.Writer
-  build-depends:       base          ^>= 4.9
+  build-depends:       base           >= 4.9 && < 4.14
                      , deepseq       ^>= 1.4.3
                      , MonadRandom   ^>= 0.5
                      , unliftio-core ^>= 0.1.2
@@ -70,7 +70,7 @@ test-suite examples
   other-modules:       Parser
                      , ReinterpretLog
                      , Teletype
-  build-depends:       base       ^>= 4.9
+  build-depends:       base        >= 4.9 && < 4.14
                      , fused-effects
                      , hspec      ^>= 2.4.1
                      , QuickCheck ^>= 2.7
@@ -83,7 +83,7 @@ test-suite test
   main-is:             Spec.hs
   other-modules:       Control.Effect.Spec
                      , Control.Effect.NonDet.Spec
-  build-depends:       base               ^>= 4.9
+  build-depends:       base                >= 4.9 && < 4.14
                      , fused-effects
                      , hspec              ^>= 2.4.1
                      , inspection-testing ^>= 0.4
@@ -93,7 +93,7 @@ test-suite doctest
   import:              common
   type:                exitcode-stdio-1.0
   main-is:             Doctest.hs
-  build-depends:       base    ^>= 4.9
+  build-depends:       base     >= 4.9 && < 4.14
                      , doctest ^>= 0.7
                      , fused-effects
   hs-source-dirs:      test
@@ -103,7 +103,7 @@ benchmark benchmark
   import:             common
   type:               exitcode-stdio-1.0
   main-is:            Bench.hs
-  build-depends:      base ^>= 4.9
+  build-depends:      base >= 4.9 && < 4.14
                     , fused-effects
                     , gauge
   hs-source-dirs:     benchmark

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -51,7 +51,7 @@ library
                      , Control.Effect.Sum
                      , Control.Effect.Trace
                      , Control.Effect.Writer
-  build-depends:       base >=4.9 && <4.13
+  build-depends:       base >=4.9 && <4.14
                      , deepseq >=1.4.3 && <1.5
                      , MonadRandom >=0.5 && <0.6
                      , unliftio-core >= 0.1.2
@@ -67,7 +67,7 @@ test-suite examples
   other-modules:       Parser
                      , ReinterpretLog
                      , Teletype
-  build-depends:       base >=4.9 && <4.13
+  build-depends:       base >=4.9 && <4.14
                      , fused-effects
                      , hspec >=2.4.1
                      , QuickCheck >= 2.7 && < 3
@@ -80,7 +80,7 @@ test-suite test
   main-is:             Spec.hs
   other-modules:       Control.Effect.Spec
                      , Control.Effect.NonDet.Spec
-  build-depends:       base >=4.9 && <4.13
+  build-depends:       base >=4.9 && <4.14
                      , fused-effects
                      , hspec >=2.4.1
                      , inspection-testing >= 0.4 && <1
@@ -90,7 +90,7 @@ test-suite doctest
   import:              common
   type:                exitcode-stdio-1.0
   main-is:             Doctest.hs
-  build-depends:       base >=4.9 && <4.13
+  build-depends:       base >=4.9 && <4.14
                      , doctest >=0.7 && <1.0
                      , fused-effects
   hs-source-dirs:      test
@@ -100,7 +100,7 @@ benchmark benchmark
   import:             common
   type:               exitcode-stdio-1.0
   main-is:            Bench.hs
-  build-depends:      base >=4.9 && <4.13
+  build-depends:      base >=4.9 && <4.14
                     , fused-effects
                     , gauge
   hs-source-dirs:     benchmark

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -72,8 +72,8 @@ test-suite examples
                      , Teletype
   build-depends:       base        >= 4.9 && < 4.14
                      , fused-effects
-                     , hspec      ^>= 2.7
-                     , QuickCheck ^>= 2.13
+                     , hspec       >= 2.4.1
+                     , QuickCheck  >= 2.7 && < 3
                      , transformers
   hs-source-dirs:      examples
 
@@ -85,7 +85,7 @@ test-suite test
                      , Control.Effect.NonDet.Spec
   build-depends:       base                >= 4.9 && < 4.14
                      , fused-effects
-                     , hspec              ^>= 2.7
+                     , hspec               >= 2.4.1
                      , inspection-testing ^>= 0.4
   hs-source-dirs:      test
 
@@ -94,7 +94,7 @@ test-suite doctest
   type:                exitcode-stdio-1.0
   main-is:             Doctest.hs
   build-depends:       base     >= 4.9 && < 4.14
-                     , doctest ^>= 0.16
+                     , doctest  >= 0.7 && < 1
                      , fused-effects
   hs-source-dirs:      test
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -19,6 +19,7 @@ extra-source-files:
 tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.2
+                   , GHC == 8.8.1
 
 common common
   default-language:    Haskell2010

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -101,8 +101,8 @@ benchmark benchmark
   type:               exitcode-stdio-1.0
   main-is:            Bench.hs
   build-depends:      base >=4.9 && <4.13
-                    , criterion
                     , fused-effects
+                    , gauge
   hs-source-dirs:     benchmark
   ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -A4m -n2m"
 

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -19,7 +19,7 @@ import Control.Effect.Carrier
 import Control.Effect.NonDet
 import Control.Effect.Reader
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -55,7 +55,7 @@ runCull :: Alternative m => CullC m a -> m a
 runCull (CullC m) = runNonDetC (runReader False m) ((<|>) . pure) empty
 
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
-  deriving (Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO)
+  deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)
 
 instance Alternative (CullC m) where
   empty = CullC empty
@@ -90,7 +90,7 @@ runNonDetOnce :: (Alternative f, Carrier sig m, Effect sig) => OnceC m a -> m (f
 runNonDetOnce = runNonDet . runCull . cull . runOnceC
 
 newtype OnceC m a = OnceC { runOnceC :: CullC (NonDetC m) a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance (Carrier sig m, Effect sig) => Carrier (NonDet :+: sig) (OnceC m) where
   eff = OnceC . eff . R . R . handleCoercible

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -14,7 +14,6 @@ module Control.Effect.Cull
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.NonDet
 import Control.Effect.Reader

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -19,11 +19,10 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.NonDet
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Prelude hiding (fail)
 
 -- | 'Cut' effects are used with 'NonDet' to provide control over backtracking.
 data Cut m k
@@ -103,8 +102,8 @@ instance Monad (CutC m) where
     a (\ a' as -> runCutC (f a') cons as fail) nil fail
   {-# INLINE (>>=) #-}
 
-instance MonadFail m => MonadFail (CutC m) where
-  fail s = CutC (\ _ _ _ -> fail s)
+instance Fail.MonadFail m => Fail.MonadFail (CutC m) where
+  fail s = CutC (\ _ _ _ -> Fail.fail s)
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (CutC m) where

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -15,7 +15,6 @@ module Control.Effect.Cut
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.NonDet
 import Control.Monad (MonadPlus(..))

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -16,11 +16,10 @@ module Control.Effect.Error
 import Control.Applicative (Alternative(..), liftA2)
 import Control.Effect.Carrier
 import Control.Monad (MonadPlus(..), (<=<))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Prelude hiding (fail)
 
 data Error exc m k
   = Throw exc
@@ -90,8 +89,8 @@ instance MonadIO m => MonadIO (ErrorC e m) where
   liftIO io = ErrorC (Right <$> liftIO io)
   {-# INLINE liftIO #-}
 
-instance MonadFail m => MonadFail (ErrorC e m) where
-  fail s = ErrorC (fail s)
+instance Fail.MonadFail m => Fail.MonadFail (ErrorC e m) where
+  fail s = ErrorC (Fail.fail s)
   {-# INLINE fail #-}
 
 instance (Alternative m, Monad m) => MonadPlus (ErrorC e m)

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -8,7 +8,7 @@ module Control.Effect.Fail
   -- * Re-exports
 , Carrier
 , Member
-, MonadFail(..)
+, Fail.MonadFail(..)
 , run
 ) where
 
@@ -16,12 +16,11 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.Error
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import GHC.Generics (Generic1)
-import Prelude hiding (fail)
 
 newtype Fail (m :: * -> *) k = Fail String
   deriving stock (Functor, Generic1)
@@ -36,12 +35,12 @@ runFail = runError . runFailC
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
   deriving newtype (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance (Carrier sig m, Effect sig) => MonadFail (FailC m) where
+instance (Carrier sig m, Effect sig) => Fail.MonadFail (FailC m) where
   fail s = FailC (throwError s)
   {-# INLINE fail #-}
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
-  eff (L (Fail s)) = fail s
+  eff (L (Fail s)) = Fail.fail s
   eff (R other)    = FailC (eff (R (handleCoercible other)))
   {-# INLINE eff #-}
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -17,7 +17,7 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -57,7 +57,7 @@ runFresh :: Functor m => FreshC m a -> m a
 runFresh = evalState 0 . runFreshC
 
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => Carrier (Fresh :+: sig) (FreshC m) where
   eff (L (Fresh   k)) = FreshC $ do

--- a/src/Control/Effect/Interpose.hs
+++ b/src/Control/Effect/Interpose.hs
@@ -14,7 +14,7 @@ import Control.Applicative
 import Control.Effect.Carrier
 import Control.Effect.Reader
 import Control.Monad (MonadPlus (..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -31,7 +31,7 @@ runInterpose :: (forall x . eff m x -> m x) -> InterposeC eff m a -> m a
 runInterpose handler = runReader (Handler handler) . runInterposeC
 
 newtype InterposeC eff m a = InterposeC { runInterposeC :: ReaderC (Handler eff m) m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans (InterposeC eff) where
   lift = InterposeC . lift

--- a/src/Control/Effect/Interpret.hs
+++ b/src/Control/Effect/Interpret.hs
@@ -11,7 +11,7 @@ import Control.Effect.Carrier
 import Control.Effect.Reader
 import Control.Effect.State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -27,7 +27,7 @@ runInterpret :: (forall x . eff m x -> m x) -> InterpretC eff m a -> m a
 runInterpret handler = runReader (Handler handler) . runInterpretC
 
 newtype InterpretC eff m a = InterpretC { runInterpretC :: ReaderC (Handler eff m) m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans (InterpretC eff) where
   lift = InterpretC . lift
@@ -57,7 +57,7 @@ runInterpretState :: (forall x . s -> eff (StateC s m) x -> m (s, x)) -> s -> In
 runInterpretState handler state = runState state . runReader (HandlerState (\ eff -> StateC (\ s -> handler s eff))) . runInterpretStateC
 
 newtype InterpretStateC eff s m a = InterpretStateC { runInterpretStateC :: ReaderC (HandlerState eff s m) (StateC s m) a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans (InterpretStateC eff s) where
   lift = InterpretStateC . lift . lift

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -15,7 +15,7 @@ module Control.Effect.Lift
 import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
@@ -37,7 +37,7 @@ sendM :: (Member (Lift n) sig, Carrier sig m, Functor n) => n a -> m a
 sendM = send . Lift . fmap pure
 
 newtype LiftC m a = LiftC { runLiftC :: m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving newtype (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans LiftC where
   lift = LiftC

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -15,12 +15,11 @@ module Control.Effect.NonDet
 import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import GHC.Generics (Generic1)
-import Prelude hiding (fail)
 
 data NonDet m k
   = Empty
@@ -63,8 +62,8 @@ instance Monad (NonDetC m) where
     a (\ a' -> runNonDetC (f a') cons)
   {-# INLINE (>>=) #-}
 
-instance MonadFail m => MonadFail (NonDetC m) where
-  fail s = NonDetC (\ _ _ -> fail s)
+instance Fail.MonadFail m => Fail.MonadFail (NonDetC m) where
+  fail s = NonDetC (\ _ _ -> Fail.fail s)
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (NonDetC m) where

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -10,7 +10,6 @@ module Control.Effect.Pure
 import Control.Applicative
 import Control.Monad.Fix
 import Data.Coerce
-import Data.Function (fix)
 import GHC.Generics (Generic1)
 
 data Pure (m :: * -> *) k

--- a/src/Control/Effect/Random.hs
+++ b/src/Control/Effect/Random.hs
@@ -20,7 +20,7 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.Random.Class (MonadInterleave(..), MonadRandom(..))
 import Control.Monad.IO.Class (MonadIO(..))
@@ -69,7 +69,7 @@ evalRandomIO :: MonadIO m => RandomC R.StdGen m a -> m a
 evalRandomIO m = liftIO R.newStdGen >>= flip evalRandom m
 
 newtype RandomC g m a = RandomC { runRandomC :: StateC g m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig, R.RandomGen g) => MonadRandom (RandomC g m) where
   getRandom = RandomC $ do

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -17,12 +17,11 @@ module Control.Effect.Reader
 import Control.Applicative (Alternative(..), liftA2)
 import Control.Effect.Carrier
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
-import Prelude hiding (fail)
 
 data Reader r m k
   = Ask (r -> m k)
@@ -88,8 +87,8 @@ instance Monad m => Monad (ReaderC r m) where
   ReaderC a >>= f = ReaderC (\ r -> a r >>= runReader r . f)
   {-# INLINE (>>=) #-}
 
-instance MonadFail m => MonadFail (ReaderC r m) where
-  fail = ReaderC . const . fail
+instance Fail.MonadFail m => Fail.MonadFail (ReaderC r m) where
+  fail = ReaderC . const . Fail.fail
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (ReaderC s m) where

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -16,7 +16,7 @@ import           Control.Effect.Carrier
 import           Control.Effect.Reader
 import qualified Control.Exception as Exc
 import           Control.Monad (MonadPlus(..))
-import           Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
@@ -99,7 +99,7 @@ runResource :: MonadUnliftIO m
 runResource r = withRunInIO (\f -> runHandler (Handler f) r)
 
 newtype ResourceC m a = ResourceC { runResourceC :: ReaderC (Handler m) m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadUnliftIO m => MonadUnliftIO (ResourceC m) where
   askUnliftIO = ResourceC . ReaderC $ \(Handler h) ->

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -21,7 +21,7 @@ import Control.Effect.Carrier
 import Control.Effect.Error
 import Control.Effect.Reader
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -92,7 +92,7 @@ runResumable :: ResumableC err m a -> m (Either (SomeError err) a)
 runResumable = runError . runResumableC
 
 newtype ResumableC err m a = ResumableC { runResumableC :: ErrorC (SomeError err) m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving newtype (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => Carrier (Resumable err :+: sig) (ResumableC err m) where
   eff (L (Resumable err _)) = ResumableC (throwError (SomeError err))
@@ -114,7 +114,7 @@ runResumableWith :: (forall x . err x -> m x)
 runResumableWith with = runReader (Handler with) . runResumableWithC
 
 newtype ResumableWithC err m a = ResumableWithC { runResumableWithC :: ReaderC (Handler err m) m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving newtype (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans (ResumableWithC err) where
   lift = ResumableWithC . lift

--- a/src/Control/Effect/State/Lazy.hs
+++ b/src/Control/Effect/State/Lazy.hs
@@ -16,11 +16,10 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.State.Internal as State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Prelude hiding (fail)
 
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
@@ -51,8 +50,8 @@ instance (Alternative m, Monad m) => Alternative (StateC s m) where
   StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
   {-# INLINE (<|>) #-}
 
-instance MonadFail m => MonadFail (StateC s m) where
-  fail s = StateC (const (fail s))
+instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
+  fail s = StateC (const (Fail.fail s))
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (StateC s m) where

--- a/src/Control/Effect/State/Strict.hs
+++ b/src/Control/Effect/State/Strict.hs
@@ -16,11 +16,10 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.State.Internal as State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Prelude hiding (fail)
 
 -- | Run a 'State' effect starting from the passed value.
 --
@@ -72,8 +71,8 @@ instance Monad m => Monad (StateC s m) where
     fa `seq` runState s' fa
   {-# INLINE (>>=) #-}
 
-instance MonadFail m => MonadFail (StateC s m) where
-  fail s = StateC (const (fail s))
+instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
+  fail s = StateC (const (Fail.fail s))
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (StateC s m) where

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -20,7 +20,7 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -45,7 +45,7 @@ runTraceByPrinting :: TraceByPrintingC m a -> m a
 runTraceByPrinting = runTraceByPrintingC
 
 newtype TraceByPrintingC m a = TraceByPrintingC { runTraceByPrintingC :: m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving newtype (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans TraceByPrintingC where
   lift = TraceByPrintingC
@@ -64,7 +64,7 @@ runTraceByIgnoring :: TraceByIgnoringC m a -> m a
 runTraceByIgnoring = runTraceByIgnoringC
 
 newtype TraceByIgnoringC m a = TraceByIgnoringC { runTraceByIgnoringC :: m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving newtype (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans TraceByIgnoringC where
   lift = TraceByIgnoringC
@@ -83,7 +83,7 @@ runTraceByReturning :: Functor m => TraceByReturningC m a -> m ([String], a)
 runTraceByReturning = fmap (first reverse) . runState [] . runTraceByReturningC
 
 newtype TraceByReturningC m a = TraceByReturningC { runTraceByReturningC :: StateC [String] m a }
-  deriving newtype (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving newtype (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => Carrier (Trace :+: sig) (TraceByReturningC m) where
   eff (L (Trace m k)) = TraceByReturningC (modify (m :)) *> k

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -20,7 +20,7 @@ import Control.Applicative (Alternative(..))
 import Control.Effect.Carrier
 import Control.Effect.State
 import Control.Monad (MonadPlus(..))
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -93,7 +93,7 @@ execWriter = fmap fst . runWriter
 --
 --   This is based on a post Gabriel Gonzalez made to the Haskell mailing list: https://mail.haskell.org/pipermail/libraries/2013-March/019528.html
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Monoid w, Carrier sig m, Effect sig) => Carrier (Writer w :+: sig) (WriterC w m) where
   eff (L (Tell w     k)) = WriterC $ do


### PR DESCRIPTION
This PR bumps us to support ghc 8.8.1. This is branched off of the 0.5.0.0 tag, so I intend to tag 0.5.0.1 on this branch before merging `master` in &c.—so please do _not_ merge `master` into this branch until we’re good to go!

- [x] Depends on https://github.com/nomeata/inspection-testing/pull/36.
- [x] Depends on https://github.com/nomeata/inspection-testing/pull/37.
- [x] Probably depends on a new release of `inspection-testing` being pushed to hackage.
