### PR TITLE
Split Error into Throw & Catch effects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@
 
 - Defines a new `Has` constraint synonym, conveniently combining `Carrier` and `Member` constraints and used for all effect constructors. ([#217](https://github.com/fused-effects/fused-effects/pull/217))
 
-- Allows effects to be defined and handled as sums of other effects, while still using the constructors for the component effects. This has been used to redefine `NonDet` as a sum of `Empty` and `Choose`. ([#199](https://github.com/fused-effects/fused-effects/pull/199), [#219](https://github.com/fused-effects/fused-effects/pull/219))
+- Allows effects to be defined and handled as sums of other effects, while still using the constructors for the component effects. This has been used to redefine `NonDet` as a sum of `Empty` and `Choose`, and `Error` as a sum of `Throw` and `Catch`. ([#199](https://github.com/fused-effects/fused-effects/pull/199), [#219](https://github.com/fused-effects/fused-effects/pull/219), [#247](https://github.com/fused-effects/fused-effects/pull/247))
 
 - Adds a `NonDetC` carrier for `NonDet` in `Control.Effect.NonDet.Maybe`. ([#227](https://github.com/fused-effects/fused-effects/pull/227))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 - Adds a `Choose` effect, modelling nondeterminism without failure ([#198](https://github.com/fused-effects/fused-effects/pull/198)).
 
+- Adds a `Throw` effect, modelling failure with a value. ([#247](https://github.com/fused-effects/fused-effects/pull/247))
+
 - Adds a `oneOf` function to `Control.Effect.NonDet` to provide an idiom for the common case of nondeterministically selecting from a container. ([#201](https://github.com/fused-effects/fused-effects/pull/201))
 
 - Adds a `foldMapA` function to `Control.Effect.NonDet` mapping containers into nondeterministic computations using a supplied function. ([#204](https://github.com/fused-effects/fused-effects/pull/204))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Adds a `Throw` effect, modelling failure with a value. ([#247](https://github.com/fused-effects/fused-effects/pull/247))
 
+- Adds a `Catch` effect which can be used with `Throw` (or other kinds of failure) to model recoverable failure. ([#247](https://github.com/fused-effects/fused-effects/pull/247))
+
 - Adds a `oneOf` function to `Control.Effect.NonDet` to provide an idiom for the common case of nondeterministically selecting from a container. ([#201](https://github.com/fused-effects/fused-effects/pull/201))
 
 - Adds a `foldMapA` function to `Control.Effect.NonDet` mapping containers into nondeterministic computations using a supplied function. ([#204](https://github.com/fused-effects/fused-effects/pull/204))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -48,6 +48,8 @@
 
 - Simplifies `ResourceC` by moving the `MonadUnliftIO` constraint on its `Carrier` instance instead of on the `runResource` handler, obviating the need for it to wrap a `ReaderC` carrier. This should not impact usage except in code manually constructing/eliminating `ResourceC` values. ([#254](https://github.com/fused-effects/fused-effects/pull/254))
 
+- Redefines `Fail` as a synonym for `Throw String`. ([#247](https://github.com/fused-effects/fused-effects/pull/247))
+
 # v0.5.0.1
 
 - Adds support for ghc 8.8.1.

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -65,6 +65,7 @@ library
     Control.Carrier.Resumable.Resume
     Control.Carrier.State.Lazy
     Control.Carrier.State.Strict
+    Control.Carrier.Throw.Either
     Control.Carrier.Trace.Ignoring
     Control.Carrier.Trace.Printing
     Control.Carrier.Trace.Returning

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -66,6 +66,7 @@ library
     Control.Carrier.State.Lazy
     Control.Carrier.State.Strict
     Control.Carrier.Throw.Either
+    Control.Carrier.Throw.Error
     Control.Carrier.Trace.Ignoring
     Control.Carrier.Trace.Printing
     Control.Carrier.Trace.Returning

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -66,7 +66,6 @@ library
     Control.Carrier.State.Lazy
     Control.Carrier.State.Strict
     Control.Carrier.Throw.Either
-    Control.Carrier.Throw.Error
     Control.Carrier.Trace.Ignoring
     Control.Carrier.Trace.Printing
     Control.Carrier.Trace.Returning

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -44,6 +44,7 @@ library
   import:              common
   hs-source-dirs:      src
   exposed-modules:
+    -- Carriers
     Control.Carrier
     Control.Carrier.Choose.Church
     Control.Carrier.Class
@@ -68,6 +69,7 @@ library
     Control.Carrier.Trace.Printing
     Control.Carrier.Trace.Returning
     Control.Carrier.Writer.Strict
+    -- Effects
     Control.Effect.Catch
     Control.Effect.Choose
     Control.Effect.Class

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -15,9 +15,11 @@ import Control.Effect.Class
 import Control.Effect.Sum
 import Data.Kind (Constraint)
 
-type family Has sub sup m :: Constraint where
-  Has (l :+: r) u m = (Has l u m, Has r u m)
-  Has t         u m = (Member t u, Carrier u m)
+type Has eff sig m = (Has' eff sig, Carrier sig m)
+
+type family Has' sub sup :: Constraint where
+  Has' (l :+: r) u = (Has' l u, Has' r u)
+  Has' t         u = Member t u
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -15,6 +15,7 @@ import Control.Effect.Class
 import Control.Effect.Sum
 import Data.Kind (Constraint)
 
+-- | The @m@ is a carrier for @sig@ containing @eff@.
 type Has eff sig m = (Has' eff sig, Carrier sig m)
 
 type family Has' sub sup :: Constraint where

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -17,12 +17,12 @@ import Control.Effect.Sum
 import Data.Kind (Constraint)
 
 -- | The @m@ is a carrier for @sig@ containing @eff@.
-type Has eff sig m = (Has' eff sig, Carrier sig m)
+type Has eff sig m = (Members eff sig, Carrier sig m)
 
 -- | Decompose sums on the left into multiple 'Member' constraints.
-type family Has' sub sup :: Constraint where
-  Has' (l :+: r) u = (Has' l u, Has' r u)
-  Has' t         u = Member t u
+type family Members sub sup :: Constraint where
+  Members (l :+: r) u = (Members l u, Members r u)
+  Members t         u = Member t u
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -16,6 +16,12 @@ import Control.Effect.Class
 import Control.Effect.Sum
 
 -- | @m@ is a carrier for @sig@ containing @eff@.
+--
+-- Note that if @eff@ is a sum, it will be decomposed into multiple 'Member' constraints. While this technically allows one to combine multiple unrelated effects into a single 'Has' constraint, doing so has two significant drawbacks:
+--
+-- 1. Due to [a problem with recursive type families](https://gitlab.haskell.org/ghc/ghc/issues/8095), this can lead to significantly slower compiles.
+--
+-- 2. It defeats @ghc@’s warnings for redundant constraints, and thus can lead to a proliferation of redundant constraints as code is changed.
 type Has eff sig m = (Members eff sig, Carrier sig m)
 
 

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -19,6 +19,7 @@ import Data.Kind (Constraint)
 -- | The @m@ is a carrier for @sig@ containing @eff@.
 type Has eff sig m = (Has' eff sig, Carrier sig m)
 
+-- | Decompose sums on the left into multiple 'Member' constraints.
 type family Has' sub sup :: Constraint where
   Has' (l :+: r) u = (Has' l u, Has' r u)
   Has' t         u = Member t u

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -15,11 +15,9 @@ import Control.Effect.Class
 import Control.Effect.Sum
 import Data.Kind (Constraint)
 
-type Has eff sig m = (Has' eff sig, Carrier sig m)
-
-type family Has' sub sup :: Constraint where
-  Has' (l :+: r) u = (Has' l u, Has' r u)
-  Has' t         u = Member t u
+type family Has sub sup m :: Constraint where
+  Has (l :+: r) u m = (Has l u m, Has r u m)
+  Has t         u m = (Member t u, Carrier u m)
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds, TypeFamilies, TypeOperators #-}
 module Control.Carrier
 ( -- * Re-exports
   module Control.Carrier.Class
@@ -13,10 +13,16 @@ import {-# SOURCE #-} Control.Carrier.Class
 import Control.Carrier.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
+import Data.Kind (Constraint)
 
-type Has eff sig m = (Member eff sig, Carrier sig m)
+type Has eff sig m = (Has' eff sig, Carrier sig m)
+
+type family Has' sub sup :: Constraint where
+  Has' (l :+: r) u = (Has' l u, Has' r u)
+  Has' t         u = Member t u
+
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
-send :: Has eff sig m => eff m a -> m a
+send :: (Member eff sig, Carrier sig m) => eff m a -> m a
 send = eff . inj
 {-# INLINE send #-}

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE ConstraintKinds #-}
 module Control.Carrier
 ( -- * Effect requests
   Has
@@ -14,15 +14,9 @@ import {-# SOURCE #-} Control.Carrier.Class
 import Control.Carrier.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
-import Data.Kind (Constraint)
 
 -- | The @m@ is a carrier for @sig@ containing @eff@.
 type Has eff sig m = (Members eff sig, Carrier sig m)
-
--- | Decompose sums on the left into multiple 'Member' constraints.
-type family Members sub sup :: Constraint where
-  Members (l :+: r) u = (Members l u, Members r u)
-  Members t         u = Member t u
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -15,7 +15,7 @@ import Control.Carrier.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
 
--- | The @m@ is a carrier for @sig@ containing @eff@.
+-- | @m@ is a carrier for @sig@ containing @eff@.
 type Has eff sig m = (Members eff sig, Carrier sig m)
 
 

--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE ConstraintKinds, TypeFamilies, TypeOperators #-}
 module Control.Carrier
-( -- * Re-exports
-  module Control.Carrier.Class
+( -- * Effect requests
+  Has
+, send
+  -- * Re-exports
+, module Control.Carrier.Class
 , module Control.Carrier.Pure
 , module Control.Effect.Class
 , (:+:)(..)
-, Has
-, send
 ) where
 
 import {-# SOURCE #-} Control.Carrier.Class

--- a/src/Control/Carrier.hs-boot
+++ b/src/Control/Carrier.hs-boot
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds, TypeFamilies, TypeOperators #-}
 module Control.Carrier
 ( -- * Re-exports
   module Control.Carrier.Class
@@ -13,7 +13,13 @@ import {-# SOURCE #-} Control.Carrier.Class
 import Control.Carrier.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
+import Data.Kind (Constraint)
 
-type Has eff sig m = (Member eff sig, Carrier sig m)
+type Has eff sig m = (Has' eff sig, Carrier sig m)
 
-send :: Has eff sig m => eff m a -> m a
+type family Has' sub sup :: Constraint where
+  Has' (l :+: r) u = (Has' l u, Has' r u)
+  Has' t         u = Member t u
+
+
+send :: (Member eff sig, Carrier sig m) => eff m a -> m a

--- a/src/Control/Carrier.hs-boot
+++ b/src/Control/Carrier.hs-boot
@@ -1,12 +1,13 @@
-{-# LANGUAGE ConstraintKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE ConstraintKinds #-}
 module Control.Carrier
-( -- * Re-exports
-  module Control.Carrier.Class
+( -- * Effect requests
+  Has
+, send
+  -- * Re-exports
+, module Control.Carrier.Class
 , module Control.Carrier.Pure
 , module Control.Effect.Class
 , (:+:)(..)
-, Has
-, send
 ) where
 
 import {-# SOURCE #-} Control.Carrier.Class

--- a/src/Control/Carrier.hs-boot
+++ b/src/Control/Carrier.hs-boot
@@ -15,11 +15,11 @@ import Control.Effect.Class
 import Control.Effect.Sum
 import Data.Kind (Constraint)
 
-type Has eff sig m = (Has' eff sig, Carrier sig m)
+type Has eff sig m = (Members eff sig, Carrier sig m)
 
-type family Has' sub sup :: Constraint where
-  Has' (l :+: r) u = (Has' l u, Has' r u)
-  Has' t         u = Member t u
+type family Members sub sup :: Constraint where
+  Members (l :+: r) u = (Members l u, Members r u)
+  Members t         u = Member t u
 
 
 send :: (Member eff sig, Carrier sig m) => eff m a -> m a

--- a/src/Control/Carrier.hs-boot
+++ b/src/Control/Carrier.hs-boot
@@ -13,13 +13,7 @@ import {-# SOURCE #-} Control.Carrier.Class
 import Control.Carrier.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
-import Data.Kind (Constraint)
 
 type Has eff sig m = (Members eff sig, Carrier sig m)
-
-type family Members sub sup :: Constraint where
-  Members (l :+: r) u = (Members l u, Members r u)
-  Members t         u = Member t u
-
 
 send :: (Member eff sig, Carrier sig m) => eff m a -> m a

--- a/src/Control/Carrier.hs-boot
+++ b/src/Control/Carrier.hs-boot
@@ -15,11 +15,9 @@ import Control.Effect.Class
 import Control.Effect.Sum
 import Data.Kind (Constraint)
 
-type Has eff sig m = (Has' eff sig, Carrier sig m)
-
-type family Has' sub sup :: Constraint where
-  Has' (l :+: r) u = (Has' l u, Has' r u)
-  Has' t         u = Member t u
+type family Has sub sup m :: Constraint where
+  Has (l :+: r) u m = (Has l u m, Has r u m)
+  Has t         u m = (Member t u, Carrier u m)
 
 
 send :: (Member eff sig, Carrier sig m) => eff m a -> m a

--- a/src/Control/Carrier.hs-boot
+++ b/src/Control/Carrier.hs-boot
@@ -15,9 +15,11 @@ import Control.Effect.Class
 import Control.Effect.Sum
 import Data.Kind (Constraint)
 
-type family Has sub sup m :: Constraint where
-  Has (l :+: r) u m = (Has l u m, Has r u m)
-  Has t         u m = (Member t u, Carrier u m)
+type Has eff sig m = (Has' eff sig, Carrier sig m)
+
+type family Has' sub sup :: Constraint where
+  Has' (l :+: r) u = (Has' l u, Has' r u)
+  Has' t         u = Member t u
 
 
 send :: (Member eff sig, Carrier sig m) => eff m a -> m a

--- a/src/Control/Carrier/Class.hs
+++ b/src/Control/Carrier/Class.hs
@@ -3,13 +3,15 @@ module Control.Carrier.Class
 ( Carrier(..)
 ) where
 
+import Control.Effect.Catch (Catch(..))
 import Control.Effect.Choose (Choose(..))
 import Control.Effect.Class
 import Control.Effect.Empty (Empty(..))
-import Control.Effect.Error (Error(..))
+import Control.Effect.Error (Error)
 import Control.Effect.NonDet (NonDet)
 import Control.Effect.Reader (Reader(..))
 import Control.Effect.Sum ((:+:)(..))
+import Control.Effect.Throw (Throw(..))
 import Control.Effect.Writer (Writer(..))
 import Control.Monad ((<=<))
 import Data.List.NonEmpty (NonEmpty)
@@ -28,8 +30,8 @@ instance Carrier Empty Maybe where
   eff Empty = Nothing
 
 instance Carrier (Error e) (Either e) where
-  eff (Throw e)     = Left e
-  eff (Catch m h k) = either (k <=< h) k m
+  eff (L (Throw e))     = Left e
+  eff (R (Catch m h k)) = either (k <=< h) k m
 
 instance Carrier (Reader r) ((->) r) where
   eff (Ask       k) r = k r r

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -40,9 +40,9 @@ instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
 instance (Alternative m, Monad m) => MonadPlus (ErrorC e m)
 
 instance (Carrier sig m, Effect sig) => Carrier (Error e :+: sig) (ErrorC e m) where
-  eff (L (Throw e))     = ErrorC (ExceptT (pure (Left e)))
-  eff (L (Catch m h k)) = ErrorC (ExceptT (runError m >>= either (either (pure . Left) (runError . k) <=< runError . h) (runError . k)))
-  eff (R other)         = ErrorC (ExceptT (eff (handle (Right ()) (either (pure . Left) runError) other)))
+  eff (L (L (Throw e)))     = ErrorC (ExceptT (pure (Left e)))
+  eff (L (R (Catch m h k))) = ErrorC (ExceptT (runError m >>= either (either (pure . Left) (runError . k) <=< runError . h) (runError . k)))
+  eff (R other)             = ErrorC (ExceptT (eff (handle (Right ()) (either (pure . Left) runError) other)))
   {-# INLINE eff #-}
 
 

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -30,12 +30,12 @@ newtype FailC m a = FailC { runFailC :: ErrorC String m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Carrier sig m, Effect sig) => Fail.MonadFail (FailC m) where
-  fail = send . Fail
+  fail = send . Throw
   {-# INLINE fail #-}
 
 instance (Carrier sig m, Effect sig) => Carrier (Fail :+: sig) (FailC m) where
-  eff (L (Fail s)) = FailC (throwError s)
-  eff (R other)    = FailC (eff (R (handleCoercible other)))
+  eff (L (Throw s)) = FailC (throwError s)
+  eff (R other)     = FailC (eff (R (handleCoercible other)))
   {-# INLINE eff #-}
 
 

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -20,6 +20,7 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
+-- | Run a 'Throw' effect, returning failures in 'Left' and successful computations’ results in 'Right'.
 runThrow :: ThrowC e m a -> m (Either e a)
 runThrow = runError . runThrowC
 

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 module Control.Carrier.Throw.Either
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -13,3 +14,4 @@ import Control.Carrier
 import Control.Effect.Throw
 
 newtype ThrowC e m a = ThrowC { runThrow :: m (Either e a) }
+  deriving (Functor)

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Carrier.Throw.Either
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -25,3 +25,7 @@ runThrow = runError . runThrowC
 
 newtype ThrowC e m a = ThrowC { runThrowC :: ErrorC e m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+
+instance (Carrier sig m, Effect sig) => Carrier (Throw e :+: sig) (ThrowC e m) where
+  eff (L (Throw e)) = ThrowC (throwError e)
+  eff (R other)     = ThrowC (eff (R (handleCoercible other)))

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,0 +1,2 @@
+module Control.Carrier.Throw.Either
+() where

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,2 +1,6 @@
 module Control.Carrier.Throw.Either
-() where
+( -- * Throw effect
+  module Control.Effect.Throw
+) where
+
+import Control.Effect.Throw

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -4,14 +4,18 @@ module Control.Carrier.Throw.Either
   module Control.Effect.Throw
   -- * Throw carrier
 , runThrow
-, ThrowC(ThrowC)
+, ThrowC(..)
   -- * Re-exports
 , Carrier
 , run
 ) where
 
 import Control.Carrier
+import Control.Carrier.Error.Either
 import Control.Effect.Throw
 
-newtype ThrowC e m a = ThrowC { runThrow :: m (Either e a) }
+runThrow :: ThrowC e m a -> m (Either e a)
+runThrow = runError . runThrowC
+
+newtype ThrowC e m a = ThrowC { runThrowC :: ErrorC e m a }
   deriving (Functor)

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,6 +1,10 @@
 module Control.Carrier.Throw.Either
 ( -- * Throw effect
   module Control.Effect.Throw
+  -- * Re-exports
+, Carrier
+, run
 ) where
 
+import Control.Carrier
 import Control.Effect.Throw

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFunctor, GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Throw.Either
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -10,12 +10,18 @@ module Control.Carrier.Throw.Either
 , run
 ) where
 
+import Control.Applicative (Alternative)
 import Control.Carrier
 import Control.Carrier.Error.Either
 import Control.Effect.Throw
+import Control.Monad (MonadPlus)
+import qualified Control.Monad.Fail as Fail
+import Control.Monad.Fix
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
 
 runThrow :: ThrowC e m a -> m (Either e a)
 runThrow = runError . runThrowC
 
 newtype ThrowC e m a = ThrowC { runThrowC :: ErrorC e m a }
-  deriving (Functor)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,6 +1,9 @@
 module Control.Carrier.Throw.Either
 ( -- * Throw effect
   module Control.Effect.Throw
+  -- * Throw carrier
+, runThrow
+, ThrowC(ThrowC)
   -- * Re-exports
 , Carrier
 , run
@@ -8,3 +11,5 @@ module Control.Carrier.Throw.Either
 
 import Control.Carrier
 import Control.Effect.Throw
+
+newtype ThrowC e m a = ThrowC { runThrow :: m (Either e a) }

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -9,7 +10,13 @@ module Control.Carrier.Throw.Error
 , run
 ) where
 
+import Control.Applicative (Alternative)
 import Control.Carrier
 import Control.Effect.Throw
+import Control.Monad (MonadPlus)
+import qualified Control.Monad.Fail as Fail
+import Control.Monad.Fix
+import Control.Monad.IO.Class
 
 newtype ThrowC e m a = ThrowC { runThrow :: m a }
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,2 +1,6 @@
 module Control.Carrier.Throw.Error
-() where
+( -- * Throw effect
+  module Control.Effect.Throw
+) where
+
+import Control.Effect.Throw

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,10 +1,6 @@
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
-  -- * Re-exports
-, Carrier
-, run
 ) where
 
-import Control.Carrier
 import Control.Effect.Throw

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -10,13 +9,7 @@ module Control.Carrier.Throw.Error
 , run
 ) where
 
-import Control.Applicative (Alternative)
 import Control.Carrier
 import Control.Effect.Throw
-import Control.Monad (MonadPlus)
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 
 newtype ThrowC e m a = ThrowC { runThrow :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,9 +1,6 @@
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
-  -- * Throw carrier
-, runThrow
-, ThrowC(ThrowC)
   -- * Re-exports
 , Carrier
 , run
@@ -11,5 +8,3 @@ module Control.Carrier.Throw.Error
 
 import Control.Carrier
 import Control.Effect.Throw
-
-newtype ThrowC e m a = ThrowC { runThrow :: m a }

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -12,7 +12,6 @@ module Control.Carrier.Throw.Error
 
 import Control.Applicative (Alternative)
 import Control.Carrier
-import Control.Effect.Error
 import Control.Effect.Throw
 import Control.Monad (MonadPlus)
 import qualified Control.Monad.Fail as Fail
@@ -25,7 +24,3 @@ newtype ThrowC e m a = ThrowC { runThrow :: m a }
 
 instance MonadTrans (ThrowC e) where
   lift = ThrowC
-
-instance (Has (Error e) sig m) => Carrier (Throw e :+: sig) (ThrowC e m) where
-  eff (L (Throw e)) = ThrowC (throwError e)
-  eff (R other)     = ThrowC (eff (handleCoercible other))

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,2 +1,0 @@
-module Control.Carrier.Throw.Error
-() where

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -17,10 +17,6 @@ import Control.Monad (MonadPlus)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Class
 
 newtype ThrowC e m a = ThrowC { runThrow :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
-
-instance MonadTrans (ThrowC e) where
-  lift = ThrowC

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,6 +1,9 @@
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
+  -- * Throw carrier
+, runThrow
+, ThrowC(ThrowC)
   -- * Re-exports
 , Carrier
 , run
@@ -8,3 +11,5 @@ module Control.Carrier.Throw.Error
 
 import Control.Carrier
 import Control.Effect.Throw
+
+newtype ThrowC e m a = ThrowC { runThrow :: m a }

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
@@ -12,6 +12,7 @@ module Control.Carrier.Throw.Error
 
 import Control.Applicative (Alternative)
 import Control.Carrier
+import Control.Effect.Error
 import Control.Effect.Throw
 import Control.Monad (MonadPlus)
 import qualified Control.Monad.Fail as Fail
@@ -24,3 +25,7 @@ newtype ThrowC e m a = ThrowC { runThrow :: m a }
 
 instance MonadTrans (ThrowC e) where
   lift = ThrowC
+
+instance (Has (Error e) sig m) => Carrier (Throw e :+: sig) (ThrowC e m) where
+  eff (L (Throw e)) = ThrowC (throwError e)
+  eff (R other)     = ThrowC (eff (handleCoercible other))

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -17,6 +17,10 @@ import Control.Monad (MonadPlus)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
 
 newtype ThrowC e m a = ThrowC { runThrow :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+
+instance MonadTrans (ThrowC e) where
+  lift = ThrowC

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,6 +1,10 @@
 module Control.Carrier.Throw.Error
 ( -- * Throw effect
   module Control.Effect.Throw
+  -- * Re-exports
+, Carrier
+, run
 ) where
 
+import Control.Carrier
 import Control.Effect.Throw

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,0 +1,2 @@
+module Control.Carrier.Throw.Error
+() where

--- a/src/Control/Carrier/Throw/Error.hs
+++ b/src/Control/Carrier/Throw/Error.hs
@@ -1,6 +1,2 @@
 module Control.Carrier.Throw.Error
-( -- * Throw effect
-  module Control.Effect.Throw
-) where
-
-import Control.Effect.Throw
+() where

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -5,6 +5,8 @@ module Control.Effect.Catch
 ( -- * Catch effect
   Catch(..)
 , catchError
+  -- * Re-exports
+, Has
 ) where
 
 import {-# SOURCE #-} Control.Carrier

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -2,7 +2,8 @@
 
 -- | An effect modelling catchable failure when used with 'Control.Effect.Throw.Throw'.
 module Control.Effect.Catch
-( Catch(..)
+( -- * Catch effect
+  Catch(..)
 , catchError
 ) where
 

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -24,7 +24,7 @@ instance Effect (Catch e) where
 -- Errors thrown by the handler will escape up to the nearest enclosing 'catchError' (if any).
 -- Note that this effect does /not/ handle errors thrown from impure contexts such as IO,
 -- nor will it handle exceptions thrown from pure code. If you need to handle IO-based errors,
--- consider if 'Control.Effect.Resource' fits your use case; if not, use 'liftIO' with
--- 'Control.Exception.try' or use 'Control.Exception.Catch' from outside the effect invocation.
+-- consider if 'Control.Effect.Resource' fits your use case; if not, use 'Control.Monad.IO.Class.liftIO' with
+-- 'Control.Exception.try' or use 'Control.Exception.catch' from outside the effect invocation.
 catchError :: Has (Catch e) sig m => m a -> (e -> m a) -> m a
 catchError m h = send (Catch m h pure)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -26,5 +26,7 @@ instance Effect (Catch e) where
 -- nor will it handle exceptions thrown from pure code. If you need to handle IO-based errors,
 -- consider if 'Control.Effect.Resource' fits your use case; if not, use 'Control.Monad.IO.Class.liftIO' with
 -- 'Control.Exception.try' or use 'Control.Exception.catch' from outside the effect invocation.
+--
+-- @since 0.1.0.0
 catchError :: Has (Catch e) sig m => m a -> (e -> m a) -> m a
 catchError m h = send (Catch m h pure)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -6,6 +6,7 @@ module Control.Effect.Catch
 
 import Control.Carrier
 
+-- | 'Catch' effects can be used alongside 'Control.Effect.Throw.Throw' to provide recoverable exceptions.
 data Catch e m k
   = forall b . Catch (m b) (e -> m b) (b -> m k)
 

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Catch
 ( Catch(..)
+, catchError
 ) where
 
 import Control.Carrier
@@ -15,3 +16,14 @@ instance HFunctor (Catch e) where
 
 instance Effect (Catch e) where
   handle state handler (Catch m h k) = Catch (handler (m <$ state)) (handler . (<$ state) . h) (handler . fmap k)
+
+
+-- | Run a computation which can throw errors with a handler to run on error.
+--
+-- Errors thrown by the handler will escape up to the nearest enclosing 'catchError' (if any).
+-- Note that this effect does /not/ handle errors thrown from impure contexts such as IO,
+-- nor will it handle exceptions thrown from pure code. If you need to handle IO-based errors,
+-- consider if 'Control.Effect.Resource' fits your use case; if not, use 'liftIO' with
+-- 'Control.Exception.try' or use 'Control.Exception.Catch' from outside the effect invocation.
+catchError :: Has (Catch e) sig m => m a -> (e -> m a) -> m a
+catchError m h = send (Catch m h pure)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -3,7 +3,12 @@ module Control.Effect.Catch
 ( Catch(..)
 ) where
 
+import Control.Carrier
+
 data Catch e m k
   = forall b . Catch (m b) (e -> m b) (b -> m k)
 
 deriving instance Functor m => Functor (Catch e m)
+
+instance HFunctor (Catch e) where
+  hmap f (Catch m h k) = Catch (f m) (f . h) (f . k)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 
--- | An effect modelling catchable failure when used with 'Control.Effect.Throw.Throw'.
+{- | An effect modelling catchable failure when used with 'Control.Effect.Throw.Throw'.
+
+Predefined carriers:
+
+* "Control.Carrier.Error.Either" (with 'Control.Effect.Throw.Throw')
+-}
 module Control.Effect.Catch
 ( -- * Catch effect
   Catch(..)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -12,3 +12,6 @@ deriving instance Functor m => Functor (Catch e m)
 
 instance HFunctor (Catch e) where
   hmap f (Catch m h k) = Catch (f m) (f . h) (f . k)
+
+instance Effect (Catch e) where
+  handle state handler (Catch m h k) = Catch (handler (m <$ state)) (handler . (<$ state) . h) (handler . fmap k)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+
+-- | An effect modelling catchable failure when used with 'Control.Effect.Throw.Throw'.
 module Control.Effect.Catch
 ( Catch(..)
 , catchError

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -4,7 +4,7 @@ module Control.Effect.Catch
 , catchError
 ) where
 
-import Control.Carrier
+import {-# SOURCE #-} Control.Carrier
 
 -- | 'Catch' effects can be used alongside 'Control.Effect.Throw.Throw' to provide recoverable exceptions.
 data Catch e m k

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MonoLocalBinds, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MonoLocalBinds, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -2,7 +2,7 @@
 
 {- | An effect modelling nondeterminism without failure (one or more successful results).
 
-The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Choose' and 'Control.Effect.Empty.Empty'.
+The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Choose' and 'Empty'.
 
 Predefined carriers:
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 
-{- | An effect modelling catchable failure with a polymorphic error type.
+{- | An effect modelling catchable failure with a polymorphic error type, the combination of 'Throw' and 'Catch'.
 
 This effect is similar to the traditional @MonadError@ typeclass, though it allows the presence of multiple @Error@ effects in a given effect stack. It offers precise exception handling, rather than the dynamic exception hierarchy provided by the @exceptions@ package. The 'Control.Effect.Resource' effect or the @fused-effects-exceptions@ package may be more suitable for handling dynamic/impure effect handling.
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -15,11 +15,13 @@ module Control.Effect.Error
   Error
 , module Control.Effect.Throw
 , module Control.Effect.Catch
+  -- * Re-exports
+, Has
 ) where
 
-import Control.Effect.Catch
-import Control.Effect.Sum
-import Control.Effect.Throw
+import Control.Carrier
+import Control.Effect.Catch hiding (Has)
+import Control.Effect.Throw hiding (Has)
 
 -- | @since 0.1.0.0
 type Error e = Throw e :+: Catch e

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,52 +1,13 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Error
 ( -- * Error effect
-  Error(..)
-, throwError
-, catchError
-  -- * Re-exports
-, Has
+  Error
+, module Control.Effect.Throw
+, module Control.Effect.Catch
 ) where
 
-import {-# SOURCE #-} Control.Carrier
+import Control.Effect.Catch
+import Control.Effect.Sum
+import Control.Effect.Throw
 
-data Error exc m k
-  = Throw exc
-  | forall b . Catch (m b) (exc -> m b) (b -> m k)
-
-deriving instance Functor m => Functor (Error exc m)
-
-instance HFunctor (Error exc) where
-  hmap _ (Throw exc)   = Throw exc
-  hmap f (Catch m h k) = Catch (f m) (f . h) (f . k)
-
-instance Effect (Error exc) where
-  handle _     _       (Throw exc)   = Throw exc
-  handle state handler (Catch m h k) = Catch (handler (m <$ state)) (handler . (<$ state) . h) (handler . fmap k)
-
--- | Throw an error, escaping the current computation up to the nearest 'catchError' (if any).
---
---   prop> run (runError (throwError a)) === Left @Int @Int a
-throwError :: Has (Error exc) sig m => exc -> m a
-throwError = send . Throw
-
--- | Run a computation which can throw errors with a handler to run on error.
---
--- Errors thrown by the handler will escape up to the nearest enclosing 'catchError' (if any).
--- Note that this effect does /not/ handle errors thrown from impure contexts such as IO,
--- nor will it handle exceptions thrown from pure code. If you need to handle IO-based errors,
--- consider if 'Control.Effect.Resource' fits your use case; if not, use 'liftIO' with
--- 'Control.Exception.try' or use 'Control.Exception.Catch' from outside the effect invocation.
---
---   prop> run (runError (pure a `catchError` pure)) === Right a
---   prop> run (runError (throwError a `catchError` pure)) === Right @Int @Int a
---   prop> run (runError (throwError a `catchError` (throwError @Int))) === Left @Int @Int a
-catchError :: Has (Error exc) sig m => m a -> (exc -> m a) -> m a
-catchError m h = send (Catch m h pure)
-
-
--- $setup
--- >>> :seti -XFlexibleContexts
--- >>> :seti -XTypeApplications
--- >>> import Test.QuickCheck
--- >>> import Control.Carrier.Error.Either
+type Error e = Throw e :+: Catch e

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,18 +1,12 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, KindSignatures #-}
 module Control.Effect.Fail
 ( -- * Fail effect
-  Fail(..)
+  Fail
 , Fail.MonadFail(..)
   -- * Re-exports
 , Has
 ) where
 
-import Control.Carrier
+import Control.Effect.Throw
 import qualified Control.Monad.Fail as Fail
-import GHC.Generics (Generic1)
 
-newtype Fail (m :: * -> *) k = Fail String
-  deriving (Functor, Generic1)
-
-instance HFunctor Fail
-instance Effect   Fail
+type Fail = Throw String

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 -- | Operations on /sums/, combining effects into a /signature/.
 module Control.Effect.Sum
 ( -- * Membership
@@ -31,46 +31,26 @@ class Member (sub :: (* -> *) -> (* -> *)) sup where
   -- | Inject a member of a signature into the signature.
   inj :: sub m a -> sup m a
 
-instance {-# OVERLAPPABLE #-} Member sub sub where
-  inj = id
-
-instance (Member' elem sub sup, Elem sub sup ~ elem) => Member sub sup where
-  inj = inj' @elem
-
-
-type family Elem (sub :: (* -> *) -> (* -> *)) sup :: Bool where
-  Elem t t         = 'True
-  Elem t (l :+: r) = Elem t l || Elem t r
-  Elem _ _         = 'False
-
-type family (a :: Bool) || (b :: Bool) where
-  'False || 'False = 'False
-  _      || _      = 'True
-
-
-class Member' (elem :: Bool) (sub :: (* -> *) -> (* -> *)) sup where
-  inj' :: sub m a -> sup m a
-
 -- | Reflexivity: @t@ is a member of itself.
-instance Member' 'True t t where
-  inj' = id
+instance Member t t where
+  inj = id
 
 -- | Left-recursion: if @t@ is a member of @l1 ':+:' l2 ':+:' r@, then we can inject it into @(l1 ':+:' l2) ':+:' r@ by injection into a right-recursive signature, followed by left-association.
 instance {-# OVERLAPPABLE #-}
-         Member' 'True t (l1 :+: l2 :+: r)
-      => Member' 'True t ((l1 :+: l2) :+: r) where
-  inj' = reassoc . inj' @'True where
+         Member t (l1 :+: l2 :+: r)
+      => Member t ((l1 :+: l2) :+: r) where
+  inj = reassoc . inj where
     reassoc (L l)     = L (L l)
     reassoc (R (L l)) = L (R l)
     reassoc (R (R r)) = R r
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}
-         Member' 'True l (l :+: r) where
-  inj' = L
+         Member l (l :+: r) where
+  inj = L
 
 -- | Right-recursion: if @t@ is a member of @r@, we can inject it into @r@ in O(n), followed by lifting that into @l ':+:' r@ in O(1).
 instance {-# OVERLAPPABLE #-}
-         Member' 'True l r
-      => Member' 'True l (l' :+: r) where
-  inj' = R . inj' @'True
+         Member l r
+      => Member l (l' :+: r) where
+  inj = R . inj

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,13 +1,15 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeFamilies, TypeOperators, UndecidableInstances #-}
 -- | Operations on /sums/, combining effects into a /signature/.
 module Control.Effect.Sum
 ( -- * Membership
   Member(..)
+, Members
   -- * Sums
 , (:+:)(..)
 ) where
 
 import Control.Effect.Class
+import Data.Kind (Constraint)
 import GHC.Generics (Generic1)
 
 -- | Higher-order sums are used to combine multiple effects into a signature, typically by chaining on the right.
@@ -54,3 +56,9 @@ instance {-# OVERLAPPABLE #-}
          Member l r
       => Member l (l' :+: r) where
   inj = R . inj
+
+
+-- | Decompose sums on the left into multiple 'Member' constraints.
+type family Members sub sup :: Constraint where
+  Members (l :+: r) u = (Members l u, Members r u)
+  Members t         u = Member t u

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -59,6 +59,8 @@ instance {-# OVERLAPPABLE #-}
 
 
 -- | Decompose sums on the left into multiple 'Member' constraints.
+--
+-- Note that while this, and by extension 'Control.Carrier.Has', can be used to group together multiple membership checks into a single (composite) constraint, large signatures on the left can slow compiles down due to [a problem with recursive type families](https://gitlab.haskell.org/ghc/ghc/issues/8095).
 type family Members sub sup :: Constraint where
   Members (l :+: r) u = (Members l u, Members r u)
   Members t         u = Member t u

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 -- | Operations on /sums/, combining effects into a /signature/.
 module Control.Effect.Sum
 ( -- * Membership
@@ -31,26 +31,46 @@ class Member (sub :: (* -> *) -> (* -> *)) sup where
   -- | Inject a member of a signature into the signature.
   inj :: sub m a -> sup m a
 
--- | Reflexivity: @t@ is a member of itself.
-instance Member t t where
+instance {-# OVERLAPPABLE #-} Member sub sub where
   inj = id
+
+instance (Member' elem sub sup, Elem sub sup ~ elem) => Member sub sup where
+  inj = inj' @elem
+
+
+type family Elem (sub :: (* -> *) -> (* -> *)) sup :: Bool where
+  Elem t t         = 'True
+  Elem t (l :+: r) = Elem t l || Elem t r
+  Elem _ _         = 'False
+
+type family (a :: Bool) || (b :: Bool) where
+  'False || 'False = 'False
+  _      || _      = 'True
+
+
+class Member' (elem :: Bool) (sub :: (* -> *) -> (* -> *)) sup where
+  inj' :: sub m a -> sup m a
+
+-- | Reflexivity: @t@ is a member of itself.
+instance Member' 'True t t where
+  inj' = id
 
 -- | Left-recursion: if @t@ is a member of @l1 ':+:' l2 ':+:' r@, then we can inject it into @(l1 ':+:' l2) ':+:' r@ by injection into a right-recursive signature, followed by left-association.
 instance {-# OVERLAPPABLE #-}
-         Member t (l1 :+: l2 :+: r)
-      => Member t ((l1 :+: l2) :+: r) where
-  inj = reassoc . inj where
+         Member' 'True t (l1 :+: l2 :+: r)
+      => Member' 'True t ((l1 :+: l2) :+: r) where
+  inj' = reassoc . inj' @'True where
     reassoc (L l)     = L (L l)
     reassoc (R (L l)) = L (R l)
     reassoc (R (R r)) = R r
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}
-         Member l (l :+: r) where
-  inj = L
+         Member' 'True l (l :+: r) where
+  inj' = L
 
 -- | Right-recursion: if @t@ is a member of @r@, we can inject it into @r@ in O(n), followed by lifting that into @l ':+:' r@ in O(1).
 instance {-# OVERLAPPABLE #-}
-         Member l r
-      => Member l (l' :+: r) where
-  inj = R . inj
+         Member' 'True l r
+      => Member' 'True l (l' :+: r) where
+  inj' = R . inj' @'True

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -31,46 +31,41 @@ class Member (sub :: (* -> *) -> (* -> *)) sup where
   -- | Inject a member of a signature into the signature.
   inj :: sub m a -> sup m a
 
-instance {-# OVERLAPPABLE #-} Member sub sub where
-  inj = id
-
-instance (Member' elem sub sup, Elem sub sup ~ elem) => Member sub sup where
-  inj = inj' @elem
+instance (Member' side sub sup, Find sub sup ~ side) => Member sub sup where
+  inj = inj' @side
 
 
-type family Elem (sub :: (* -> *) -> (* -> *)) sup :: Bool where
-  Elem t t         = 'True
-  Elem t (l :+: r) = Elem t l || Elem t r
-  Elem _ _         = 'False
+data Where = None | Here | LL | RR
 
-type family (a :: Bool) || (b :: Bool) where
-  'False || 'False = 'False
-  _      || _      = 'True
+type family Find (sub :: (* -> *) -> (* -> *)) sup :: Where where
+  Find t t         = 'Here
+  Find t (l :+: r) = Find' 'LL t l <> Find' 'RR t r
+  Find _ _         = 'None
+
+type family Find' (side :: Where) (sub :: (* -> *) -> (* -> *)) sup :: Where where
+  Find' s t t         = s
+  Find' s t (l :+: r) = Find' s t l <> Find' s t r
+  Find' _ _ _         = 'None
 
 
-class Member' (elem :: Bool) (sub :: (* -> *) -> (* -> *)) sup where
+type family (a :: Where) <> (b :: Where) where
+  'None <> b = b
+  a     <> _ = a
+
+
+class Member' (side :: Where) (sub :: (* -> *) -> (* -> *)) sup where
   inj' :: sub m a -> sup m a
 
 -- | Reflexivity: @t@ is a member of itself.
-instance Member' 'True t t where
+instance Member' 'Here t t where
   inj' = id
 
 -- | Left-recursion: if @t@ is a member of @l1 ':+:' l2 ':+:' r@, then we can inject it into @(l1 ':+:' l2) ':+:' r@ by injection into a right-recursive signature, followed by left-association.
-instance {-# OVERLAPPABLE #-}
-         Member' 'True t (l1 :+: l2 :+: r)
-      => Member' 'True t ((l1 :+: l2) :+: r) where
-  inj' = reassoc . inj' @'True where
-    reassoc (L l)     = L (L l)
-    reassoc (R (L l)) = L (R l)
-    reassoc (R (R r)) = R r
-
--- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
-instance {-# OVERLAPPABLE #-}
-         Member' 'True l (l :+: r) where
-  inj' = L
+instance Member t l
+      => Member' 'LL t (l :+: r) where
+  inj' = L . inj
 
 -- | Right-recursion: if @t@ is a member of @r@, we can inject it into @r@ in O(n), followed by lifting that into @l ':+:' r@ in O(1).
-instance {-# OVERLAPPABLE #-}
-         Member' 'True l r
-      => Member' 'True l (l' :+: r) where
-  inj' = R . inj' @'True
+instance Member t r
+      => Member' 'RR t (l :+: r) where
+  inj' = R . inj

--- a/src/Control/Effect/Throw.hs
+++ b/src/Control/Effect/Throw.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, KindSignatures #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
 module Control.Effect.Throw
 ( -- * Throw effect
   Throw(..)
+, throwError
   -- * Re-exports
 , Has
 ) where
@@ -15,3 +16,8 @@ data Throw e (m :: * -> *) k
 
 instance HFunctor (Throw e)
 instance Effect   (Throw e)
+
+
+-- | Throw an error, escaping the current computation up to the nearest 'Control.Effect.Catch.catchError' (if any).
+throwError :: Has (Throw e) sig m => e -> m a
+throwError = send . Throw

--- a/src/Control/Effect/Throw.hs
+++ b/src/Control/Effect/Throw.hs
@@ -7,7 +7,7 @@ module Control.Effect.Throw
 , Has
 ) where
 
-import Control.Carrier
+import {-# SOURCE #-} Control.Carrier
 import GHC.Generics (Generic1)
 
 data Throw e (m :: * -> *) k

--- a/src/Control/Effect/Throw.hs
+++ b/src/Control/Effect/Throw.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
+
+-- | An effect for polymorphic failure.
 module Control.Effect.Throw
 ( -- * Throw effect
   Throw(..)

--- a/src/Control/Effect/Throw.hs
+++ b/src/Control/Effect/Throw.hs
@@ -19,5 +19,7 @@ instance Effect   (Throw e)
 
 
 -- | Throw an error, escaping the current computation up to the nearest 'Control.Effect.Catch.catchError' (if any).
+--
+-- @since 0.1.0.0
 throwError :: Has (Throw e) sig m => e -> m a
 throwError = send . Throw

--- a/src/Control/Effect/Throw.hs
+++ b/src/Control/Effect/Throw.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
 
--- | An effect for polymorphic failure.
+{- | An effect for polymorphic failure.
+
+Predefined carriers:
+
+* "Control.Carrier.Throw.Either"
+* "Control.Carrier.Error.Either" (with 'Control.Effect.Catch.Catch')
+-}
 module Control.Effect.Throw
 ( -- * Throw effect
   Throw(..)


### PR DESCRIPTION
This PR explores splitting `Error` up into separate `Throw` and `Catch` effects.

- [x] Redefines `Error e` as a synonym for `Throw e :+: Catch e`.
- [x] Redefines `Fail` as a synonym for `Throw String`.
- [x] Fixes #154.