### PR TITLE
Inject/Project find effects nested on the left

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@
 
 - Defines a new `Has` constraint synonym, conveniently combining `Carrier` and `Member` constraints and used for all effect constructors. ([#217](https://github.com/fused-effects/fused-effects/pull/217))
 
+- Allows effects to be defined and handled as sums of other effects, while still using the constructors for the component effects. This has been used to redefine `NonDet` as a sum of `Empty` and `Choose`. ([#199](https://github.com/fused-effects/fused-effects/pull/199), [#219](https://github.com/fused-effects/fused-effects/pull/219))
+
 ## Backwards-incompatible changes
 
 - Improves the performance of `runInterpret` using reflection, changing its signature slightly ([#193](https://github.com/fused-effects/fused-effects/pull/193), h/t [@ocharles](https://github.com/ocharles)).
@@ -19,8 +21,6 @@
 - Removes `fmap'` and `handlePure`, both deprecated in 0.5.0.0 ([#205](https://github.com/fused-effects/fused-effects/pull/205)).
 
 - Redefines `NonDetC` as a Church-encoded binary tree instead of a Church-encoded list ([#197](https://github.com/fused-effects/fused-effects/pull/197)).
-
-- Removes the `NonDet` effect, replacing it with the combination of the new `Choose` and `Empty` effects ([#199](https://github.com/fused-effects/fused-effects/pull/199)).
 
 - Removes the `OnceC` carrier for `Cull` effects, replacing it with the composition of `CullC` on some other `Alternative` carrier, e.g. `NonDetC` ([#204](https://github.com/fused-effects/fused-effects/pull/204)).
 

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -53,7 +53,7 @@ instance (Carrier sig m, Effect sig) => Carrier (Cull :+: NonDet :+: sig) (CullC
   eff (L (Cull m k))         = CullC (local (const True) (runCullC m)) >>= k
   eff (R (L (L Empty)))      = empty
   eff (R (L (R (Choose k)))) = k True <|> k False
-  eff (R (R other))          = CullC (eff (R (R (R (handleCoercible other)))))
+  eff (R (R other))          = CullC (eff (R (R (handleCoercible other))))
   {-# INLINE eff #-}
 
 

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -49,11 +49,11 @@ instance MonadTrans CullC where
   lift = CullC . lift . lift
   {-# INLINE lift #-}
 
-instance (Carrier sig m, Effect sig) => Carrier (Cull :+: Empty :+: Choose :+: sig) (CullC m) where
+instance (Carrier sig m, Effect sig) => Carrier (Cull :+: NonDet :+: sig) (CullC m) where
   eff (L (Cull m k))         = CullC (local (const True) (runCullC m)) >>= k
-  eff (R (L Empty))          = empty
-  eff (R (R (L (Choose k)))) = k True <|> k False
-  eff (R (R (R other)))      = CullC (eff (R (R (R (handleCoercible other)))))
+  eff (R (L (L Empty)))      = empty
+  eff (R (L (R (Choose k)))) = k True <|> k False
+  eff (R (R other))          = CullC (eff (R (R (R (handleCoercible other)))))
   {-# INLINE eff #-}
 
 

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -75,12 +75,12 @@ instance MonadTrans CutC where
   lift m = CutC (\ cons nil _ -> m >>= flip cons nil)
   {-# INLINE lift #-}
 
-instance (Carrier sig m, Effect sig) => Carrier (Cut :+: Empty :+: Choose :+: sig) (CutC m) where
+instance (Carrier sig m, Effect sig) => Carrier (Cut :+: NonDet :+: sig) (CutC m) where
   eff (L Cutfail)    = CutC $ \ _    _   fail -> fail
   eff (L (Call m k)) = CutC $ \ cons nil fail -> runCutC m (\ a as -> runCutC (k a) cons as fail) nil nil
-  eff (R (L Empty))          = empty
-  eff (R (R (L (Choose k)))) = k True <|> k False
-  eff (R (R (R other)))      = CutC $ \ cons nil _ -> eff (handle [()] (fmap concat . traverse runCutAll) other) >>= foldr cons nil
+  eff (R (L (L Empty)))      = empty
+  eff (R (L (R (Choose k)))) = k True <|> k False
+  eff (R (R other))          = CutC $ \ cons nil _ -> eff (handle [()] (fmap concat . traverse runCutAll) other) >>= foldr cons nil
   {-# INLINE eff #-}
 
 

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -83,10 +83,10 @@ instance MonadTrans NonDetC where
   lift m = NonDetC (\ _ leaf _ -> m >>= leaf)
   {-# INLINE lift #-}
 
-instance (Carrier sig m, Effect sig) => Carrier (Empty :+: Choose :+: sig) (NonDetC m) where
-  eff (L Empty)          = empty
-  eff (R (L (Choose k))) = k True <|> k False
-  eff (R (R other))      = NonDetC $ \ fork leaf nil -> eff (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil
+instance (Carrier sig m, Effect sig) => Carrier (NonDet :+: sig) (NonDetC m) where
+  eff (L (L Empty))      = empty
+  eff (L (R (Choose k))) = k True <|> k False
+  eff (R other)          = NonDetC $ \ fork leaf nil -> eff (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil
   {-# INLINE eff #-}
 
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE TypeOperators #-}
 module Control.Effect.NonDet
 ( -- * NonDet effects
   module Control.Effect.Choose
 , module Control.Effect.Empty
+, NonDet
 , oneOf
 , foldMapA
   -- * Re-exports
@@ -12,9 +14,12 @@ module Control.Effect.NonDet
 import Control.Applicative (Alternative(..))
 import Control.Effect.Choose hiding ((<|>), many, some)
 import Control.Effect.Empty hiding (empty, guard)
+import Control.Effect.Sum
 import Control.Monad (guard)
 import Data.Coerce
 import Data.Monoid (Alt(..))
+
+type NonDet = Empty :+: Choose
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.
 -- This can be used to emulate the style of nondeterminism associated with

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -26,7 +26,7 @@ type Member sub sup = (Inject sub sup, Project sub sup)
 class Inject (sub :: (* -> *) -> (* -> *)) sup where
   inj :: sub m a -> sup m a
 
-instance Inject sub sub where
+instance Inject t t where
   inj = id
 
 instance {-# OVERLAPPABLE #-} Inject sub (sub :+: sup) where

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -54,6 +54,14 @@ instance Project t t where
   prj = Just
 
 instance {-# OVERLAPPABLE #-}
+         Project t (l1 :+: l2 :+: r)
+      => Project t ((l1 :+: l2) :+: r) where
+  prj = prj . reassoc where
+    reassoc (L (L l)) = L l
+    reassoc (L (R l)) = R (L l)
+    reassoc (R r)     = R (R r)
+
+instance {-# OVERLAPPABLE #-}
          Project l (l :+: r) where
   prj (L f) = Just f
   prj _     = Nothing

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -50,13 +50,13 @@ instance {-# OVERLAPPABLE #-}
 class Project (sub :: (* -> *) -> (* -> *)) sup where
   prj :: sup m a -> Maybe (sub m a)
 
-instance Project sub sub where
+instance Project t t where
   prj = Just
 
-instance {-# OVERLAPPABLE #-} Project sub (sub :+: sup) where
+instance {-# OVERLAPPABLE #-} Project l (l :+: r) where
   prj (L f) = Just f
   prj _     = Nothing
 
-instance {-# OVERLAPPABLE #-} Project sub sup => Project sub (sub' :+: sup) where
+instance {-# OVERLAPPABLE #-} Project l r => Project l (l' :+: r) where
   prj (R g) = prj g
   prj _     = Nothing

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -39,7 +39,7 @@ instance {-# OVERLAPPABLE #-}
 
 instance {-# OVERLAPPABLE #-}
          Inject l (l :+: r) where
-  inj = L . inj
+  inj = L
 
 instance {-# OVERLAPPABLE #-}
          Inject l r

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -53,10 +53,13 @@ class Project (sub :: (* -> *) -> (* -> *)) sup where
 instance Project t t where
   prj = Just
 
-instance {-# OVERLAPPABLE #-} Project l (l :+: r) where
+instance {-# OVERLAPPABLE #-}
+         Project l (l :+: r) where
   prj (L f) = Just f
   prj _     = Nothing
 
-instance {-# OVERLAPPABLE #-} Project l r => Project l (l' :+: r) where
+instance {-# OVERLAPPABLE #-}
+         Project l r
+      => Project l (l' :+: r) where
   prj (R g) = prj g
   prj _     = Nothing


### PR DESCRIPTION
This PR allows effects to occur on the left as well as the right, which will enable us to split `Error` up into both `Throw` and `Catch`, reintroduce `NonDet` as a synonym for `Empty :+: Choose`, etc.

- [x] Reintroduces `NonDet` as a synonym for `Empty :+: Choose`.
- [x] Uses `NonDet` in the `Carrier` instances for `NonDetC`, `CutC`, and `CullC`.
- [x] ~~Splits `Error` into `Throw` & `Catch`.~~ Deferring to a future PR.
- [x] ~~Redefines `Fail` as a synonym for `Throw String`.~~ Deferring to a future PR.
- [x] Fixes #213.