### PR TITLE
NonEmpty as a pure carrier for Choose.

### DIFF
--- a/src/Control/Carrier/Class.hs
+++ b/src/Control/Carrier/Class.hs
@@ -12,12 +12,16 @@ import Control.Effect.Reader (Reader(..))
 import Control.Effect.Sum ((:+:)(..))
 import Control.Effect.Writer (Writer(..))
 import Control.Monad ((<=<))
+import Data.List.NonEmpty (NonEmpty)
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
 class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   eff :: sig m a -> m a
 
+
+instance Carrier Choose NonEmpty where
+  eff (Choose m) = m True <> m False
 
 instance Carrier Empty Maybe where
   eff Empty = Nothing

--- a/src/Control/Carrier/Class.hs
+++ b/src/Control/Carrier/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, FlexibleInstances, FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances, FunctionalDependencies #-}
 module Control.Carrier.Class
 ( Carrier(..)
 ) where
@@ -13,10 +13,7 @@ import Control.Effect.Sum ((:+:)(..))
 import Control.Effect.Writer (Writer(..))
 import Control.Monad ((<=<))
 import Data.List.NonEmpty (NonEmpty)
-
-#if __GLASGOW_HASKELL__ < 840
-import Data.Semigroup ((<>))
-#endif
+import qualified Data.Semigroup as S
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
 class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
@@ -25,7 +22,7 @@ class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
 
 
 instance Carrier Choose NonEmpty where
-  eff (Choose m) = m True <> m False
+  eff (Choose m) = m True S.<> m False
 
 instance Carrier Empty Maybe where
   eff Empty = Nothing

--- a/src/Control/Carrier/Class.hs
+++ b/src/Control/Carrier/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, FunctionalDependencies #-}
+{-# LANGUAGE CPP, FlexibleInstances, FunctionalDependencies #-}
 module Control.Carrier.Class
 ( Carrier(..)
 ) where
@@ -13,6 +13,10 @@ import Control.Effect.Sum ((:+:)(..))
 import Control.Effect.Writer (Writer(..))
 import Control.Monad ((<=<))
 import Data.List.NonEmpty (NonEmpty)
+
+#if __GLASGOW_HASKELL__ < 840
+import Data.Semigroup ((<>))
+#endif
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
 class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where


### PR DESCRIPTION
In keeping with #206, this offers a solo `Carrier` instance for
`NonEmpty` lists over the `Choose` effects. Because `NonEmpty` is now
in `base`, this doesn't add new dependencies, and nicely rounds out
the carrier definition of `[]` for `NonDet` and `Maybe` for `Empty`.