### PR TITLE
Add documentation for use of NonDet effect (#174).

### DIFF
--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -20,6 +20,11 @@ import Control.Monad (MonadPlus(..), guard)
 import Data.Coerce
 import Data.Monoid (Alt(..))
 
+-- | The nondeterminism effect is the composition of 'Empty' and 'Choose' effects.
+-- Nondeterministic operations can be performed with the 'Control.Effect.Choose.<|>' operator
+-- for nondeterministic choice and 'Control.Effect.Empty.empty' for failure. If the
+-- carrier type for your monad has an 'Alternative' instance, you can program directly
+-- against the 'Alternative' typeclass and hide the operators provided by @fused-effects@.
 type NonDet = Empty :+: Choose
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,19 +1,21 @@
 {-# LANGUAGE TypeOperators #-}
 module Control.Effect.NonDet
 ( -- * NonDet effects
-  module Control.Effect.Choose
-, module Control.Effect.Empty
-, NonDet
+  NonDet
 , oneOf
 , foldMapA
   -- * Re-exports
 , Alternative(..)
-, MonadPlus(..)
 , guard
+, optional
+, MonadPlus(..)
+  -- * Constituent effects
+, Control.Effect.Choose.Choose (..)
+, Control.Effect.Empty.Empty (..)
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Effect.Choose hiding ((<|>), many, some)
+import Control.Applicative (Alternative(..), optional)
+import Control.Effect.Choose hiding ((<|>), many, some, optional)
 import Control.Effect.Empty hiding (empty, guard)
 import Control.Effect.Sum
 import Control.Monad (MonadPlus(..), guard)
@@ -21,15 +23,18 @@ import Data.Coerce
 import Data.Monoid (Alt(..))
 
 -- | The nondeterminism effect is the composition of 'Empty' and 'Choose' effects.
--- Nondeterministic operations can be performed with the 'Control.Effect.Choose.<|>' operator
--- for nondeterministic choice and 'Control.Effect.Empty.empty' for failure. If the
--- carrier type for your monad has an 'Alternative' instance, you can program directly
--- against the 'Alternative' typeclass and hide the operators provided by @fused-effects@.
+-- Nondeterministic operations are encapsulated by the 'Control.Applicative.Alternative'
+-- class, where 'Control.Applicative.empty' represents failure and 'Control.Applicative.<|>'
+-- represents choice. This module reexports the 'Alternative' interface. If you can't or
+-- don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and
+-- 'Control.Effect.Choose.<|>' effects (from 'Control.Effect.Empty' and 'Control.Effect.Choose')
+-- directly.
 type NonDet = Empty :+: Choose
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.
 -- This can be used to emulate the style of nondeterminism associated with
 -- programming in the list monad:
+--
 -- @
 --   pythagoreanTriples = do
 --     a <- oneOf [1..10]
@@ -38,6 +43,7 @@ type NonDet = Empty :+: Choose
 --     guard (a^2 + b^2 == c^2)
 --     pure (a, b, c)
 -- @
+--
 oneOf :: (Foldable t, Alternative m) => t a -> m a
 oneOf = foldMapA pure
 


### PR DESCRIPTION
This patch adds a Haddock comment that explains how the `NonDet`
effect works as a composition of `Empty` and `Choose`, and details
the ways it can be used (either with the operators provided by the
effects themselves or with the `Alternative` instance for the carrier
in question.)

Fixes #174.