### PR TITLE
Correct the Applicative & MonadFix instances for ErrorC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@
 
 ## Backwards-incompatible changes
 
-- Fixes unlawful behaviour in the `Applicative` instance for `ErrorC`, which had different behaviour between `<*>` and `ap` in the presence of a divergent rhs. ([#228](https://github.com/fused-effects/fused-effects/pull/228))
+- Fixes unlawful behaviour in the `Applicative` instance for `ErrorC`, which had different behaviour between `<*>` and `ap` in the presence of a divergent rhs. In order to accomplish this, `ErrorC` has been defined as a wrapper around `Control.Monad.Trans.Except.ExceptT`. ([#228](https://github.com/fused-effects/fused-effects/pull/228))
 
 - Improves the performance of `runInterpret` using reflection, changing its signature slightly ([#193](https://github.com/fused-effects/fused-effects/pull/193), h/t [@ocharles](https://github.com/ocharles)).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
 
 ## Backwards-incompatible changes
 
+- Fixes unlawful behaviour in the `Applicative` instance for `ErrorC`, which had different behaviour between `<*>` and `ap` in the presence of a divergent rhs. ([#228](https://github.com/fused-effects/fused-effects/pull/228))
+
 - Improves the performance of `runInterpret` using reflection, changing its signature slightly ([#193](https://github.com/fused-effects/fused-effects/pull/193), h/t [@ocharles](https://github.com/ocharles)).
 
 - Removes `Control.Effect.Random` (and the dependencies on `random` & `MonadRandom`) in favour of a new [`fused-effects-random` package](https://github.com/fused-effects/fused-effects-random) ([#200](https://github.com/fused-effects/fused-effects/pull/200)).

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -30,6 +30,7 @@ runError = runExceptT . runErrorC
 newtype ErrorC e m a = ErrorC { runErrorC :: ExceptT e m a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
 
+-- | 'ErrorC' passes 'Alternative' operations along to the underlying monad @m@, rather than combining errors à la 'ExceptT'.
 instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
   empty = ErrorC (ExceptT empty)
   {-# INLINE empty #-}

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -37,6 +37,7 @@ instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
   ErrorC (ExceptT l) <|> ErrorC (ExceptT r) = ErrorC (ExceptT (l <|> r))
   {-# INLINE (<|>) #-}
 
+-- | 'ErrorC' passes 'MonadPlus' operations along to the underlying monad @m@, rather than combining errors à la 'ExceptT'.
 instance (Alternative m, Monad m) => MonadPlus (ErrorC e m)
 
 instance (Carrier sig m, Effect sig) => Carrier (Error e :+: sig) (ErrorC e m) where

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -11,7 +11,7 @@ module Control.Carrier.Error.Either
 , run
 ) where
 
-import Control.Applicative (Alternative(..), liftA2)
+import Control.Applicative (Alternative(..))
 import Control.Carrier
 import Control.Effect.Error
 import Control.Monad (MonadPlus(..), (<=<))
@@ -29,13 +29,13 @@ runError = runErrorC
 newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
   deriving (Functor)
 
-instance Applicative m => Applicative (ErrorC e m) where
+instance Monad m => Applicative (ErrorC e m) where
   pure a = ErrorC (pure (Right a))
   {-# INLINE pure #-}
-  ErrorC f <*> ErrorC a = ErrorC (liftA2 (<*>) f a)
+  ErrorC f <*> ErrorC a = ErrorC $ f >>= either (pure . Left) ((`fmap` a) . fmap)
   {-# INLINE (<*>) #-}
 
-instance Alternative m => Alternative (ErrorC e m) where
+instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
   empty = ErrorC empty
   {-# INLINE empty #-}
   ErrorC l <|> ErrorC r = ErrorC (l <|> r)

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -14,7 +14,7 @@ module Control.Carrier.Error.Either
 import Control.Applicative (Alternative(..))
 import Control.Carrier
 import Control.Effect.Error
-import Control.Monad (MonadPlus(..), (<=<))
+import Control.Monad (MonadPlus(..), (<=<), ap)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -32,7 +32,7 @@ newtype ErrorC e m a = ErrorC { runErrorC :: m (Either e a) }
 instance Monad m => Applicative (ErrorC e m) where
   pure a = ErrorC (pure (Right a))
   {-# INLINE pure #-}
-  ErrorC f <*> ErrorC a = ErrorC $ f >>= either (pure . Left) ((`fmap` a) . fmap)
+  (<*>) = ap
   {-# INLINE (<*>) #-}
 
 instance (Alternative m, Monad m) => Alternative (ErrorC e m) where


### PR DESCRIPTION
It was previously incorrect in that `throwError e <*> a` would diverge when `a` diverged, but `ap (throwError e) a` would not.

- [x] Fixes #230.
- [x] Fixes #231.