### PR TITLE
Generalize NonDet benchmarks

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -12,13 +12,11 @@ import Data.Functor.Identity
 import Data.Monoid (Sum(..))
 import Gauge
 
-import qualified NonDet.NQueens as NQueens
+import qualified NonDet
 
 main :: IO ()
 main = defaultMain
-  [ bgroup "NonDet"
-    [ NQueens.benchmark
-    ]
+  [ NonDet.benchmark
   , bgroup "WriterC"
     [ bgroup "Cod"
       [ bench "100"   $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 100

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -1,0 +1,2 @@
+module NonDet
+() where

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -6,12 +6,12 @@ module NonDet
 import qualified Control.Carrier.NonDet.Church as NonDet.Church
 import           Control.Carrier.Pure
 import           Gauge hiding (benchmark)
-import qualified NonDet.NQueens
+import qualified NonDet.NQueens as NQueens
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "NonDet"
   [ bgroup "N-queens problem"
-    [ NonDet.NQueens.benchmark "NonDet.Church" (run . NonDet.Church.runNonDet)
-    , NonDet.NQueens.benchmark "[]"            (id @[_])
+    [ NQueens.benchmark "NonDet.Church" (run . NonDet.Church.runNonDet)
+    , NQueens.benchmark "[]"            (id @[_])
     ]
   ]

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -1,2 +1,11 @@
 module NonDet
-() where
+( benchmark
+) where
+
+import           Gauge hiding (benchmark)
+import qualified NonDet.NQueens
+
+benchmark :: Gauge.Benchmark
+benchmark = bgroup "NonDet"
+  [ NonDet.NQueens.benchmark
+  ]

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -11,7 +11,7 @@ import qualified NonDet.NQueens
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "NonDet"
   [ bgroup "N-queens problem"
-    [ NonDet.NQueens.benchmark (run . NonDet.Church.runNonDet)
-    , NonDet.NQueens.benchmark (id @[_])
+    [ NonDet.NQueens.benchmark "NonDet.Church" (run . NonDet.Church.runNonDet)
+    , NonDet.NQueens.benchmark "[]"            (id @[_])
     ]
   ]

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -10,6 +10,8 @@ import qualified NonDet.NQueens
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "NonDet"
-  [ NonDet.NQueens.benchmark (run . NonDet.Church.runNonDet)
-  , NonDet.NQueens.benchmark (id @[_])
+  [ bgroup "N-queens problem"
+    [ NonDet.NQueens.benchmark (run . NonDet.Church.runNonDet)
+    , NonDet.NQueens.benchmark (id @[_])
+    ]
   ]

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 module NonDet
 ( benchmark
 ) where
@@ -10,4 +11,5 @@ import qualified NonDet.NQueens
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "NonDet"
   [ NonDet.NQueens.benchmark (run . NonDet.Church.runNonDet)
+  , NonDet.NQueens.benchmark (id @[_])
   ]

--- a/benchmark/NonDet.hs
+++ b/benchmark/NonDet.hs
@@ -2,10 +2,12 @@ module NonDet
 ( benchmark
 ) where
 
+import qualified Control.Carrier.NonDet.Church as NonDet.Church
+import           Control.Carrier.Pure
 import           Gauge hiding (benchmark)
 import qualified NonDet.NQueens
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "NonDet"
-  [ NonDet.NQueens.benchmark
+  [ NonDet.NQueens.benchmark (run . NonDet.Church.runNonDet)
   ]

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -45,8 +45,8 @@ addOne n curr = do
 queens :: (Alternative m, Monad m) => Int -> m Board
 queens n = foldl' (>>=) (pure empty) (replicate n (addOne n))
 
-benchmark :: (Alternative m, Monad m) => (m Board -> [Board]) -> Gauge.Benchmark
-benchmark runQueens = bgroup "N-queens problem"
+benchmark :: (Alternative m, Monad m) => String -> (m Board -> [Board]) -> Gauge.Benchmark
+benchmark title runQueens = bgroup title
   [ bench "4"  $ whnf (runQueens . queens) 4
   , bench "8"  $ whnf (runQueens . queens) 8
   , bench "16" $ whnf (runQueens . queens) 16

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -5,11 +5,10 @@
 -- Based largely on the implementation by Sreekar Shastry,
 -- available at https://github.com/sshastry/queenslogic
 
-module NonDet.NQueens (runQueens, benchmark) where
+module NonDet.NQueens (benchmark) where
 
 import Control.Applicative
-import Control.Carrier.NonDet.Church
-import Control.Carrier.Pure
+import Control.Monad (guard)
 import Data.Foldable
 import Data.List
 import Gauge hiding (benchmark)
@@ -46,11 +45,8 @@ addOne n curr = do
 queens :: (Alternative m, Monad m) => Int -> m Board
 queens n = foldl' (>>=) (pure empty) (replicate n (addOne n))
 
-runQueens :: NonDetC PureC Board -> [Board]
-runQueens = run . runNonDet
-
-benchmark :: Gauge.Benchmark
-benchmark = bgroup "N-queens problem"
+benchmark :: (Alternative m, Monad m) => (m Board -> [Board]) -> Gauge.Benchmark
+benchmark runQueens = bgroup "N-queens problem"
   [ bench "4"  $ whnf (runQueens . queens) 4
   , bench "8"  $ whnf (runQueens . queens) 8
   , bench "16" $ whnf (runQueens . queens) 16

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -51,3 +51,4 @@ benchmark runQueens = bgroup "N-queens problem"
   , bench "8"  $ whnf (runQueens . queens) 8
   , bench "16" $ whnf (runQueens . queens) 16
   ]
+{-# INLINE benchmark #-}

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -9,6 +9,7 @@ module NonDet.NQueens (runQueens, benchmark) where
 
 import Control.Applicative
 import Control.Carrier.NonDet.Church
+import Control.Carrier.Pure
 import Data.Foldable
 import Data.List
 import Gauge hiding (benchmark)
@@ -45,12 +46,12 @@ addOne n curr = do
 queens :: (Alternative m, Monad m) => Int -> m Board
 queens n = foldl' (>>=) (pure empty) (replicate n (addOne n))
 
-runQueens :: Int -> [Board]
-runQueens = run . runNonDet . queens
+runQueens :: NonDetC PureC Board -> [Board]
+runQueens = run . runNonDet
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "N-queens problem"
-  [ bench "4"  $ whnf runQueens 4
-  , bench "8"  $ whnf runQueens 8
-  , bench "16" $ whnf runQueens 16
+  [ bench "4"  $ whnf (runQueens . queens) 4
+  , bench "8"  $ whnf (runQueens . queens) 8
+  , bench "16" $ whnf (runQueens . queens) 16
   ]

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -141,6 +141,7 @@ benchmark benchmark
   hs-source-dirs:     benchmark
   main-is:            Bench.hs
   other-modules:
+    NonDet
     NonDet.NQueens
   build-depends:
       base

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -140,7 +140,8 @@ benchmark benchmark
   type:               exitcode-stdio-1.0
   hs-source-dirs:     benchmark
   main-is:            Bench.hs
-  other-modules:      NonDet.NQueens
+  other-modules:
+    NonDet.NQueens
   build-depends:
       base
     , fused-effects


### PR DESCRIPTION
This PR generalizes the `NonDet` benchmarks over the carrier, allowing us to compare performance of multiple implementations.