### PR TITLE
Use oneOf in the benchmarks.

### DIFF
--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -39,8 +39,7 @@ isSafeIn (i,j) qs = null (diags (i,j) `intersect` underThreat)
 addOne :: (Member NonDet sig, Carrier sig m, Alternative m) => Int -> Board -> m Board
 addOne n curr = do
   let i = length curr + 1
-  let choose = asum . fmap pure
-  j <- choose [1..n]
+  j <- oneOf [1..n]
   guard ((i, j) `isSafeIn` curr)
   pure (curr ++ [j])
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -20,6 +20,7 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Data.Coerce
 import Data.Maybe (fromJust)
 import Data.Monoid
 import GHC.Generics (Generic1)
@@ -54,7 +55,9 @@ runNonDet (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
 --     pure (a, b, c)
 -- @
 oneOf :: (Foldable t, Alternative m) => t a -> m a
-oneOf = getAlt . foldMap (Alt . pure)
+oneOf = getAlt #. foldMap (Alt #. pure)
+  where (#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
+        (#.) _ = coerce
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype NonDetC m a = NonDetC

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,47 +1,20 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.NonDet
-( -- * NonDet effect
-  NonDet(..)
-  -- * NonDet carrier
-, runNonDet
-, NonDetC(..)
+( -- * NonDet effects
+  module Control.Effect.Choose
+, module Control.Effect.Empty
 , oneOf
+, foldMapA
   -- * Re-exports
 , Alternative(..)
-, Carrier
-, Member
-, run
+, guard
 ) where
 
-import Control.Applicative (Alternative(..), liftA2)
-import Control.Effect.Carrier
-import Control.Monad (MonadPlus(..), join)
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Class
+import Control.Applicative (Alternative(..))
+import Control.Effect.Choose hiding ((<|>), many, some)
+import Control.Effect.Empty hiding (empty, guard)
+import Control.Monad (guard)
 import Data.Coerce
-import Data.Maybe (fromJust)
-import Data.Monoid
-import GHC.Generics (Generic1)
-
-data NonDet m k
-  = Empty
-  | Choose (Bool -> m k)
-  deriving (Functor, Generic1)
-
-instance HFunctor NonDet
-instance Effect   NonDet
-
-
--- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.
---
---   Using @[]@ as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unlike 'Control.Effect.Cull.runNonDetOnce', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
---
---   prop> run (runNonDet (pure a)) === [a]
---   prop> run (runNonDet (pure a)) === Just a
-runNonDet :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
-runNonDet (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
+import Data.Monoid (Alt(..))
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.
 -- This can be used to emulate the style of nondeterminism associated with
@@ -55,101 +28,16 @@ runNonDet (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
 --     pure (a, b, c)
 -- @
 oneOf :: (Foldable t, Alternative m) => t a -> m a
-oneOf = getAlt #. foldMap (Alt #. pure)
-  where (#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
-        (#.) _ = coerce
+oneOf = foldMapA pure
 
--- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
-newtype NonDetC m a = NonDetC
-  { -- | A higher-order function receiving three continuations, respectively implementing '<|>', 'pure', and 'empty'.
-    runNonDetC :: forall b . (m b -> m b -> m b) -> (a -> m b) -> m b -> m b
-  }
-  deriving (Functor)
-
--- $
---   prop> run (runNonDet (pure a *> pure b)) === Just b
---   prop> run (runNonDet (pure a <* pure b)) === Just a
-instance Applicative (NonDetC m) where
-  pure a = NonDetC (\ _ leaf _ -> leaf a)
-  {-# INLINE pure #-}
-  NonDetC f <*> NonDetC a = NonDetC $ \ fork leaf nil ->
-    f fork (\ f' -> a fork (leaf . f') nil) nil
-  {-# INLINE (<*>) #-}
-
--- $
---   prop> run (runNonDet (pure a <|> (pure b <|> pure c))) === Fork (Leaf a) (Fork (Leaf b) (Leaf c))
---   prop> run (runNonDet ((pure a <|> pure b) <|> pure c)) === Fork (Fork (Leaf a) (Leaf b)) (Leaf c)
-instance Alternative (NonDetC m) where
-  empty = NonDetC (\ _ _ nil -> nil)
-  {-# INLINE empty #-}
-  NonDetC l <|> NonDetC r = NonDetC $ \ fork leaf nil -> fork (l fork leaf nil) (r fork leaf nil)
-  {-# INLINE (<|>) #-}
-
-instance Monad (NonDetC m) where
-  NonDetC a >>= f = NonDetC $ \ fork leaf nil ->
-    a fork (\ a' -> runNonDetC (f a') fork leaf nil) nil
-  {-# INLINE (>>=) #-}
-
-instance Fail.MonadFail m => Fail.MonadFail (NonDetC m) where
-  fail s = lift (Fail.fail s)
-  {-# INLINE fail #-}
-
-instance MonadFix m => MonadFix (NonDetC m) where
-  mfix f = NonDetC $ \ fork leaf nil ->
-    mfix (\ a -> runNonDetC (f (fromJust (fold (<|>) Just Nothing a)))
-      (liftA2 Fork)
-      (pure . Leaf)
-      (pure Nil))
-    >>= fold fork leaf nil
-  {-# INLINE mfix #-}
-
-instance MonadIO m => MonadIO (NonDetC m) where
-  liftIO io = lift (liftIO io)
-  {-# INLINE liftIO #-}
-
-instance MonadPlus (NonDetC m)
-
-instance MonadTrans NonDetC where
-  lift m = NonDetC (\ _ leaf _ -> m >>= leaf)
-  {-# INLINE lift #-}
-
-instance (Carrier sig m, Effect sig) => Carrier (NonDet :+: sig) (NonDetC m) where
-  eff (L Empty)      = empty
-  eff (L (Choose k)) = k True <|> k False
-  eff (R other)      = NonDetC $ \ fork leaf nil -> eff (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil
-  {-# INLINE eff #-}
+-- | Map a 'Foldable' collection of values into a nondeterministic computation using the supplied action.
+foldMapA :: (Foldable t, Alternative m) => (a -> m b) -> t a -> m b
+foldMapA f = getAlt #. foldMap (Alt #. f)
 
 
-data BinaryTree a = Nil | Leaf a | Fork (BinaryTree a) (BinaryTree a)
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-instance Applicative BinaryTree where
-  pure = Leaf
-  {-# INLINE pure #-}
-  f <*> a = fold Fork (<$> a) Nil f
-  {-# INLINE (<*>) #-}
-
-instance Alternative BinaryTree where
-  empty = Nil
-  {-# INLINE empty #-}
-  (<|>) = Fork
-  {-# INLINE (<|>) #-}
-
-instance Monad BinaryTree where
-  a >>= f = fold Fork f Nil a
-  {-# INLINE (>>=) #-}
-
-
-fold :: (b -> b -> b) -> (a -> b) -> b -> BinaryTree a -> b
-fold fork leaf nil = go where
-  go Nil        = nil
-  go (Leaf a)   = leaf a
-  go (Fork a b) = fork (go a) (go b)
-{-# INLINE fold #-}
-
-
--- $setup
--- >>> :seti -XFlexibleContexts
--- >>> import Test.QuickCheck
--- >>> import Control.Effect.Pure
--- >>> import Data.Foldable (asum)
+-- | Compose a function operationally equivalent to 'id' on the left.
+--
+--   cf https://github.com/fused-effects/diffused-effects/pull/1#discussion_r323560758
+(#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
+(#.) _ = coerce
+{-# INLINE (#.) #-}


### PR DESCRIPTION
This produces a slight improvement in the benchmark (on the order of µs).