### PR TITLE
Document the effects and their carriers.

### DIFF
--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -31,14 +31,20 @@ import qualified Data.Semigroup as S
 import Prelude hiding (head, tail)
 
 -- | Run a 'Choose' effect, passing branches and results to the supplied continuations.
+--
+-- @since 1.0.0.0
 runChoose :: (m b -> m b -> m b) -> (a -> m b) -> ChooseC m a -> m b
 runChoose fork leaf m = runChooseC m fork leaf
 
 -- | Run a 'Choose' effect, passing results to the supplied function, and merging branches together using 'S.<>'.
+--
+-- @since 1.0.0.0
 runChooseS :: (S.Semigroup b, Applicative m) => (a -> m b) -> ChooseC m a -> m b
 runChooseS leaf = runChoose (liftA2 (S.<>)) leaf
 
 -- | A carrier for 'Choose' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
+--
+-- @since 1.0.0.0
 newtype ChooseC m a = ChooseC
   { -- | A higher-order function receiving two continuations, respectively implementing choice and 'pure'.
     runChooseC :: forall b . (m b -> m b -> m b) -> (a -> m b) -> m b

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
-{- |
-A carrier for 'Choose' effects (nondeterminism via choice).
+{- | A carrier for 'Choose' effects (nondeterminism via choice).
 
 Under the hood, it uses a Church-encoded binary tree to avoid the problems associated with a naïve list-based implementation (see ["ListT done right"](http://wiki.haskell.org/ListT_done_right)).
 -}

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for 'Choose' effects (nondeterminism via choice).
+{- | A carrier for 'Choose' effects (nondeterminism without failure).
 
 Under the hood, it uses a Church-encoded binary tree to avoid the problems associated with a naïve list-based implementation (see ["ListT done right"](http://wiki.haskell.org/ListT_done_right)).
 -}

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
--- | Provides 'ChooseC', a carrier for 'Choose' effects (nondeterminism via choice).
---
--- It can be invoked with custom functions for choice, success, and failure
- -- ('runChoose'), or it can delegate said operations to an 'S.Semigroup' instance
- -- ('runChooseS'). Under the hood, it uses a Church-encoded structure and a binary
- -- tree to prevent the problems associated with a naïve list-based implementation.
+
+{- |
+A carrier for 'Choose' effects (nondeterminism via choice).
+
+Under the hood, it uses a Church-encoded binary tree to avoid the problems associated with a naïve list-based implementation (see ["ListT done right"](http://wiki.haskell.org/ListT_done_right)).
+-}
+
 module Control.Carrier.Choose.Church
 ( -- * Choose effect
   module Control.Effect.Choose

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE DeriveTraversable, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+-- | Provides 'ChooseC', a carrier for 'Choose' effects (nondeterminism via choice).
+--
+-- It can be invoked with custom functions for choice, success, and failure
+ -- ('runChoose'), or it can delegate said operations to an 'S.Semigroup' instance
+ -- ('runChooseS'). Under the hood, it uses a Church-encoded structure and a binary
+ -- tree to prevent the problems associated with a naïve list-based implementation.
 module Control.Carrier.Choose.Church
 ( -- * Choose effect
   module Control.Effect.Choose

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -49,6 +49,7 @@ runCullA = runCull (liftA2 (<|>)) (pure . pure) (pure empty)
 runCullM :: (Applicative m, Monoid b) => (a -> b) -> CullC m a -> m b
 runCullM leaf = runCull (liftA2 mappend) (pure . leaf) (pure mempty)
 
+-- | @since 1.0.0.0
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
 

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -34,17 +34,20 @@ import Control.Monad.Trans.Class
 -- | Run a 'Cull' effect with the supplied continuations for '<|>', 'pure', and 'empty'. Branches outside of any 'cull' block will not be pruned.
 --
 --   prop> run (runCull (liftA2 (<|>)) (pure . pure) (pure empty) (pure a <|> pure b)) === [a, b]
+--
+-- @since 1.0.0.0
 runCull :: (m b -> m b -> m b) -> (a -> m b) -> m b -> CullC m a -> m b
 runCull fork leaf nil = runNonDet fork leaf nil . runReader False . runCullC
 
--- | Run a 'Cull' effect, interpreting the result into an 'Alternative' functor. Choice is handled
--- with 'Control.Applicative.<|>', embedding with 'pure', and failure with 'Control.Applicative.empty'.
+-- | Run a 'Cull' effect, interpreting the result into an 'Alternative' functor. Choice is handled with 'Control.Applicative.<|>', embedding with 'pure', and failure with 'Control.Applicative.empty'.
+--
+-- @since 1.0.0.0
 runCullA :: (Alternative f, Applicative m) => CullC m a -> m (f a)
 runCullA = runCull (liftA2 (<|>)) (pure . pure) (pure empty)
 
--- | Run a 'Cull' effect, interpreting the result into a 'Monoid'. Choice is handled
--- with 'mappend', failure with 'Control.Applicative.empty', and embedding with the composition of
--- 'pure' and the provided function returning a monoid.
+-- | Run a 'Cull' effect, interpreting the result into a 'Monoid'. Choice is handled with 'mappend', failure with 'Control.Applicative.empty', and embedding with the composition of 'pure' and the provided function returning a monoid.
+--
+-- @since 1.0.0.0
 runCullM :: (Applicative m, Monoid b) => (a -> b) -> CullC m a -> m b
 runCullM leaf = runCull (liftA2 mappend) (pure . leaf) (pure mempty)
 

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
--- | Provides 'NonDetC', a carrier for the 'Control.Effect.Cull.Cull' and 'Control.Effect.NonDet.NonDet'
+-- | Provides 'CullC', a carrier for the 'Control.Effect.Cull.Cull' and 'Control.Effect.NonDet.NonDet'
 -- effects used in tandem.
 module Control.Carrier.Cull.Church
 ( -- * Cull effect

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 {- |
-A carrier for 'Control.Effect.Cull.Cull' and 'Control.Effect.NonDet.NonDet' effects used in tandem (@Cull :+: NonDet@).
+A carrier for 'Cull' and 'NonDet' effects used in tandem (@Cull :+: NonDet@).
 -}
 
 module Control.Carrier.Cull.Church

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -37,7 +37,7 @@ import Control.Monad.Trans.Class
 runCull :: (m b -> m b -> m b) -> (a -> m b) -> m b -> CullC m a -> m b
 runCull fork leaf nil = runNonDet fork leaf nil . runReader False . runCullC
 
--- | Run a 'Cull' effect, interpreting the result into an 'Alternative' functor. Choice is handled with '<|>', embedding with 'pure', and failure with 'Control.Applicative.empty'.
+-- | Run a 'Cull' effect, interpreting the result into an 'Alternative' functor. Choice is handled with '<|>', embedding with 'pure', and failure with 'empty'.
 --
 -- @since 1.0.0.0
 runCullA :: (Alternative f, Applicative m) => CullC m a -> m (f a)

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -37,13 +37,13 @@ import Control.Monad.Trans.Class
 runCull :: (m b -> m b -> m b) -> (a -> m b) -> m b -> CullC m a -> m b
 runCull fork leaf nil = runNonDet fork leaf nil . runReader False . runCullC
 
--- | Run a 'Cull' effect, interpreting the result into an 'Alternative' functor. Choice is handled with 'Control.Applicative.<|>', embedding with 'pure', and failure with 'Control.Applicative.empty'.
+-- | Run a 'Cull' effect, interpreting the result into an 'Alternative' functor. Choice is handled with '<|>', embedding with 'pure', and failure with 'Control.Applicative.empty'.
 --
 -- @since 1.0.0.0
 runCullA :: (Alternative f, Applicative m) => CullC m a -> m (f a)
 runCullA = runCull (liftA2 (<|>)) (pure . pure) (pure empty)
 
--- | Run a 'Cull' effect, interpreting the result into a 'Monoid'. Choice is handled with 'mappend', failure with 'Control.Applicative.empty', and embedding with the composition of 'pure' and the provided function returning a monoid.
+-- | Run a 'Cull' effect, interpreting the result into a 'Monoid'. Choice is handled with 'mappend', failure with 'empty', and embedding with the composition of 'pure' and the provided function returning a monoid.
 --
 -- @since 1.0.0.0
 runCullM :: (Applicative m, Monoid b) => (a -> b) -> CullC m a -> m b

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 {- |
 A carrier for 'Control.Effect.Cull.Cull' and 'Control.Effect.NonDet.NonDet' effects used in tandem (@Cull :+: NonDet@).
-
-This carrier is implemented atop "Control.Carrier.NonDet.Church".
 -}
 
 module Control.Carrier.Cull.Church

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -43,7 +43,7 @@ runCull fork leaf nil = runNonDet fork leaf nil . runReader False . runCullC
 runCullA :: (Alternative f, Applicative m) => CullC m a -> m (f a)
 runCullA = runCull (liftA2 (<|>)) (pure . pure) (pure empty)
 
--- | Run a 'Cull' effect, interpreting the result into a 'Monoid'. Choice is handled with 'mappend', failure with 'empty', and embedding with the composition of 'pure' and the provided function returning a monoid.
+-- | Run a 'Cull' effect, mapping the result into a 'Monoid'.
 --
 -- @since 1.0.0.0
 runCullM :: (Applicative m, Monoid b) => (a -> b) -> CullC m a -> m b

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
--- | Provides 'CullC', a carrier for the 'Control.Effect.Cull.Cull' and 'Control.Effect.NonDet.NonDet'
--- effects used in tandem.
+{- |
+A carrier for 'Control.Effect.Cull.Cull' and 'Control.Effect.NonDet.NonDet' effects used in tandem (@Cull :+: NonDet@).
+
+This carrier is implemented atop "Control.Carrier.NonDet.Church".
+-}
+
 module Control.Carrier.Cull.Church
 ( -- * Cull effect
   module Control.Effect.Cull

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for 'Cull' and 'NonDet' effects used in tandem (@Cull :+: NonDet@).
--}
-
+-- | A carrier for 'Cull' and 'NonDet' effects used in tandem (@Cull :+: NonDet@).
 module Control.Carrier.Cull.Church
 ( -- * Cull effect
   module Control.Effect.Cull

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
-{- |
-A carrier for 'Cull' and 'NonDet' effects used in tandem (@Cull :+: NonDet@).
+
+{- | A carrier for 'Cull' and 'NonDet' effects used in tandem (@Cull :+: NonDet@).
 -}
 
 module Control.Carrier.Cull.Church

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -46,6 +46,7 @@ runCutA = runCut (fmap . (<|>) . pure) (pure empty) (pure empty)
 runCutM :: (Applicative m, Monoid b) => (a -> b) -> CutC m a -> m b
 runCutM leaf = runCut (fmap . mappend . leaf) (pure mempty) (pure mempty)
 
+-- | @since 1.0.0.0
 newtype CutC m a = CutC
   { -- | A higher-order function receiving three parameters: a function to combine each solution with the rest of the solutions, an action to run when no results are produced (e.g. on 'empty'), and an action to run when no results are produced and backtrcking should not be attempted (e.g. on 'cutfail').
     runCutC :: forall b . (a -> m b -> m b) -> m b -> m b -> m b

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+
+{- |
+A carrier for 'Cut' and 'NonDet' effects used in tandem (@Cut :+: NonDet@).
+-}
+
 module Control.Carrier.Cut.Church
 ( -- * Cut effect
   module Control.Effect.Cut
@@ -22,16 +27,23 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
--- | Run a 'Cut' effect with the supplied continuations for 'pure'/'<|>', 'empty', and 'cutfail'.
+-- | Run a 'Cut' effect with the supplied continuations for 'pure' / '<|>', 'empty', and 'cutfail'.
 --
 --   prop> run (runCut (fmap . (:)) (pure []) (pure []) (pure a)) === [a]
+--
+-- @since 1.0.0.0
 runCut :: (a -> m b -> m b) -> m b -> m b -> CutC m a -> m b
 runCut cons nil fail m = runCutC m cons nil fail
 
 -- | Run a 'Cut' effect, returning all its results in an 'Alternative' collection.
+--
+-- @since 1.0.0.0
 runCutA :: (Alternative f, Applicative m) => CutC m a -> m (f a)
 runCutA = runCut (fmap . (<|>) . pure) (pure empty) (pure empty)
 
+-- | Run a 'Cut' effect, modeling choice and failure with '<>' and 'mempty' and embedding results with the passed function.
+--
+-- @since 1.0.0.0
 runCutM :: (Applicative m, Monoid b) => (a -> b) -> CutC m a -> m b
 runCutM leaf = runCut (fmap . mappend . leaf) (pure mempty) (pure mempty)
 

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for 'Cut' and 'NonDet' effects used in tandem (@Cut :+: NonDet@).
--}
-
+-- | A carrier for 'Cut' and 'NonDet' effects used in tandem (@Cut :+: NonDet@).
 module Control.Carrier.Cut.Church
 ( -- * Cut effect
   module Control.Effect.Cut

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
-{- |
-A carrier for 'Cut' and 'NonDet' effects used in tandem (@Cut :+: NonDet@).
+{- | A carrier for 'Cut' and 'NonDet' effects used in tandem (@Cut :+: NonDet@).
 -}
 
 module Control.Carrier.Cut.Church

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for a 'Empty' effect, indicating failure with a 'Nothing' value. Users that need
+-- access to an error message should use the 'Control.Effect.Fail.Fail' effect.
+--
+-- Note that 'Empty' effects can, when they are the last effect in a stack, be interpreted directly
+-- to a 'Maybe' without a call to 'runEmpty'.
 module Control.Carrier.Empty.Maybe
 ( -- * Empty effect
   module Control.Effect.Empty

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -34,6 +34,7 @@ runEmpty :: EmptyC m a -> m (Maybe a)
 runEmpty = runMaybeT . runEmptyC
 {-# INLINE runEmpty #-}
 
+-- | @since 1.0.0.0
 newtype EmptyC m a = EmptyC { runEmptyC :: MaybeT m a }
   deriving (Applicative, Functor, Monad, MonadFix, MonadIO, MonadTrans)
 

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for a 'Empty' effect, indicating failure with a 'Nothing' value. Users that need access to an error message should use the 'Control.Effect.Fail.Fail' effect.
+{- | A carrier for an 'Empty' effect, indicating failure with a 'Nothing' value. Users that need access to an error message should use the 'Control.Effect.Fail.Fail' effect.
 
 Note that 'Empty' effects can, when they are the last effect in a stack, be interpreted directly to a 'Maybe' without a call to 'runEmpty'.
 -}

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for a 'Empty' effect, indicating failure with a 'Nothing' value. Users that need
--- access to an error message should use the 'Control.Effect.Fail.Fail' effect.
---
--- Note that 'Empty' effects can, when they are the last effect in a stack, be interpreted directly
--- to a 'Maybe' without a call to 'runEmpty'.
+
+{- | A carrier for a 'Empty' effect, indicating failure with a 'Nothing' value. Users that need access to an error message should use the 'Control.Effect.Fail.Fail' effect.
+
+Note that 'Empty' effects can, when they are the last effect in a stack, be interpreted directly to a 'Maybe' without a call to 'runEmpty'.
+-}
+
 module Control.Carrier.Empty.Maybe
 ( -- * Empty effect
   module Control.Effect.Empty
@@ -27,6 +28,8 @@ import Control.Monad.Trans.Maybe
 --
 --   prop> run (runEmpty empty)    === Nothing
 --   prop> run (runEmpty (pure a)) === Just a
+--
+-- @since 1.0.0.0
 runEmpty :: EmptyC m a -> m (Maybe a)
 runEmpty = runMaybeT . runEmptyC
 {-# INLINE runEmpty #-}

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+
+{- | A carrier for an 'Error' effect.
+-}
 module Control.Carrier.Error.Either
 ( -- * Error effect
   module Control.Effect.Error

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for an 'Error' effect.
--}
+-- | A carrier for an 'Error' effect.
 module Control.Carrier.Error.Either
 ( -- * Error effect
   module Control.Effect.Error

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Control.Monad.Fail.fail'.
-
-Note that 'Fail' effects can, when they are the last effect in a stack, be interpreted directly to an 'Either' without a call to 'runFail'.
+{- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Fail.fail'.
 -}
 module Control.Carrier.Fail.Either
 ( -- * Fail effect

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Fail.fail'.
--}
+-- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Fail.fail'.
 module Control.Carrier.Fail.Either
 ( -- * Fail effect
   module Control.Effect.Fail

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 -- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations
 -- will return a 'Left' containing the 'String' value passed to 'Control.Monad.Fail.fail'.
+--
+-- Note that 'Fail' effects can, when they are the last effect in a stack, be interpreted directly
+-- to an 'Either' without a call to 'runFail'.
 module Control.Carrier.Fail.Either
 ( -- * Fail effect
   module Control.Effect.Fail

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations
--- will return a 'Left' containing the 'String' value passed to 'Control.Monad.Fail.fail'.
---
--- Note that 'Fail' effects can, when they are the last effect in a stack, be interpreted directly
--- to an 'Either' without a call to 'runFail'.
+
+{- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Control.Monad.Fail.fail'.
+
+Note that 'Fail' effects can, when they are the last effect in a stack, be interpreted directly to an 'Either' without a call to 'runFail'.
+-}
 module Control.Carrier.Fail.Either
 ( -- * Fail effect
   module Control.Effect.Fail
@@ -28,6 +28,8 @@ import Control.Monad.Trans.Class
 -- | Run a 'Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
 --
 --   prop> run (runFail (pure a)) === Right a
+--
+-- @since 1.0.0.0
 runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations
+-- will return a 'Left' containing the 'String' value passed to 'Control.Monad.Fail.fail'.
 module Control.Carrier.Fail.Either
 ( -- * Fail effect
   module Control.Effect.Fail

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -31,6 +31,7 @@ import Control.Monad.Trans.Class
 runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 
+-- | @since 1.0.0.0
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
+
+{- | A carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
+-}
 module Control.Carrier.Fresh.Strict
 ( -- * Fresh effect
   module Control.Effect.Fresh

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -30,6 +30,7 @@ import Control.Monad.Trans.Class
 runFresh :: Functor m => FreshC m a -> m a
 runFresh = evalState 0 . runFreshC
 
+-- | @since 1.0.0.0
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
 module Control.Carrier.Fresh.Strict
 ( -- * Fresh effect
   module Control.Effect.Fresh

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
--}
+-- | A carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
 module Control.Carrier.Fresh.Strict
 ( -- * Fresh effect
   module Control.Effect.Fresh

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -59,6 +59,8 @@ reify a k =
 -- Note that due to the higher-rank type, you have to use either '$' or explicit application when applying this interpreter. That is, you will need to write @runInterpret f (runInterpret g myPrgram)@ or @runInterpret f $ runInterpret g $ myProgram@. If you try and write @runInterpret f . runInterpret g@, you will unfortunately get a rather scary type error!
 --
 --   prop> run (runInterpret (\ op -> case op of { Get k -> k a ; Put _ k -> k }) get) === a
+--
+-- @since 1.0.0.0
 runInterpret
   :: forall eff m a.
      (HFunctor eff, Monad m)
@@ -85,6 +87,8 @@ runInterpret f m =
 -- | Interpret an effect using a higher-order function with some state variable.
 --
 --   prop> run (runInterpretState (\ s op -> case op of { Get k -> runState s (k s) ; Put s' k -> runState s' k }) a get) === a
+--
+-- @since 1.0.0.0
 runInterpretState
   :: (HFunctor eff, Monad m)
   => (forall x . s -> eff (StateC s m) x -> m (s, x))

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
--- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using
--- a passed-in higher order function to interpret that effect. The resulting code will be
--- less efficient than using a carrier monad and 'Carrier' instance directly, but this
--- module is suitable for prototyping new effects quickly, or when efficiency is not a concern.
+
+{- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using a passed-in higher order function to interpret that effect. The resulting code will be less efficient than using a carrier monad and 'Carrier' instance directly, but this module is suitable for prototyping new effects quickly, or when efficiency is not a concern.
+-}
+
 module Control.Carrier.Interpret
 ( runInterpret
 , runInterpretState

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
-
+-- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using
+-- a passed-in higher order function to interpret that effect. The resulting code will be
+-- less efficient than using a carrier monad and 'Carrier' instance directly, but this
+-- module is suitable for prototyping new effects quickly, or when efficiency is not a concern.
 module Control.Carrier.Interpret
 ( runInterpret
 , runInterpretState

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 
-{- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using a passed-in higher order function to interpret that effect. This is suitable for prototyping new effects quickly.
+-- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using a passed-in higher order function to interpret that effect. This is suitable for prototyping new effects quickly.
 -}
 
 module Control.Carrier.Interpret

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 
 -- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using a passed-in higher order function to interpret that effect. This is suitable for prototyping new effects quickly.
--}
 
 module Control.Carrier.Interpret
 ( runInterpret

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 
-{- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using a passed-in higher order function to interpret that effect. The resulting code will be less efficient than using a carrier monad and 'Carrier' instance directly, but this module is suitable for prototyping new effects quickly, or when efficiency is not a concern.
+{- | Provides an 'InterpretC' carrier capable of interpreting an arbitrary effect using a passed-in higher order function to interpret that effect. This is suitable for prototyping new effects quickly.
 -}
 
 module Control.Carrier.Interpret

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
--- | Provides a carrier over a monad @m@ that allows monadic actions to be lifted
--- into a larger context with 'Control.Effect.Lift.sendM'.
+{- | Provides a carrier over a monad @m@ that allows monadic actions to be lifted into a larger context with 'Control.Effect.Lift.sendM'.
+-}
 module Control.Carrier.Lift
 ( -- * Lift effect
   module Control.Effect.Lift

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
+-- | Provides a carrier over a monad @m@ that allows monadic actions to be lifted
+-- into a larger context with 'Control.Effect.Lift.sendM'.
 module Control.Carrier.Lift
 ( -- * Lift effect
   module Control.Effect.Lift

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -28,6 +28,7 @@ import Control.Monad.Trans.Class
 runM :: LiftC m a -> m a
 runM = runLiftC
 
+-- | @since 1.0.0.0
 newtype LiftC m a = LiftC { runLiftC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
-{- | A carrier for 'Lift' allowing monadic actions to be lifted into a larger context with 'sendM'.
--}
+
+-- | A carrier for 'Lift' allowing monadic actions to be lifted into a larger context with 'sendM'.
 module Control.Carrier.Lift
 ( -- * Lift effect
   module Control.Effect.Lift

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
-{- | Provides a carrier over a monad @m@ that allows monadic actions to be lifted into a larger context with 'Control.Effect.Lift.sendM'.
+{- | A carrier for 'Lift' allowing monadic actions to be lifted into a larger context with 'sendM'.
 -}
 module Control.Carrier.Lift
 ( -- * Lift effect

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -23,6 +23,8 @@ import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 
 -- | Extract a 'Lift'ed 'Monad'ic action from an effectful computation.
+--
+-- @since 1.0.0.0
 runM :: LiftC m a -> m a
 runM = runLiftC
 

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -49,8 +49,7 @@ runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 runNonDetA :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDetA = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
 
--- | Run a 'NonDet' effect, collecting branches' results with 'mappend' and representing failure
--- with 'mempty'. The given function parameter converts successful results of type @a@ to monoidal @b@ values.
+-- | Run a 'NonDet' effect, collecting results into a 'Monoid'.
 runNonDetM :: (Applicative m, Monoid b) => (a -> b) -> NonDetC m a -> m b
 runNonDetM leaf = runNonDet (liftA2 mappend) (pure . leaf) (pure mempty)
 

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -2,7 +2,7 @@
 
 {- | Provides 'NonDetC', a carrier for 'NonDet' effects providing choice and failure.
 
-Under the hood, it uses a Church-encoded structure and a binary tree to prevent the problems associated with a naïve list-based implementation. This design is based on that detailed in Ralf Hinze's [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
+Under the hood, it uses a Church-encoded structure and a binary tree to prevent the problems associated with a naïve list-based implementation.
 -}
 
 module Control.Carrier.NonDet.Church

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -30,11 +30,12 @@ import Control.Monad.Trans.Class
 -- | Run a 'NonDet' effect, using the provided functions to interpret choice, leaf results, and failure.
 --
 -- @since 1.0.0.0
-runNonDet :: (m b -> m b -> m b) -- ^ Handles choice ('Control.Effect.Choose.<|>')
-          -> (a -> m b)          -- ^ Handles embedding results ('pure')
-          -> m b                 -- ^ Handles failure ('Control.Effect.Empty.empty')
-          -> NonDetC m a         -- ^ A nondeterministic
-          -> m b
+runNonDet
+  :: (m b -> m b -> m b) -- ^ Handles choice ('<|>')
+  -> (a -> m b)          -- ^ Handles embedding results ('pure')
+  -> m b                 -- ^ Handles failure ('empty')
+  -> NonDetC m a         -- ^ A nondeterministic computation to execute
+  -> m b
 runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -1,14 +1,10 @@
 {-# LANGUAGE DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
--- | Provides 'NonDetC', a carrier for 'NonDet' effects providing choice and failure.
---
--- It can be invoked with custom functions for choice, success, and failure ('runNonDet'), or it can delegate
--- said operations to an 'Control.Applicative.Alternative' instance ('runNonDetA') or an underlying monoidal
--- result ('runNonDetM'). Under the hood, it uses a Church-encoded structure and a binary tree to prevent
--- the problems associated with a naïve list-based implementation.
---
--- This design is based on that detailed in Ralf Hinze's [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
---
--- The carrier provided by "Control.Carrier.NonDet.Maybe" is similar, but can handle infinite search spaces at the cost of being able to return only one result.
+
+{- | Provides 'NonDetC', a carrier for 'NonDet' effects providing choice and failure.
+
+Under the hood, it uses a Church-encoded structure and a binary tree to prevent the problems associated with a naïve list-based implementation. This design is based on that detailed in Ralf Hinze's [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
+-}
+
 module Control.Carrier.NonDet.Church
 ( -- * NonDet effects
   module Control.Effect.NonDet
@@ -31,8 +27,9 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
--- | Run a 'NonDet' effect, using the provided functions to interpret
--- choice, leaf results, and failure.
+-- | Run a 'NonDet' effect, using the provided functions to interpret choice, leaf results, and failure.
+--
+-- @since 1.0.0.0
 runNonDet :: (m b -> m b -> m b) -- ^ Handles choice ('Control.Effect.Choose.<|>')
           -> (a -> m b)          -- ^ Handles embedding results ('pure')
           -> m b                 -- ^ Handles failure ('Control.Effect.Empty.empty')
@@ -42,10 +39,12 @@ runNonDet fork leaf nil (NonDetC m) = m fork leaf nil
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.
 --
---   Using @[]@ as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unless used with 'Control.Effect.Cull.cull', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
+-- Using @[]@ as the 'Alternative' functor will produce all results, while 'Maybe' will return only the first. However, unless used with 'Control.Effect.Cull.cull', this will still enumerate the entire search space before returning, meaning that it will diverge for infinite search spaces, even when using 'Maybe'.
 --
 --   prop> run (runNonDetA (pure a)) === [a]
 --   prop> run (runNonDetA (pure a)) === Just a
+--
+-- @since 1.0.0.0
 runNonDetA :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDetA = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
 

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -50,10 +50,14 @@ runNonDetA :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDetA = runNonDet (liftA2 (<|>)) (pure . pure) (pure empty)
 
 -- | Run a 'NonDet' effect, collecting results into a 'Monoid'.
+--
+-- @since 1.0.0.0
 runNonDetM :: (Applicative m, Monoid b) => (a -> b) -> NonDetC m a -> m b
 runNonDetM leaf = runNonDet (liftA2 mappend) (pure . leaf) (pure mempty)
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
+--
+-- @since 1.0.0.0
 newtype NonDetC m a = NonDetC
   { -- | A higher-order function receiving three continuations, respectively implementing '<|>', 'pure', and 'empty'.
     runNonDetC :: forall b . (m b -> m b -> m b) -> (a -> m b) -> m b -> m b

--- a/src/Control/Carrier/NonDet/Maybe.hs
+++ b/src/Control/Carrier/NonDet/Maybe.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | Provides a carrier for 'NonDet' effects providing choice and failure.
---
--- This is similar to the 'Control.Carrier.NonDet.Church.NonDetC' in "Control.Carrier.NonDet.Church",
--- but terminates immediately upon finding a successful result. This allows us to search a
--- potentially-infinite search space, as long as said space eventually returns a result, in contrast
--- with the Church-encoded carrier, which needs to enumerate the entire space before returning.
---
--- In previous versions of this package, this function was called @runNonDetOnce@.
+{- | A carrier for 'NonDet' effects providing choice and failure.
+
+Unlike the Church-encoded 'NonDet' carrier, this carrier terminates immediately upon finding a successful result.
+-}
+
 module Control.Carrier.NonDet.Maybe
 ( -- * NonDet effects
   module Control.Effect.NonDet
@@ -31,6 +28,8 @@ import Control.Monad.Trans.Maybe
 --   prop> run (runNonDet empty)    === Nothing
 --   prop> run (runNonDet (pure a)) === Just a
 --   prop> run (runNonDet (let f x = pure x <|> f x in f a)) === Just a
+--
+-- @since 1.0.0.0
 runNonDet :: NonDetC m a -> m (Maybe a)
 runNonDet = runMaybeT . runNonDetC
 {-# INLINE runNonDet #-}
@@ -39,6 +38,8 @@ newtype NonDetC m a = NonDetC { runNonDetC :: MaybeT m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 -- | 'NonDetC' passes 'Fail.MonadFail' operations along to the underlying monad @m@, rather than interpreting it as a synonym for 'empty' à la 'MaybeT'.
+--
+-- @since 1.0.0.0
 instance Fail.MonadFail m => Fail.MonadFail (NonDetC m) where
   fail = lift . Fail.fail
   {-# INLINE fail #-}

--- a/src/Control/Carrier/NonDet/Maybe.hs
+++ b/src/Control/Carrier/NonDet/Maybe.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 {- | A carrier for 'NonDet' effects providing choice and failure.
 
-Unlike the Church-encoded 'NonDet' carrier, this carrier terminates immediately upon finding a successful result.
+This carrier terminates immediately upon finding a successful result.
 -}
 
 module Control.Carrier.NonDet.Maybe

--- a/src/Control/Carrier/NonDet/Maybe.hs
+++ b/src/Control/Carrier/NonDet/Maybe.hs
@@ -1,4 +1,12 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | Provides a carrier for 'NonDet' effects providing choice and failure.
+--
+-- This is similar to the 'Control.Carrier.NonDet.Church.NonDetC' in "Control.Carrier.NonDet.Church",
+-- but terminates immediately upon finding a successful result. This allows us to search a
+-- potentially-infinite search space, as long as said space eventually returns a result, in contrast
+-- with the Church-encoded carrier, which needs to enumerate the entire space before returning.
+--
+-- In previous versions of this package, this function was called @runNonDetOnce@.
 module Control.Carrier.NonDet.Maybe
 ( -- * NonDet effects
   module Control.Effect.NonDet

--- a/src/Control/Carrier/Pure.hs
+++ b/src/Control/Carrier/Pure.hs
@@ -24,6 +24,7 @@ run :: PureC a -> a
 run = runPureC
 {-# INLINE run #-}
 
+-- | @since 1.0.0.0
 newtype PureC a = PureC { runPureC :: a }
 
 instance Functor PureC where

--- a/src/Control/Carrier/Pure.hs
+++ b/src/Control/Carrier/Pure.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE EmptyCase, MultiParamTypeClasses #-}
 
-{- | A carrier for pure effects, used to kick off a stack of effects with 'run'.
--}
-
+-- | A carrier for pure effects, used to kick off a stack of effects with 'run'.
 module Control.Carrier.Pure
 ( -- * Pure effect
   module Control.Effect.Pure

--- a/src/Control/Carrier/Pure.hs
+++ b/src/Control/Carrier/Pure.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE EmptyCase, MultiParamTypeClasses #-}
--- | A carrier for pure effects, used to kick off a stack of effects with 'run'.
+
+{- | A carrier for pure effects, used to kick off a stack of effects with 'run'.
+-}
+
 module Control.Carrier.Pure
 ( -- * Pure effect
   module Control.Effect.Pure
@@ -15,6 +18,8 @@ import Control.Monad.Fix
 import Data.Coerce
 
 -- | Run an action exhausted of effects to produce its final result value.
+--
+-- @since 1.0.0.0
 run :: PureC a -> a
 run = runPureC
 {-# INLINE run #-}

--- a/src/Control/Carrier/Pure.hs
+++ b/src/Control/Carrier/Pure.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyCase, MultiParamTypeClasses #-}
+-- | A carrier for pure effects, used to kick off a stack of effects with 'run'.
 module Control.Carrier.Pure
 ( -- * Pure effect
   module Control.Effect.Pure

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for 'Reader' effects.
--}
+-- | A carrier for 'Reader' effects.
 
 module Control.Carrier.Reader
 ( -- * Reader effect

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -33,6 +33,7 @@ runReader :: r -> ReaderC r m a -> m a
 runReader r c = runReaderC c r
 {-# INLINE runReader #-}
 
+-- | @since 1.0.0.0
 newtype ReaderC r m a = ReaderC { runReaderC :: r -> m a }
   deriving (Functor)
 

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+
+{- | A carrier for 'Reader' effects.
+-}
+
 module Control.Carrier.Reader
 ( -- * Reader effect
   module Control.Effect.Reader
@@ -23,6 +27,8 @@ import Control.Monad.Trans.Class
 -- | Run a 'Reader' effect with the passed environment value.
 --
 --   prop> run (runReader a (pure b)) === b
+--
+-- @since 1.0.0.0
 runReader :: r -> ReaderC r m a -> m a
 runReader r c = runReaderC c r
 {-# INLINE runReader #-}

--- a/src/Control/Carrier/Resource.hs
+++ b/src/Control/Carrier/Resource.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+-- | Provides a carrier for a 'Resource' effect. This carrier is implemented atop 'Control.Exception.catch'
+-- from "Control.Exception" and is thus safe in the presence of asynchronous exceptions.
 module Control.Carrier.Resource
 ( -- * Resource effect
   module Control.Effect.Resource

--- a/src/Control/Carrier/Resource.hs
+++ b/src/Control/Carrier/Resource.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
--- | Provides a carrier for a 'Resource' effect. This carrier is implemented atop 'Control.Exception.catch'
--- from "Control.Exception" and is thus safe in the presence of asynchronous exceptions.
+
+{- | Provides a carrier for a 'Resource' effect. This carrier is implemented atop 'Control.Exception.catch' from "Control.Exception" and is thus safe in the presence of asynchronous exceptions.
+-}
+
 module Control.Carrier.Resource
 ( -- * Resource effect
   module Control.Effect.Resource
@@ -41,6 +43,8 @@ unliftResource handler = runReader (UnliftIO handler) . runResourceC
 --   . runState @Int 1
 --   $ myComputation
 -- @
+--
+-- @since 1.0.0.0
 runResource :: MonadUnliftIO m
             => ResourceC m a
             -> m a

--- a/src/Control/Carrier/Resource.hs
+++ b/src/Control/Carrier/Resource.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
-{- | Provides a carrier for a 'Resource' effect. This carrier is implemented atop 'Control.Exception.catch' from "Control.Exception" and is thus safe in the presence of asynchronous exceptions.
--}
-
+-- | Provides a carrier for a 'Resource' effect. This carrier is implemented atop 'Control.Exception.catch' from "Control.Exception" and is thus safe in the presence of asynchronous exceptions.
 module Control.Carrier.Resource
 ( -- * Resource effect
   module Control.Effect.Resource

--- a/src/Control/Carrier/Resumable/Either.hs
+++ b/src/Control/Carrier/Resumable/Either.hs
@@ -35,6 +35,7 @@ import Data.Functor.Classes
 runResumable :: ResumableC err m a -> m (Either (SomeError err) a)
 runResumable = runError . runResumableC
 
+-- | @since 1.0.0.0
 newtype ResumableC err m a = ResumableC { runResumableC :: ErrorC (SomeError err) m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Resumable/Either.hs
+++ b/src/Control/Carrier/Resumable/Either.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | Provides a carrier for 'Resumable' that disallows resumption of exceptions.
+-- This can be useful when debugging or intercepting the behavior of a computation
+-- that invokes resumability.
 module Control.Carrier.Resumable.Either
 ( -- * Resumable effect
   module Control.Effect.Resumable

--- a/src/Control/Carrier/Resumable/Either.hs
+++ b/src/Control/Carrier/Resumable/Either.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | Provides a carrier for 'Resumable' that disallows resumption of exceptions.
--- This can be useful when debugging or intercepting the behavior of a computation
--- that invokes resumability.
+{- | A carrier for 'Resumable' that disallows resumption of exceptions.
+
+This can be useful when debugging or intercepting the behavior of a computation that invokes resumability.
+-}
 module Control.Carrier.Resumable.Either
 ( -- * Resumable effect
   module Control.Effect.Resumable
@@ -29,6 +30,8 @@ import Data.Functor.Classes
 -- | Run a 'Resumable' effect, returning uncaught errors in 'Left' and successful computations’ values in 'Right'.
 --
 --   prop> run (runResumable (pure a)) === Right @(SomeError Identity) @Int a
+--
+-- @since 1.0.0.0
 runResumable :: ResumableC err m a -> m (Either (SomeError err) a)
 runResumable = runError . runResumableC
 

--- a/src/Control/Carrier/Resumable/Resume.hs
+++ b/src/Control/Carrier/Resumable/Resume.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
-{- | Provides a carrier for 'Resumable' that can, given a handler function, resume the computation that threw an exception.
--}
+-- | Provides a carrier for 'Resumable' that can, given a handler function, resume the computation that threw an exception.
 module Control.Carrier.Resumable.Resume
 ( -- * Resumable effect
   module Control.Effect.Resumable

--- a/src/Control/Carrier/Resumable/Resume.hs
+++ b/src/Control/Carrier/Resumable/Resume.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
--- | Provides a carrier for 'Resumable' that can, given a handler function, resume
--- the computation that threw an exception.
+
+{- | Provides a carrier for 'Resumable' that can, given a handler function, resume the computation that threw an exception.
+-}
 module Control.Carrier.Resumable.Resume
 ( -- * Resumable effect
   module Control.Effect.Resumable
@@ -30,6 +31,8 @@ import Control.Monad.Trans.Class
 --
 --   prop> run (runResumable (\ (Err b) -> pure (1 + b)) (pure a)) === a
 --   prop> run (runResumable (\ (Err b) -> pure (1 + b)) (throwResumable (Err a))) === 1 + a
+--
+-- @since 1.0.0.0
 runResumable
   :: (forall x . err x -> m x)
   -> ResumableC err m a

--- a/src/Control/Carrier/Resumable/Resume.hs
+++ b/src/Control/Carrier/Resumable/Resume.hs
@@ -39,6 +39,7 @@ runResumable
   -> m a
 runResumable with = runReader (Handler with) . runResumableC
 
+-- | @since 1.0.0.0
 newtype ResumableC err m a = ResumableC { runResumableC :: ReaderC (Handler err m) m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 

--- a/src/Control/Carrier/Resumable/Resume.hs
+++ b/src/Control/Carrier/Resumable/Resume.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+-- | Provides a carrier for 'Resumable' that can, given a handler function, resume
+-- the computation that threw an exception.
 module Control.Carrier.Resumable.Resume
 ( -- * Resumable effect
   module Control.Effect.Resumable

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -27,6 +27,7 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
+-- | @since 1.0.0.0
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
 
 instance Functor m => Functor (StateC s m) where

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for the 'Control.Effect.State.State' effect that refrains from evaluating
--- its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but
--- allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
---
--- Note that the parameter order in 'runState', 'evalState', and 'execState'
--- is reversed compared the equivalent functions provided by @transformers@.
--- This is an intentional decision made to enable the composition of effect
--- handlers with '.' without invoking 'flip'.
+
+{- | A carrier for the 'Control.Effect.State.State' effect that refrains from evaluating its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
+
+Note that the parameter order in 'runState', 'evalState', and 'execState' is reversed compared the equivalent functions provided by @transformers@. This is an intentional decision made to enable the composition of effect handlers with '.' without invoking 'flip'.
+-}
+
 module Control.Carrier.State.Lazy
 ( -- * State effect
   module State
@@ -88,6 +86,8 @@ instance (Carrier sig m, Effect sig) => Carrier (State s :+: sig) (StateC s m) w
 --
 --   prop> run (runState a (pure b)) === (a, b)
 --   prop> take 5 . snd . run $ runState () (traverse pure [1..]) === [1,2,3,4,5]
+--
+-- @since 1.0.0.0
 runState :: s -> StateC s m a -> m (s, a)
 runState s c = runStateC c s
 {-# INLINE[3] runState #-}
@@ -95,6 +95,8 @@ runState s c = runStateC c s
 -- | Run a lazy 'State' effect, yielding the result value and discarding the final state.
 --
 --   prop> run (evalState a (pure b)) === b
+--
+-- @since 1.0.0.0
 evalState :: forall s m a . Functor m => s -> StateC s m a -> m a
 evalState s = fmap snd . runState s
 {-# INLINE[3] evalState #-}
@@ -102,6 +104,8 @@ evalState s = fmap snd . runState s
 -- | Run a lazy 'State' effect, yielding the final state and discarding the return value.
 --
 --   prop> run (execState a (pure b)) === a
+--
+-- @since 1.0.0.0
 execState :: forall s m a . Functor m => s -> StateC s m a -> m s
 execState s = fmap fst . runState s
 {-# INLINE[3] execState #-}

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for the 'Control.Effect.State.State' effect that refrains from evaluating its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
+{- | A carrier for the 'State' effect that refrains from evaluating its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
 
 Note that the parameter order in 'runState', 'evalState', and 'execState' is reversed compared the equivalent functions provided by @transformers@. This is an intentional decision made to enable the composition of effect handlers with '.' without invoking 'flip'.
 -}

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for the 'Control.Effect.State.State' effect that refrains from evaluating
+-- its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but
+-- allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
 module Control.Carrier.State.Lazy
 ( -- * State effect
   module State

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -2,6 +2,11 @@
 -- | A carrier for the 'Control.Effect.State.State' effect that refrains from evaluating
 -- its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but
 -- allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
+--
+-- Note that the parameter order in 'runState', 'evalState', and 'execState'
+-- is reversed compared the equivalent functions provided by @transformers@.
+-- This is an intentional decision made to enable the composition of effect
+-- handlers with '.' without invoking 'flip'.
 module Control.Carrier.State.Lazy
 ( -- * State effect
   module State

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 -- | A carrier for the 'Control.Effect.State.State' effect. It evaluates its inner state
 -- strictly, which is the correct choice for the majority of use cases.
+--
+-- Note that the parameter order in 'runState', 'evalState', and 'execState'
+-- is reversed compared the equivalent functions provided by @transformers@.
+-- This is an intentional decision made to enable the composition of effect
+-- handlers with '.' without invoking 'flip'.
 module Control.Carrier.State.Strict
 ( -- * State effect
   module Control.Effect.State

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -54,6 +54,7 @@ execState s = fmap fst . runState s
 {-# INLINE[3] execState #-}
 
 
+-- | @since 1.0.0.0
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
   deriving (Functor)
 

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for the 'Control.Effect.State.State' effect. It evaluates its inner state
+-- strictly, which is the correct choice for the majority of use cases.
 module Control.Carrier.State.Strict
 ( -- * State effect
   module Control.Effect.State

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for the 'Control.Effect.State.State' effect. It evaluates its inner state
--- strictly, which is the correct choice for the majority of use cases.
---
--- Note that the parameter order in 'runState', 'evalState', and 'execState'
--- is reversed compared the equivalent functions provided by @transformers@.
--- This is an intentional decision made to enable the composition of effect
--- handlers with '.' without invoking 'flip'.
+
+{- | A carrier for the 'State' effect. It evaluates its inner state strictly, which is the correct choice for the majority of use cases.
+
+Note that the parameter order in 'runState', 'evalState', and 'execState' is reversed compared the equivalent functions provided by @transformers@. This is an intentional decision made to enable the composition of effect handlers with '.' without invoking 'flip'.
+-}
 module Control.Carrier.State.Strict
 ( -- * State effect
   module Control.Effect.State
@@ -31,6 +29,8 @@ import Control.Monad.Trans.Class
 -- | Run a 'State' effect starting from the passed value.
 --
 --   prop> run (runState a (pure b)) === (a, b)
+--
+-- @since 1.0.0.0
 runState :: s -> StateC s m a -> m (s, a)
 runState s x = runStateC x s
 {-# INLINE[3] runState #-}
@@ -38,6 +38,8 @@ runState s x = runStateC x s
 -- | Run a 'State' effect, yielding the result value and discarding the final state.
 --
 --   prop> run (evalState a (pure b)) === b
+--
+-- @since 1.0.0.0
 evalState :: forall s m a . Functor m => s -> StateC s m a -> m a
 evalState s = fmap snd . runState s
 {-# INLINE[3] evalState #-}
@@ -45,6 +47,8 @@ evalState s = fmap snd . runState s
 -- | Run a 'State' effect, yielding the final state and discarding the return value.
 --
 --   prop> run (execState a (pure b)) === a
+--
+-- @since 1.0.0.0
 execState :: forall s m a . Functor m => s -> StateC s m a -> m s
 execState s = fmap fst . runState s
 {-# INLINE[3] execState #-}

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -31,6 +31,7 @@ import Control.Monad.Trans.Class
 runTrace :: TraceC m a -> m a
 runTrace = runTraceC
 
+-- | @since 1.0.0.0
 newtype TraceC m a = TraceC { runTraceC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful
--- when you wish to disable tracing without removing all trace statements.
+
+{- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful when you wish to disable tracing without removing all trace statements.
+-}
+
 module Control.Carrier.Trace.Ignoring
 ( -- * Trace effect
   module Control.Effect.Trace
@@ -24,6 +26,8 @@ import Control.Monad.Trans.Class
 -- | Run a 'Trace' effect, ignoring all traces.
 --
 --   prop> run (runTrace (trace a *> pure b)) === b
+--
+-- @since 1.0.0.0
 runTrace :: TraceC m a -> m a
 runTrace = runTraceC
 

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful
+-- when you wish to disable tracing without removing all trace statements.
 module Control.Carrier.Trace.Ignoring
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful when you wish to disable tracing without removing all trace statements.
--}
-
+-- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful when you wish to disable tracing without removing all trace statements.
 module Control.Carrier.Trace.Ignoring
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
--}
-
+-- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
 module Control.Carrier.Trace.Printing
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
 module Control.Carrier.Trace.Printing
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -28,6 +28,7 @@ import System.IO
 runTrace :: TraceC m a -> m a
 runTrace = runTraceC
 
+-- | @since 1.0.0.0
 newtype TraceC m a = TraceC { runTraceC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
+
+{- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
+-}
+
 module Control.Carrier.Trace.Printing
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
+
+{- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
+-}
+
 module Control.Carrier.Trace.Returning
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -31,6 +31,7 @@ import Data.Bifunctor (first)
 runTrace :: Functor m => TraceC m a -> m ([String], a)
 runTrace = fmap (first reverse) . runState [] . runTraceC
 
+-- | @since 1.0.0.0
 newtype TraceC m a = TraceC { runTraceC :: StateC [String] m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
 module Control.Carrier.Trace.Returning
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
--}
-
+-- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
 module Control.Carrier.Trace.Returning
 ( -- * Trace effect
   module Control.Effect.Trace

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -42,7 +42,7 @@ execWriter = fmap fst . runWriter
 {-# INLINE execWriter #-}
 
 
--- | A space-efficient carrier for 'Writer' effects, implemented atop 'Control.Carrier.State.Strict'.
+-- | A space-efficient carrier for 'Writer' effects, implemented atop "Control.Carrier.State.Strict".
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
--- | Provides 'WriterC', a monadic carrier for 'Control.Effect.Writer' effects. This carrier
--- performs its append operations strictly and thus avoids the space leaks inherent in lazy
--- writer monads. This is based on a post Gabriel Gonzalez made to the Haskell mailing list:
--- <https://mail.haskell.org/pipermail/libraries/2013-March/019528.html>
+
+{- | A carrier for 'Writer' effects. This carrier performs its append operations strictly and thus avoids the space leaks inherent in lazy writer monads.
+
+This implementation is based on a post Gabriel Gonzalez made to the Haskell mailing list: <https://mail.haskell.org/pipermail/libraries/2013-March/019528.html>
+-}
+
 module Control.Carrier.Writer.Strict
 ( -- * Writer effect
   module Control.Effect.Writer

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
+-- | Provides 'WriterC', a monadic carrier for 'Control.Effect.Writer' effects. This carrier
+-- performs its append operations strictly and thus avoids the space leaks inherent in lazy
+-- writer monads. This is based on a post Gabriel Gonzalez made to the Haskell mailing list:
+-- <https://mail.haskell.org/pipermail/libraries/2013-March/019528.html>
 module Control.Carrier.Writer.Strict
 ( -- * Writer effect
   module Control.Effect.Writer
@@ -36,9 +40,7 @@ execWriter = fmap fst . runWriter
 {-# INLINE execWriter #-}
 
 
--- | A space-efficient carrier for 'Writer' effects.
---
---   This is based on a post Gabriel Gonzalez made to the Haskell mailing list: https://mail.haskell.org/pipermail/libraries/2013-March/019528.html
+-- | A space-efficient carrier for 'Writer' effects, implemented atop 'Control.Carrier.State.Strict'.
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -71,6 +71,7 @@ some a = (:) <$> a <*> many a
 some1 :: Has Choose sig m => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
 
+
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
--- | An effect modelling nondeterminism without failure (one or more successful results).
---
--- The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Choose' and
--- 'Control.Effect.Empty.Empty'.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Choose.Church.ChooseC".
--- * If 'Choose' is the last effect in a stack, it can be interpreted directly to a 'NonEmpty'.
---
+
+{- | An effect modelling nondeterminism without failure (one or more successful results).
+
+The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Choose' and 'Control.Effect.Empty.Empty'.
+
+Predefined carriers:
+
+* "Control.Carrier.Choose.Church.ChooseC".
+* If 'Choose' is the last effect in a stack, it can be interpreted directly to a 'NonEmpty'.
+-}
+
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -31,6 +31,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Semigroup as S
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 data Choose m k
   = Choose (Bool -> m k)
   deriving (Functor, Generic1)
@@ -39,28 +40,38 @@ instance HFunctor Choose
 instance Effect   Choose
 
 -- | Nondeterministically choose between two computations.
+--
+-- @since 1.0.0.0
 (<|>) :: Has Choose sig m => m a -> m a -> m a
 (<|>) a b = send (Choose (bool b a))
 
 infixl 3 <|>
 
 -- | Select between 'Just' the result of an operation, and 'Nothing'.
+--
+-- @since 1.0.0.0
 optional :: Has Choose sig m => m a -> m (Maybe a)
 optional a = Just <$> a <|> pure Nothing
 
 -- | Zero or more.
+--
+-- @since 1.0.0.0
 many :: Has Choose sig m => m a -> m [a]
 many a = go where go = (:) <$> a <*> go <|> pure []
 
 -- | One or more.
+--
+-- @since 1.0.0.0
 some :: Has Choose sig m => m a -> m [a]
 some a = (:) <$> a <*> many a
 
 -- | One or more, returning a 'NonEmpty' list of the results.
+--
+-- @since 1.0.0.0
 some1 :: Has Choose sig m => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
 
-
+-- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -6,7 +6,7 @@
 --
 -- Predefined carriers:
 --
--- * 'Control.Carrier.Choose.Church.ChooseC', from @Control.Carrier.Choose.Church@.
+-- * "Control.Carrier.Choose.Church.ChooseC".
 -- * If 'Choose' is the last effect in a stack, it can be interpreted directly to a 'NonEmpty'.
 --
 module Control.Effect.Choose

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -6,7 +6,7 @@ The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Choose' and 'Co
 
 Predefined carriers:
 
-* "Control.Carrier.Choose.Church.ChooseC".
+* "Control.Carrier.Choose.Church".
 * If 'Choose' is the last effect in a stack, it can be interpreted directly to a 'NonEmpty'.
 -}
 

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators #-}
+-- | Provides the 'HFunctor' and 'Effect' classes that an effect type implements
+-- so that a carrier monad can provide an instance of 'Carrier' for that type.
 module Control.Effect.Class
 ( HFunctor(..)
 , handleCoercible

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators #-}
 
-{- | Provides the 'HFunctor' and 'Effect' classes that an effect type implements so that a carrier monad can provide an instance of 'Carrier' for that type.
--}
-
+-- | Provides the 'HFunctor' and 'Effect' classes that an effect type implements so that a carrier monad can provide an instance of 'Carrier' for that type.
 module Control.Effect.Class
 ( HFunctor(..)
 , handleCoercible

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators #-}
--- | Provides the 'HFunctor' and 'Effect' classes that an effect type implements
--- so that a carrier monad can provide an instance of 'Carrier' for that type.
+
+{- | Provides the 'HFunctor' and 'Effect' classes that an effect type implements so that a carrier monad can provide an instance of 'Carrier' for that type.
+-}
+
 module Control.Effect.Class
 ( HFunctor(..)
 , handleCoercible

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -18,6 +18,8 @@ import GHC.Generics
 -- | Higher-order functors of kind @(* -> *) -> (* -> *)@ map functors to functors.
 --
 --   All effects must be 'HFunctor's.
+--
+-- @since 1.0.0.0
 class HFunctor h where
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
   --
@@ -31,6 +33,8 @@ class HFunctor h where
 -- | Thread a 'Coercible' carrier through an 'HFunctor'.
 --
 --   This is applicable whenever @f@ is 'Coercible' to @g@, e.g. simple @newtype@s.
+--
+-- @since 1.0.0.0
 handleCoercible :: (HFunctor sig, Functor f, Coercible f g) => sig f a -> sig g a
 handleCoercible = hmap coerce
 {-# INLINE handleCoercible #-}
@@ -42,6 +46,8 @@ handleCoercible = hmap coerce
 --   2. Support threading effects in higher-order positions through using the carrier’s suspended state.
 --
 -- All first-order effects (those without existential occurrences of @m@) admit a default definition of 'handle' provided a 'Generic1' instance is available for the effect.
+--
+-- @since 1.0.0.0
 class HFunctor sig => Effect sig where
   -- | Handle any effects in a signature by threading the carrier’s state all the way through to the continuation.
   handle :: (Functor f, Monad m)

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators #-}
 
--- | Provides the 'HFunctor' and 'Effect' classes that an effect type implements so that a carrier monad can provide an instance of 'Carrier' for that type.
+-- | Provides the 'HFunctor' and 'Effect' classes that effect types implement.
 module Control.Effect.Class
 ( HFunctor(..)
 , handleCoercible

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -18,6 +18,8 @@ module Control.Effect.Cull
 import Control.Carrier
 
 -- | 'Cull' effects are used with 'Choose' to provide control over branching.
+--
+-- @since 0.1.2.0
 data Cull m k
   = forall a . Cull (m a) (a -> m k)
 
@@ -37,6 +39,8 @@ instance Effect Cull where
 --   prop> run (runNonDetA (runCullA (cull (empty  <|> pure a)))) === [a]
 --   prop> run (runNonDetA (runCullA (cull (pure a <|> pure b) <|> pure c))) === [a, c]
 --   prop> run (runNonDetA (runCullA (cull (asum (map pure (repeat a)))))) === [a]
+--
+-- @since 0.1.2.0
 cull :: Has Cull sig m => m a -> m a
 cull m = send (Cull m pure)
 

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
--- | Provides an effect to cull choices in a given nondeterministic context.
--- This effect is used in concert with 'Control.Effect.Choose.Choose' or 'Control.Effect.NonDet.NonDet'.
--- Computations run inside a call to 'cull' will return at most one result.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Cull.Church"
+{- | Provides an effect to cull choices in a given nondeterministic context. This effect is used in concert with 'Control.Effect.Choose.Choose' or 'Control.Effect.NonDet.NonDet'.
+
+Computations run inside a call to 'cull' will return at most one result.
+
+Predefined carriers:
+
+* "Control.Carrier.Cull.Church"
+-}
 module Control.Effect.Cull
 ( -- * Cull effect
   Cull(..)

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,4 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+-- | Provides an effect to cull choices in a given nondeterministic context.
+-- This effect is used in concert with 'Control.Effect.Choose.Choose' or 'Control.Effect.NonDet.NonDet'.
+-- Computations run inside a call to 'cull' will return at most one result.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Cull.Church"
 module Control.Effect.Cull
 ( -- * Cull effect
   Cull(..)
@@ -25,10 +32,10 @@ instance Effect Cull where
 
 -- | Cull nondeterminism in the argument, returning at most one result.
 --
---   prop> run (runNonDet (runCull (cull (pure a <|> pure b)))) === [a]
---   prop> run (runNonDet (runCull (cull (empty  <|> pure a)))) === [a]
---   prop> run (runNonDet (runCull (cull (pure a <|> pure b) <|> pure c))) === [a, c]
---   prop> run (runNonDet (runCull (cull (asum (map pure (repeat a)))))) === [a]
+--   prop> run (runNonDetA (runCullA (cull (pure a <|> pure b)))) === [a]
+--   prop> run (runNonDetA (runCullA (cull (empty  <|> pure a)))) === [a]
+--   prop> run (runNonDetA (runCullA (cull (pure a <|> pure b) <|> pure c))) === [a, c]
+--   prop> run (runNonDetA (runCullA (cull (asum (map pure (repeat a)))))) === [a]
 cull :: Has Cull sig m => m a -> m a
 cull m = send (Cull m pure)
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -24,7 +24,7 @@ import Control.Carrier
 
 -- | 'Cut' effects are used with 'Choose' to provide control over backtracking.
 --
--- @since 1.0.0.0
+-- @since 0.1.2.0
 data Cut m k
   = Cutfail
   | forall a . Call (m a) (a -> m k)
@@ -48,7 +48,7 @@ instance Effect Cut where
 --   prop> run (runNonDet (runCut (cutfail <|> pure a))) === []
 --   prop> run (runNonDet (runCut (pure a <|> cutfail))) === [a]
 --
--- @since 1.0.0.0
+-- @since 0.1.2.0
 cutfail :: Has Cut sig m => m a
 cutfail = send Cutfail
 {-# INLINE cutfail #-}
@@ -57,7 +57,7 @@ cutfail = send Cutfail
 --
 --   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) === [b]
 --
--- @since 1.0.0.0
+-- @since 0.1.2.0
 call :: Has Cut sig m => m a -> m a
 call m = send (Call m pure)
 {-# INLINE call #-}
@@ -68,7 +68,7 @@ call m = send (Call m pure)
 --   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) === [a]
 --   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) === []
 --
--- @since 1.0.0.0
+-- @since 0.1.2.0
 cut :: (Alternative m, Has Cut sig m) => m ()
 cut = pure () <|> cutfail
 {-# INLINE cut #-}

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
--- | Provides an effect to delimit backtracking in a given nondeterministic context.
--- This effect is used in concert with 'Control.Effect.Choose.Choose' or 'Control.Effect.NonDet.NonDet'.
--- Computations that signal failure with 'cutfail' prevent backtracking within the nearest enclosing 'call'.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Cut.Church"
+
+{- | Provides an effect to delimit backtracking in a given nondeterministic context. This effect is used in concert with 'Control.Effect.Choose.Choose' or 'Control.Effect.NonDet.NonDet'.
+
+Computations that signal failure with 'cutfail' prevent backtracking within the nearest enclosing 'call'.
+
+Predefined carriers:
+
+* "Control.Carrier.Cut.Church"
+-}
+
 module Control.Effect.Cut
 ( -- * Cut effect
   Cut(..)

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -23,6 +23,8 @@ import Control.Applicative (Alternative(..))
 import Control.Carrier
 
 -- | 'Cut' effects are used with 'Choose' to provide control over backtracking.
+--
+-- @since 1.0.0.0
 data Cut m k
   = Cutfail
   | forall a . Call (m a) (a -> m k)
@@ -45,6 +47,8 @@ instance Effect Cut where
 --
 --   prop> run (runNonDet (runCut (cutfail <|> pure a))) === []
 --   prop> run (runNonDet (runCut (pure a <|> cutfail))) === [a]
+--
+-- @since 1.0.0.0
 cutfail :: Has Cut sig m => m a
 cutfail = send Cutfail
 {-# INLINE cutfail #-}
@@ -52,6 +56,8 @@ cutfail = send Cutfail
 -- | Delimit the effect of 'cutfail's, allowing backtracking to resume.
 --
 --   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) === [b]
+--
+-- @since 1.0.0.0
 call :: Has Cut sig m => m a -> m a
 call m = send (Call m pure)
 {-# INLINE call #-}
@@ -61,6 +67,8 @@ call m = send (Call m pure)
 --   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) === [a, b]
 --   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) === [a]
 --   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) === []
+--
+-- @since 1.0.0.0
 cut :: (Alternative m, Has Cut sig m) => m ()
 cut = pure () <|> cutfail
 {-# INLINE cut #-}

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,4 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+-- | Provides an effect to delimit backtracking in a given nondeterministic context.
+-- This effect is used in concert with 'Control.Effect.Choose.Choose' or 'Control.Effect.NonDet.NonDet'.
+-- Computations that signal failure with 'cutfail' prevent backtracking within the nearest enclosing 'call'.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Cut.Church"
 module Control.Effect.Cut
 ( -- * Cut effect
   Cut(..)

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -22,6 +22,7 @@ module Control.Effect.Empty
 import {-# SOURCE #-} Control.Carrier
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 data Empty (m :: * -> *) k = Empty
   deriving (Functor, Generic1)
 
@@ -31,10 +32,14 @@ instance Effect   Empty
 -- | Abort the computation.
 --
 --   prop> run (runEmpty empty) === Nothing
+--
+-- @since 1.0.0.0
 empty :: Has Empty sig m => m a
 empty = send Empty
 
 -- | Conditional failure, returning only if the condition is 'True'.
+--
+-- @since 1.0.0.0
 guard :: Has Empty sig m => Bool -> m ()
 guard True  = pure ()
 guard False = empty

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -7,7 +7,7 @@
 --
 -- Predefined carriers:
 --
--- * 'Control.Carrier.Empty.Maybe.EmptyC', from @Control.Carrier.Empty.Maybe@.
+-- * "Control.Carrier.Empty.Maybe.EmptyC".
 -- * If 'Empty' is the last effect in a stack, it can be interpreted directly to a 'Maybe'.
 --
 module Control.Effect.Empty

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
--- | An effect modelling nondeterminism without choice (success or failure).
---
--- This can be seen as similar to 'Control.Effect.Fail.Fail', but without an error message.
--- The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Empty' and
--- 'Control.Effect.Choice.Choice'.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Empty.Maybe.EmptyC".
--- * If 'Empty' is the last effect in a stack, it can be interpreted directly to a 'Maybe'.
---
+
+{- | An effect modelling nondeterminism without choice (success or failure).
+
+This can be seen as similar to 'Control.Effect.Fail.Fail', but without an error message. The 'Control.Effect.NonDet.NonDet' effect is the composition of 'Empty' and 'Control.Effect.Choice.Choice'.
+
+Predefined carriers:
+
+* "Control.Carrier.Empty.Maybe.EmptyC".
+* If 'Empty' is the last effect in a stack, it can be interpreted directly to a 'Maybe'.
+-}
+
 module Control.Effect.Empty
 ( -- * Empty effect
   Empty(..)

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -21,7 +21,7 @@ module Control.Effect.Error
 
 import {-# SOURCE #-} Control.Carrier
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data Error exc m k
   = Throw exc
   | forall b . Catch (m b) (exc -> m b) (b -> m k)
@@ -39,6 +39,8 @@ instance Effect (Error exc) where
 -- | Throw an error, escaping the current computation up to the nearest 'catchError' (if any).
 --
 --   prop> run (runError (throwError a)) === Left @Int @Int a
+--
+-- @since 0.1.0.0
 throwError :: Has (Error exc) sig m => exc -> m a
 throwError = send . Throw
 
@@ -53,6 +55,8 @@ throwError = send . Throw
 --   prop> run (runError (pure a `catchError` pure)) === Right a
 --   prop> run (runError (throwError a `catchError` pure)) === Right @Int @Int a
 --   prop> run (runError (throwError a `catchError` (throwError @Int))) === Left @Int @Int a
+--
+-- @since 0.1.0.0
 catchError :: Has (Error exc) sig m => m a -> (exc -> m a) -> m a
 catchError m h = send (Catch m h pure)
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,17 +1,15 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
--- | An effect modelling failure with a descriptive error message.
---
--- This effect is similar to the traditional @MonadError@ typeclass, though it allows
--- the presence of multiple @Error@ effects in a given effect stack. It offers precise exception
--- handling, rather than the dynamic exception hierarchy provided by the @exceptions@ package.
--- The 'Control.Effect.Resource' effect or the @fused-effects-exceptions@ package may be more
--- suitable for handling dynamic/impure effect handling.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Error.Either.ErrorC".
--- * If 'Error' @e@ is the last effect in a stack, it can be interpreted directly to an 'Either' @e@.
---
+
+{- | An effect modelling failure with a descriptive error message.
+
+This effect is similar to the traditional @MonadError@ typeclass, though it allows the presence of multiple @Error@ effects in a given effect stack. It offers precise exception handling, rather than the dynamic exception hierarchy provided by the @exceptions@ package. The 'Control.Effect.Resource' effect or the @fused-effects-exceptions@ package may be more suitable for handling dynamic/impure effect handling.
+
+Predefined carriers:
+
+* "Control.Carrier.Error.Either.ErrorC".
+* If 'Error' @e@ is the last effect in a stack, it can be interpreted directly to an 'Either' @e@.
+-}
+
 module Control.Effect.Error
 ( -- * Error effect
   Error(..)

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 
-{- | An effect modelling failure with a descriptive error message.
+{- | An effect modelling catchable failure with a polymorphic error type.
 
 This effect is similar to the traditional @MonadError@ typeclass, though it allows the presence of multiple @Error@ effects in a given effect stack. It offers precise exception handling, rather than the dynamic exception hierarchy provided by the @exceptions@ package. The 'Control.Effect.Resource' effect or the @fused-effects-exceptions@ package may be more suitable for handling dynamic/impure effect handling.
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -9,7 +9,7 @@
 --
 -- Predefined carriers:
 --
--- * 'Control.Carrier.Error.Either.ErrorC', from @Control.Carrier.Error.Either@.
+-- * "Control.Carrier.Error.Either.ErrorC".
 -- * If 'Error' @e@ is the last effect in a stack, it can be interpreted directly to an 'Either' @e@.
 --
 module Control.Effect.Error

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -21,6 +21,7 @@ module Control.Effect.Error
 
 import {-# SOURCE #-} Control.Carrier
 
+-- | @since 1.0.0.0
 data Error exc m k
   = Throw exc
   | forall b . Catch (m b) (exc -> m b) (b -> m k)
@@ -46,7 +47,7 @@ throwError = send . Throw
 -- Errors thrown by the handler will escape up to the nearest enclosing 'catchError' (if any).
 -- Note that this effect does /not/ handle errors thrown from impure contexts such as IO,
 -- nor will it handle exceptions thrown from pure code. If you need to handle IO-based errors,
--- consider if 'Control.Effect.Resource' fits your use case; if not, use 'liftIO' with
+-- consider if 'Control.Effect.Resource' fits your use case; if not, use 'Control.Monad.IO.Class.liftIO' with
 -- 'Control.Exception.try' or use 'Control.Exception.catch' from outside the effect invocation.
 --
 --   prop> run (runError (pure a `catchError` pure)) === Right a

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -21,6 +21,7 @@ import Control.Carrier
 import qualified Control.Monad.Fail as Fail
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 newtype Fail (m :: * -> *) k = Fail String
   deriving (Functor, Generic1)
 

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,4 +1,14 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, KindSignatures #-}
+
+{- | An effect providing failure with an error message.
+
+This effect is invoked through the 'Fail.fail' method from 'Fail.MonadFail'.
+
+Predefined carriers:
+
+* "Control.Carrier.Fail.Either"
+-}
+
 module Control.Effect.Fail
 ( -- * Fail effect
   Fail(..)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -18,7 +18,7 @@ module Control.Effect.Fresh
 
 import Control.Carrier
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data Fresh m k
   = Fresh (Int -> m k)
   | forall b . Reset (m b) (b -> m k)
@@ -37,7 +37,7 @@ instance Effect Fresh where
 --
 --   prop> run (runFresh (replicateM n fresh)) === nub (run (runFresh (replicateM n fresh)))
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 fresh :: Has Fresh sig m => m Int
 fresh = send (Fresh pure)
 
@@ -45,7 +45,7 @@ fresh = send (Fresh pure)
 --
 --   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) === run (runFresh (replicateM n fresh))
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 resetFresh :: Has Fresh sig m => m a -> m a
 resetFresh m = send (Reset m pure)
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -18,6 +18,7 @@ module Control.Effect.Fresh
 
 import Control.Carrier
 
+-- | @since 1.0.0.0
 data Fresh m k
   = Fresh (Int -> m k)
   | forall b . Reset (m b) (b -> m k)
@@ -35,12 +36,16 @@ instance Effect Fresh where
 -- | Produce a fresh (i.e. unique) 'Int'.
 --
 --   prop> run (runFresh (replicateM n fresh)) === nub (run (runFresh (replicateM n fresh)))
+--
+-- @since 1.0.0.0
 fresh :: Has Fresh sig m => m Int
 fresh = send (Fresh pure)
 
 -- | Reset the fresh counter after running a computation.
 --
 --   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) === run (runFresh (replicateM n fresh))
+--
+-- @since 1.0.0.0
 resetFresh :: Has Fresh sig m => m a -> m a
 resetFresh m = send (Reset m pure)
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -2,6 +2,10 @@
 -- | This effect provides source to an infinite source of 'Int' values, suitable
 -- for generating "fresh" values to uniquely identify data without needing to invoke
 -- random numbers or impure IO.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Fresh.Strict".
 module Control.Effect.Fresh
 ( -- * Fresh effect
   Fresh(..)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
--- | This effect provides source to an infinite source of 'Int' values, suitable
--- for generating "fresh" values to uniquely identify data without needing to invoke
--- random numbers or impure IO.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Fresh.Strict".
+
+{- | This effect provides source to an infinite source of 'Int' values, suitable for generating "fresh" values to uniquely identify data without needing to invoke random numbers or impure IO.
+
+Predefined carriers:
+
+* "Control.Carrier.Fresh.Strict".
+
+-}
 module Control.Effect.Fresh
 ( -- * Fresh effect
   Fresh(..)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
--- | Provides a mechanism to kick off the evaluation of an effect stack that
--- takes place in a monadic context.
---
--- 'Lift' effects are always the last effect in a given effect stack.
--- These stacks are invoked with 'Control.Effect.Lift.runM'.
--- The 'Control.Effect.Pure.Pure' effect is equivalent to @Lift Identity@.
+
+{- | Provides a mechanism to kick off the evaluation of an effect stack that takes place in a monadic context.
+
+'Lift' effects are always the last effect in a given effect stack. These stacks are invoked with 'Control.Effect.Lift.runM'. The 'Control.Effect.Pure.Pure' effect is equivalent to @Lift Identity@.
+-}
+
 module Control.Effect.Lift
 ( -- * Lift effect
   Lift(..)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
+-- | Provides a mechanism to kick off the evaluation of an effect stack that
+-- takes place in a monadic context.
+--
+-- 'Lift' effects are always the last effect in a given effect stack.
+-- These stacks are invoked with 'Control.Effect.Lift.runM'.
+-- The 'Control.Effect.Pure.Pure' effect is equivalent to @Lift Identity@.
 module Control.Effect.Lift
 ( -- * Lift effect
   Lift(..)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -16,7 +16,7 @@ module Control.Effect.Lift
 import Control.Carrier
 import GHC.Generics
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 newtype Lift sig m k = Lift { unLift :: sig (m k) }
   deriving (Functor, Generic1)
 

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -16,6 +16,7 @@ module Control.Effect.Lift
 import Control.Carrier
 import GHC.Generics
 
+-- | @since 1.0.0.0
 newtype Lift sig m k = Lift { unLift :: sig (m k) }
   deriving (Functor, Generic1)
 
@@ -25,5 +26,7 @@ instance Functor m => Effect   (Lift m)
 -- | Given a @Lift n@ constraint in a signature carried by @m@, 'sendM'
 -- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
 -- similar to @lift@ from the @MonadTrans@ typeclass.
+--
+-- @since 1.0.0.0
 sendM :: (Has (Lift n) sig m, Functor n) => n a -> m a
 sendM = send . Lift . fmap pure

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -7,7 +7,7 @@ Nondeterministic operations are encapsulated by the 'Alternative' class, where '
 Predefined carriers:
 
 * "Control.Carrier.NonDet.Church", which collects all branches' results using an @Alternative@ functor.
-* "Control.Carrier.NonDet.Maybe", which terminates upon encountering the first successful result.
+* "Control.Carrier.NonDet.Maybe", which returns at most one result, in `Maybe`.
 * If 'NonDet' is the last effect in a stack, it can be interpreted directly into a @[]@.
 -}
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -35,6 +35,8 @@ import Data.Coerce
 import Data.Monoid (Alt(..))
 
 -- | The nondeterminism effect is the composition of 'Empty' and 'Choose' effects.
+--
+-- @since 1.0.0.0
 type NonDet = Empty :+: Choose
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.
@@ -50,10 +52,13 @@ type NonDet = Empty :+: Choose
 --     pure (a, b, c)
 -- @
 --
+-- @since 1.0.0.0
 oneOf :: (Foldable t, Alternative m) => t a -> m a
 oneOf = foldMapA pure
 
 -- | Map a 'Foldable' collection of values into a nondeterministic computation using the supplied action.
+--
+-- @since 1.0.0.0
 foldMapA :: (Foldable t, Alternative m) => (a -> m b) -> t a -> m b
 foldMapA f = getAlt #. foldMap (Alt #. f)
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,20 +1,16 @@
 {-# LANGUAGE TypeOperators #-}
--- | An effect modelling nondeterminism with choice and failure.
---
--- Nondeterministic operations are encapsulated by the 'Control.Applicative.Alternative'
--- class, where 'Control.Applicative.empty' represents failure and 'Control.Applicative.<|>'
--- represents choice. This module reexports the 'Alternative' interface. If you can't or
--- don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and
--- 'Control.Effect.Choose.<|>' effects (from 'Control.Effect.Empty' and 'Control.Effect.Choose')
--- directly, as the 'NonDet' effect is the composition of 'Control.Effect.Choose.Choose' and
--- 'Control.Effect.Empty.Empty'.
---
--- Predefined carriers:
---
--- * "Control.Carrier.NonDet.Church", which collects all branches' results using an @Alternative@ functor.
--- * "Control.Carrier.NonDet.Maybe", which terminates upon encountering the first successful result.
--- * If 'NonDet' is the last effect in a stack, it can be interpreted directly to an @[]@ value.
---
+
+{- | An effect modelling nondeterminism with choice and failure.
+
+Nondeterministic operations are encapsulated by the 'Alternative' class, where 'empty' represents failure and '<|>' represents choice. This module reexports the 'Alternative' interface. If you can't or don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and 'Control.Effect.Choose.<|>' effects (from 'Control.Effect.Empty' and 'Control.Effect.Choose') directly, as the 'NonDet' effect is the composition of 'Choose' and 'Empty'.
+
+Predefined carriers:
+
+* "Control.Carrier.NonDet.Church", which collects all branches' results using an @Alternative@ functor.
+* "Control.Carrier.NonDet.Maybe", which terminates upon encountering the first successful result.
+* If 'NonDet' is the last effect in a stack, it can be interpreted directly to an @[]@ value.
+-}
+
 module Control.Effect.NonDet
 ( -- * NonDet effects
   NonDet

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -36,7 +36,7 @@ import Data.Monoid (Alt(..))
 
 -- | The nondeterminism effect is the composition of 'Empty' and 'Choose' effects.
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 type NonDet = Empty :+: Choose
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,4 +1,20 @@
 {-# LANGUAGE TypeOperators #-}
+-- | An effect modelling nondeterminism with choice and failure.
+--
+-- Nondeterministic operations are encapsulated by the 'Control.Applicative.Alternative'
+-- class, where 'Control.Applicative.empty' represents failure and 'Control.Applicative.<|>'
+-- represents choice. This module reexports the 'Alternative' interface. If you can't or
+-- don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and
+-- 'Control.Effect.Choose.<|>' effects (from 'Control.Effect.Empty' and 'Control.Effect.Choose')
+-- directly, as the 'NonDet' effect is the composition of 'Control.Effect.Choose.Choose' and
+-- 'Control.Effect.Empty.Empty'.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.NonDet.Church", which collects all branches' results using an @Alternative@ functor.
+-- * "Control.Carrier.NonDet.Maybe", which terminates upon encountering the first successful result.
+-- * If 'NonDet' is the last effect in a stack, it can be interpreted directly to an @[]@ value.
+--
 module Control.Effect.NonDet
 ( -- * NonDet effects
   NonDet
@@ -23,12 +39,6 @@ import Data.Coerce
 import Data.Monoid (Alt(..))
 
 -- | The nondeterminism effect is the composition of 'Empty' and 'Choose' effects.
--- Nondeterministic operations are encapsulated by the 'Control.Applicative.Alternative'
--- class, where 'Control.Applicative.empty' represents failure and 'Control.Applicative.<|>'
--- represents choice. This module reexports the 'Alternative' interface. If you can't or
--- don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and
--- 'Control.Effect.Choose.<|>' effects (from 'Control.Effect.Empty' and 'Control.Effect.Choose')
--- directly.
 type NonDet = Empty :+: Choose
 
 -- | Nondeterministically choose an element from a 'Foldable' collection.

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -2,7 +2,7 @@
 
 {- | An effect modelling nondeterminism with choice and failure.
 
-Nondeterministic operations are encapsulated by the 'Alternative' class, where 'empty' represents failure and '<|>' represents choice. This module reexports the 'Alternative' interface. If you can't or don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and 'Control.Effect.Choose.<|>' effects (from "Control.Effect.Empty" and "Control.Effect.Choose" respectively) directly, as the 'NonDet' effect is the composition of 'Choose' and 'Empty'.
+Nondeterministic operations are encapsulated by the 'Alternative' class, where 'empty' represents failure and '<|>' represents choice. This module re-exports the 'Alternative' interface. If you can't or don't want to use 'Alternative', you can use the 'Control.Effect.Empty.empty' and 'Control.Effect.Choose.<|>' operations (from "Control.Effect.Empty" and "Control.Effect.Choose" respectively) directly, as the 'NonDet' effect is the composition of 'Choose' and 'Empty'.
 
 Predefined carriers:
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -8,7 +8,7 @@ Predefined carriers:
 
 * "Control.Carrier.NonDet.Church", which collects all branches' results using an @Alternative@ functor.
 * "Control.Carrier.NonDet.Maybe", which terminates upon encountering the first successful result.
-* If 'NonDet' is the last effect in a stack, it can be interpreted directly to an @[]@ value.
+* If 'NonDet' is the last effect in a stack, it can be interpreted directly into a @[]@.
 -}
 
 module Control.Effect.NonDet

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -1,4 +1,15 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, KindSignatures #-}
+-- | Provides a mechanism to kick off the evaluation of an effect stack
+-- in a pure computation.
+--
+-- This is generally the last effect in an effect stack, unless that stack
+-- needs to delegate to a base monad with the 'Control.Effect.Lift.Lift' effect.
+-- Such stacks are invoked with 'Control.Carrier.Pure.run' once all of their
+-- constituent effects have been discharged.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Pure"
 module Control.Effect.Pure
 ( -- * Pure effect
   Pure

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, KindSignatures #-}
--- | Provides a mechanism to kick off the evaluation of an effect stack
--- in a pure computation.
---
--- This is generally the last effect in an effect stack, unless that stack
--- needs to delegate to a base monad with the 'Control.Effect.Lift.Lift' effect.
--- Such stacks are invoked with 'Control.Carrier.Pure.run' once all of their
--- constituent effects have been discharged.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Pure"
+
+{- | Provides a mechanism to kick off the evaluation of an effect stack in a pure computation.
+
+This is generally the last effect in an effect stack, unless that stack needs to delegate to a base monad with the 'Control.Effect.Lift.Lift' effect. Such stacks are invoked with 'Control.Carrier.Pure.run' once all of their constituent effects have been discharged.
+
+Predefined carriers:
+
+* "Control.Carrier.Pure"
+-}
+
 module Control.Effect.Pure
 ( -- * Pure effect
   Pure

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -17,7 +17,7 @@ module Control.Effect.Pure
 import Control.Effect.Class
 import GHC.Generics (Generic1)
 
--- | @since 1.0.0.0
+-- | @since 0.3.0.0
 data Pure (m :: * -> *) k
   deriving (Functor, Generic1)
 

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -17,6 +17,7 @@ module Control.Effect.Pure
 import Control.Effect.Class
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 data Pure (m :: * -> *) k
   deriving (Functor, Generic1)
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -6,7 +6,7 @@ This effect is similar to the traditional @MonadReader@ typeclass, though it all
 
 Predefined carriers:
 
-* "Control.Carrier.Reader.ReaderC".
+* "Control.Carrier.Reader".
 * If 'Reader' @r@ is the last effect in a stack, it can be interpreted directly to @(-> r)@ (a function taking an @r@).
 -}
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -2,8 +2,7 @@
 
 {- | An effect providing access to an immutable (but locally-modifiable) context value.
 
-This effect is similar to the traditional @MonadReader@ typeclass, though it allows the
-presence of multiple @Reader t@ effects, as long as the values of @t@ are distinct.
+This effect is similar to the traditional @MonadReader@ typeclass, though it allows the presence of multiple @Reader t@ effects, as long as the values of @t@ are distinct.
 
 Predefined carriers:
 
@@ -23,7 +22,7 @@ module Control.Effect.Reader
 
 import {-# SOURCE #-} Control.Carrier
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data Reader r m k
   = Ask (r -> m k)
   | forall b . Local (r -> r) (m b) (b -> m k)
@@ -42,7 +41,7 @@ instance Effect (Reader r) where
 --
 --   prop> run (runReader a ask) === a
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 ask :: Has (Reader r) sig m => m r
 ask = send (Ask pure)
 
@@ -50,7 +49,7 @@ ask = send (Ask pure)
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 asks :: Has (Reader r) sig m => (r -> a) -> m a
 asks f = send (Ask (pure . f))
 
@@ -59,7 +58,7 @@ asks f = send (Ask (pure . f))
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 local :: Has (Reader r) sig m => (r -> r) -> m a -> m a
 local f m = send (Local f m pure)
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
--- | An effect providing access to an immutable (but locally-modifiable) context value.
--- This
---
--- This effect is similar to the traditional @MonadReader@ typeclass, though it allows the
--- presence of multiple @Reader t@ effects, as long as the values of @t@ are distinct.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Reader.ReaderC".
--- * If 'Reader' @r@ is the last effect in a stack, it can be interpreted directly to @(-> r)@ (a function taking an @r@).
---
+
+{- | An effect providing access to an immutable (but locally-modifiable) context value.
+
+This effect is similar to the traditional @MonadReader@ typeclass, though it allows the
+presence of multiple @Reader t@ effects, as long as the values of @t@ are distinct.
+
+Predefined carriers:
+
+* "Control.Carrier.Reader.ReaderC".
+* If 'Reader' @r@ is the last effect in a stack, it can be interpreted directly to @(-> r)@ (a function taking an @r@).
+-}
+
 module Control.Effect.Reader
 ( -- * Reader effect
   Reader(..)

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -2,7 +2,7 @@
 
 {- | An effect providing access to an immutable (but locally-modifiable) context value.
 
-This effect is similar to the traditional @MonadReader@ typeclass, though it allows the presence of multiple @Reader t@ effects, as long as the values of @t@ are distinct.
+This effect is similar to the traditional @MonadReader@ typeclass, though it allows the presence of multiple @Reader t@ effects.
 
 Predefined carriers:
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -7,7 +7,7 @@
 --
 -- Predefined carriers:
 --
--- * 'Control.Carrier.Reader.ReaderC', from @Control.Carrier.Reader@.
+-- * "Control.Carrier.Reader.ReaderC".
 -- * If 'Reader' @r@ is the last effect in a stack, it can be interpreted directly to @(-> r)@ (a function taking an @r@).
 --
 module Control.Effect.Reader

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -23,6 +23,7 @@ module Control.Effect.Reader
 
 import {-# SOURCE #-} Control.Carrier
 
+-- | @since 1.0.0.0
 data Reader r m k
   = Ask (r -> m k)
   | forall b . Local (r -> r) (m b) (b -> m k)
@@ -40,12 +41,16 @@ instance Effect (Reader r) where
 -- | Retrieve the environment value.
 --
 --   prop> run (runReader a ask) === a
+--
+-- @since 1.0.0.0
 ask :: Has (Reader r) sig m => m r
 ask = send (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
+--
+-- @since 1.0.0.0
 asks :: Has (Reader r) sig m => (r -> a) -> m a
 asks f = send (Ask (pure . f))
 
@@ -53,6 +58,8 @@ asks f = send (Ask (pure . f))
 --
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
+--
+-- @since 1.0.0.0
 local :: Has (Reader r) sig m => (r -> r) -> m a -> m a
 local f m = send (Local f m pure)
 

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -1,4 +1,11 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+-- | An effect that provides a "bracket"-style function to acquire, use, and automatically release
+-- resources, in the manner of the @resourcet@ package. The 'Control.Carrier.Resource.ResourceC'
+-- carrier ensures that resources are properly released in the presence of asynchronous exceptions.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Resource".
 module Control.Effect.Resource
 ( -- * Resource effect
   Resource(..)

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
--- | An effect that provides a "bracket"-style function to acquire, use, and automatically release
--- resources, in the manner of the @resourcet@ package. The 'Control.Carrier.Resource.ResourceC'
--- carrier ensures that resources are properly released in the presence of asynchronous exceptions.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Resource".
+
+{- | An effect that provides a "bracket"-style function to acquire, use, and automatically release resources, in the manner of the @resourcet@ package. The 'Control.Carrier.Resource.ResourceC' carrier ensures that resources are properly released in the presence of asynchronous exceptions.
+
+Predefined carriers:
+
+* "Control.Carrier.Resource".
+-}
+
 module Control.Effect.Resource
 ( -- * Resource effect
   Resource(..)

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -20,7 +20,7 @@ module Control.Effect.Resource
 
 import Control.Carrier
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data Resource m k
   = forall resource any output . Resource (m resource) (resource -> m any) (resource -> m output) (output -> m k)
   | forall resource any output . OnError  (m resource) (resource -> m any) (resource -> m output) (output -> m k)
@@ -47,7 +47,7 @@ instance Effect Resource where
 -- Carriers for 'bracket' must ensure that it is safe in the presence of
 -- asynchronous exceptions.
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 bracket :: Has Resource sig m
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")
@@ -58,7 +58,7 @@ bracket acquire release use = send (Resource acquire release use pure)
 -- | Like 'bracket', but only performs the final action if there was an
 -- exception raised by the in-between computation.
 --
--- @since 1.0.0.0
+-- @since 0.2.0.0
 bracketOnError :: Has Resource sig m
                => m resource           -- ^ computation to run first ("acquire resource")
                -> (resource -> m any)  -- ^ computation to run last ("release resource")
@@ -68,7 +68,7 @@ bracketOnError acquire release use = send (OnError acquire release use pure)
 
 -- | Like 'bracket', but for the simple case of one computation to run afterward.
 --
--- @since 1.0.0.0
+-- @since 0.2.0.0
 finally :: Has Resource sig m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward (even if an exception was raised)
@@ -77,7 +77,7 @@ finally act end = bracket (pure ()) (const end) (const act)
 
 -- | Like 'bracketOnError', but for the simple case of one computation to run afterward.
 --
--- @since 1.0.0.0
+-- @since 0.2.0.0
 onException :: Has Resource sig m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward if an exception was raised

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -20,6 +20,7 @@ module Control.Effect.Resource
 
 import Control.Carrier
 
+-- | @since 1.0.0.0
 data Resource m k
   = forall resource any output . Resource (m resource) (resource -> m any) (resource -> m output) (output -> m k)
   | forall resource any output . OnError  (m resource) (resource -> m any) (resource -> m output) (output -> m k)
@@ -45,6 +46,8 @@ instance Effect Resource where
 --
 -- Carriers for 'bracket' must ensure that it is safe in the presence of
 -- asynchronous exceptions.
+--
+-- @since 1.0.0.0
 bracket :: Has Resource sig m
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")
@@ -54,6 +57,8 @@ bracket acquire release use = send (Resource acquire release use pure)
 
 -- | Like 'bracket', but only performs the final action if there was an
 -- exception raised by the in-between computation.
+--
+-- @since 1.0.0.0
 bracketOnError :: Has Resource sig m
                => m resource           -- ^ computation to run first ("acquire resource")
                -> (resource -> m any)  -- ^ computation to run last ("release resource")
@@ -62,6 +67,8 @@ bracketOnError :: Has Resource sig m
 bracketOnError acquire release use = send (OnError acquire release use pure)
 
 -- | Like 'bracket', but for the simple case of one computation to run afterward.
+--
+-- @since 1.0.0.0
 finally :: Has Resource sig m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward (even if an exception was raised)
@@ -69,6 +76,8 @@ finally :: Has Resource sig m
 finally act end = bracket (pure ()) (const end) (const act)
 
 -- | Like 'bracketOnError', but for the simple case of one computation to run afterward.
+--
+-- @since 1.0.0.0
 onException :: Has Resource sig m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward if an exception was raised

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -42,7 +42,8 @@ instance Effect Resource where
 -- ensures that @release@ is run on the value returned from @acquire@ even
 -- if @op@ throws an exception.
 --
--- 'bracket' is safe in the presence of asynchronous exceptions.
+-- Carriers for 'bracket' must ensure that it is safe in the presence of
+-- asynchronous exceptions.
 bracket :: Has Resource sig m
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -31,10 +31,7 @@ instance HFunctor (Resumable err) where
 instance Effect (Resumable err) where
   handle state handler (Resumable err k) = Resumable err (handler . (<$ state) . k)
 
--- | Throw an error which can be resumed with a value of its result type.
--- Note that the type parameters in the @err a@ paramater and @m a@ parameter must match
--- up; this is so that the calling context knows what type of value this computation
--- expected in the success case.
+-- | Throw an error which can be resumed with a value of its result type. Note that the type parameters in the @err a@ paramater and @m a@ parameter must match up; this indicates the type with which the error must be resumed.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
 --

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -18,6 +18,8 @@ module Control.Effect.Resumable
 import Control.Carrier
 
 -- | Errors which can be resumed with values of some existentially-quantified type.
+--
+-- @since 0.1.0.0
 data Resumable err m k
   = forall a . Resumable (err a) (a -> m k)
 
@@ -35,6 +37,8 @@ instance Effect (Resumable err) where
 -- expected in the success case.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
+--
+-- @since 0.1.0.0
 throwResumable :: Has (Resumable err) sig m => err a -> m a
 throwResumable err = send (Resumable err pure)
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,4 +1,12 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+-- | An effect providing the ability to throw exceptions from a context. If an exception is
+-- thrown, the calling context may choose to resume the computation. Type safety of the
+-- resumed operation is preserved by parametricity achieved from the @-XGADTs@ extension.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Resumable.Resume", which provides full resumption semantics.
+-- * "Control.Carrier.Resumable.Either", which elides resumption support (like @Control.Effect.Error@).
 module Control.Effect.Resumable
 ( -- * Resumable effect
   Resumable(..)
@@ -22,6 +30,9 @@ instance Effect (Resumable err) where
   handle state handler (Resumable err k) = Resumable err (handler . (<$ state) . k)
 
 -- | Throw an error which can be resumed with a value of its result type.
+-- Note that the type parameters in the @err a@ paramater and @m a@ parameter must match
+-- up; this is so that the calling context knows what type of value this computation
+-- expected in the success case.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
 throwResumable :: Has (Resumable err) sig m => err a -> m a

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -25,7 +25,7 @@ module Control.Effect.State
 import Control.Carrier
 import GHC.Generics (Generic1)
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data State s m k
   = Get (s -> m k)
   | Put s (m k)
@@ -36,7 +36,7 @@ data State s m k
 --
 --   prop> snd (run (runState a get)) === a
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 get :: Has (State s) sig m => m s
 get = send (Get pure)
 {-# INLINEABLE get #-}
@@ -45,7 +45,7 @@ get = send (Get pure)
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 gets :: Has (State s) sig m => (s -> a) -> m a
 gets f = send (Get (pure . f))
 {-# INLINEABLE gets #-}
@@ -56,7 +56,7 @@ gets f = send (Get (pure . f))
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 put :: Has (State s) sig m => s -> m ()
 put s = send (Put s (pure ()))
 {-# INLINEABLE put #-}
@@ -66,7 +66,7 @@ put s = send (Put s (pure ()))
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 modify :: Has (State s) sig m => (s -> s) -> m ()
 modify f = do
   a <- get
@@ -76,7 +76,7 @@ modify f = do
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 modifyLazy :: Has (State s) sig m => (s -> s) -> m ()
 modifyLazy f = get >>= put . f
 {-# INLINEABLE modifyLazy #-}

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,16 +1,15 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | An effect that adds a mutable, updatable state value to a given computation.
---
--- Not all computations require a full-fledged state effect: read-only state is better served
--- by 'Control.Effect.Reader.Reader', and append-only state without reads is better served
--- by 'Control.Effect.Writer.Writer'.
---
--- Predefined carriers:
---
--- * "Control.Carrier.State.Strict", which is strict in its updates.
--- * "Control.Carrier.State.Lazy", which is lazy in its updates. This enables more
---   programs to terminate, such as cyclic computations expressed with @MonadFix@ or
---   @-XRecursiveDo@, at the cost of efficiency.
+
+{- | An effect that adds a mutable, updatable state value to a given computation.
+
+Not all computations require a full-fledged state effect: read-only state is better served by 'Control.Effect.Reader.Reader', and append-only state without reads is better served by 'Control.Effect.Writer.Writer'.
+
+Predefined carriers:
+
+* "Control.Carrier.State.Strict", which is strict in its updates.
+* "Control.Carrier.State.Lazy", which is lazy in its updates. This enables more programs to terminate, such as cyclic computations expressed with @MonadFix@ or @-XRecursiveDo@, at the cost of efficiency.
+-}
+
 module Control.Effect.State
 ( -- * State effect
   State(..)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,4 +1,16 @@
 {-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+-- | An effect that adds a mutable, updatable state value to a given computation.
+--
+-- Not all computations require a full-fledged state effect: read-only state is better served
+-- by 'Control.Effect.Reader.Reader', and append-only state without reads is better served
+-- by 'Control.Effect.Writer.Writer'.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.State.Strict", which is strict in its updates.
+-- * "Control.Carrier.State.Lazy", which is lazy in its updates. This enables more
+--   programs to terminate, such as cyclic computations expressed with @MonadFix@ or
+--   @-XRecursiveDo@, at the cost of efficiency.
 module Control.Effect.State
 ( -- * State effect
   State(..)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -25,6 +25,7 @@ module Control.Effect.State
 import Control.Carrier
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 data State s m k
   = Get (s -> m k)
   | Put s (m k)
@@ -34,6 +35,8 @@ data State s m k
 -- | Get the current state value.
 --
 --   prop> snd (run (runState a get)) === a
+--
+-- @since 1.0.0.0
 get :: Has (State s) sig m => m s
 get = send (Get pure)
 {-# INLINEABLE get #-}
@@ -41,6 +44,8 @@ get = send (Get pure)
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
+--
+-- @since 1.0.0.0
 gets :: Has (State s) sig m => (s -> a) -> m a
 gets f = send (Get (pure . f))
 {-# INLINEABLE gets #-}
@@ -50,6 +55,8 @@ gets f = send (Get (pure . f))
 --   prop> fst (run (runState a (put b))) === b
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
+--
+-- @since 1.0.0.0
 put :: Has (State s) sig m => s -> m ()
 put s = send (Put s (pure ()))
 {-# INLINEABLE put #-}
@@ -58,6 +65,8 @@ put s = send (Put s (pure ()))
 --   This is strict in the new state.
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
+--
+-- @since 1.0.0.0
 modify :: Has (State s) sig m => (s -> s) -> m ()
 modify f = do
   a <- get
@@ -66,6 +75,8 @@ modify f = do
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
+--
+-- @since 1.0.0.0
 modifyLazy :: Has (State s) sig m => (s -> s) -> m ()
 modifyLazy f = get >>= put . f
 {-# INLINEABLE modifyLazy #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
--- | Operations on /sums/, combining effects into a /signature/.
+
+{- | Operations on /sums/, combining effects into a /signature/.
+-}
+
 module Control.Effect.Sum
 ( -- * Membership
   Member(..)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
-{- | Operations on /sums/, combining effects into a /signature/.
--}
-
+-- | Operations on /sums/, combining effects into a /signature/.
 module Control.Effect.Sum
 ( -- * Membership
   Member(..)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,12 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
+-- | An effect that provides a record of 'String' values ("traces") aggregate during
+-- the execution of a given computation.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Trace.Printing", which logs to stdout in a 'MonadIO' context.
+-- * "Control.Carrier.Trace.Returning", which aggregates all traces in a @[String].
+-- * "Control.Carrier.Trace.Ignoring", which discards all traced values.
 module Control.Effect.Trace
 ( -- * Trace effect
   Trace(..)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -4,7 +4,7 @@
 --
 -- Predefined carriers:
 --
--- * "Control.Carrier.Trace.Printing", which logs to stdout in a 'MonadIO' context.
+-- * "Control.Carrier.Trace.Printing", which logs to stderr in a 'MonadIO' context.
 -- * "Control.Carrier.Trace.Returning", which aggregates all traces in a @[String].
 -- * "Control.Carrier.Trace.Ignoring", which discards all traced values.
 module Control.Effect.Trace

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -20,6 +20,7 @@ module Control.Effect.Trace
 import Control.Carrier
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 data Trace m k = Trace
   { traceMessage :: String
   , traceCont    :: m k
@@ -30,5 +31,7 @@ instance HFunctor Trace
 instance Effect   Trace
 
 -- | Append a message to the trace log.
+--
+-- @since 1.0.0.0
 trace :: Has Trace sig m => String -> m ()
 trace message = send (Trace message (pure ()))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
--- | An effect that provides a record of 'String' values ("traces") aggregate during
--- the execution of a given computation.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Trace.Printing", which logs to stderr in a 'MonadIO' context.
--- * "Control.Carrier.Trace.Returning", which aggregates all traces in a @[String].
--- * "Control.Carrier.Trace.Ignoring", which discards all traced values.
+
+{- | An effect that provides a record of 'String' values ("traces") aggregate during the execution of a given computation.
+
+Predefined carriers:
+
+* "Control.Carrier.Trace.Printing", which logs to stderr in a 'MonadIO' context.
+* "Control.Carrier.Trace.Returning", which aggregates all traces in a @[String].
+* "Control.Carrier.Trace.Ignoring", which discards all traced values.
+-}
+
 module Control.Effect.Trace
 ( -- * Trace effect
   Trace(..)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -20,7 +20,7 @@ module Control.Effect.Trace
 import Control.Carrier
 import GHC.Generics (Generic1)
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data Trace m k = Trace
   { traceMessage :: String
   , traceCont    :: m k
@@ -32,6 +32,6 @@ instance Effect   Trace
 
 -- | Append a message to the trace log.
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 trace :: Has Trace sig m => String -> m ()
 trace message = send (Trace message (pure ()))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -4,7 +4,7 @@
 
 Predefined carriers:
 
-* "Control.Carrier.Trace.Printing", which logs to stderr in a 'MonadIO' context.
+* "Control.Carrier.Trace.Printing", which logs to stderr in a 'Control.Monad.IO.Class.MonadIO' context.
 * "Control.Carrier.Trace.Returning", which aggregates all traces in a @[String].
 * "Control.Carrier.Trace.Ignoring", which discards all traced values.
 -}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -21,7 +21,7 @@ module Control.Effect.Writer
 
 import {-# SOURCE #-} Control.Carrier
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 data Writer w m k
   = Tell w (m k)
   | forall a . Listen (m a) (w -> a -> m k)
@@ -45,7 +45,7 @@ instance Effect (Writer w) where
 --
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) === foldMap Sum ws
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 tell :: Has (Writer w) sig m => w -> m ()
 tell w = send (Tell w (pure ()))
 {-# INLINE tell #-}
@@ -54,7 +54,7 @@ tell w = send (Tell w (pure ()))
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) === (Sum a <> Sum b, Sum b)
 --
--- @since 1.0.0.0
+-- @since 0.2.0.0
 listen :: Has (Writer w) sig m => m a -> m (w, a)
 listen m = send (Listen m (curry pure))
 {-# INLINE listen #-}
@@ -63,7 +63,7 @@ listen m = send (Listen m (curry pure))
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) === (Sum a <> Sum b, applyFun f (Sum b))
 --
--- @since 1.0.0.0
+-- @since 0.2.0.0
 listens :: Has (Writer w) sig m => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry pure . f))
 {-# INLINE listens #-}
@@ -73,7 +73,7 @@ listens f m = send (Listen m (curry pure . f))
 --   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) === applyFun f (Sum a)
 --   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) === (Sum a <> applyFun f (Sum b) <> Sum c)
 --
--- @since 1.0.0.0
+-- @since 0.2.0.0
 censor :: Has (Writer w) sig m => (w -> w) -> m a -> m a
 censor f m = send (Censor f m pure)
 {-# INLINE censor #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,16 +1,13 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
--- | An effect allowing writes to an accumulated quantity alongside a computed value.
--- A 'Writer' @w@ effect keeps track of a monoidal datum of type @w@ and strictly appends
--- to that monoidal value with the 'tell' effect. Writes to that value can be detected and
--- intercepted with the 'listen' and 'censor' effects.
---
--- Predefined carriers:
---
--- * "Control.Carrier.Writer.Strict.WriterC".
---   (A lazy carrier is not provided due to the inherent space leaks associated with lazy writer monads.)
--- * If 'Writer' @w@ is the last effect in a stack, it can be interpreted to a
---   tuple @(w, a)@ given some result type @a@ and the presence of a 'Monoid' instance for @w@.
---
+
+{- | An effect allowing writes to an accumulated quantity alongside a computed value. A 'Writer' @w@ effect keeps track of a monoidal datum of type @w@ and strictly appends to that monoidal value with the 'tell' effect. Writes to that value can be detected and intercepted with the 'listen' and 'censor' effects.
+
+Predefined carriers:
+
+* "Control.Carrier.Writer.Strict.WriterC". (A lazy carrier is not provided due to the inherent space leaks associated with lazy writer monads.)
+* If 'Writer' @w@ is the last effect in a stack, it can be interpreted to a tuple @(w, a)@ given some result type @a@ and the presence of a 'Monoid' instance for @w@.
+-}
+
 module Control.Effect.Writer
 ( -- * Writer effect
   Writer(..)

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -21,6 +21,7 @@ module Control.Effect.Writer
 
 import {-# SOURCE #-} Control.Carrier
 
+-- | @since 1.0.0.0
 data Writer w m k
   = Tell w (m k)
   | forall a . Listen (m a) (w -> a -> m k)
@@ -43,6 +44,8 @@ instance Effect (Writer w) where
 -- | Write a value to the log.
 --
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) === foldMap Sum ws
+--
+-- @since 1.0.0.0
 tell :: Has (Writer w) sig m => w -> m ()
 tell w = send (Tell w (pure ()))
 {-# INLINE tell #-}
@@ -50,6 +53,8 @@ tell w = send (Tell w (pure ()))
 -- | Run a computation, returning the pair of its output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) === (Sum a <> Sum b, Sum b)
+--
+-- @since 1.0.0.0
 listen :: Has (Writer w) sig m => m a -> m (w, a)
 listen m = send (Listen m (curry pure))
 {-# INLINE listen #-}
@@ -57,6 +62,8 @@ listen m = send (Listen m (curry pure))
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) === (Sum a <> Sum b, applyFun f (Sum b))
+--
+-- @since 1.0.0.0
 listens :: Has (Writer w) sig m => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry pure . f))
 {-# INLINE listens #-}
@@ -65,6 +72,8 @@ listens f m = send (Listen m (curry pure . f))
 --
 --   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) === applyFun f (Sum a)
 --   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) === (Sum a <> applyFun f (Sum b) <> Sum c)
+--
+-- @since 1.0.0.0
 censor :: Has (Writer w) sig m => (w -> w) -> m a -> m a
 censor f m = send (Censor f m pure)
 {-# INLINE censor #-}

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -4,7 +4,7 @@
 
 Predefined carriers:
 
-* "Control.Carrier.Writer.Strict.WriterC". (A lazy carrier is not provided due to the inherent space leaks associated with lazy writer monads.)
+* "Control.Carrier.Writer.Strict". (A lazy carrier is not provided due to the inherent space leaks associated with lazy writer monads.)
 * If 'Writer' @w@ is the last effect in a stack, it can be interpreted to a tuple @(w, a)@ given some result type @a@ and the presence of a 'Monoid' instance for @w@.
 -}
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,4 +1,16 @@
 {-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+-- | An effect allowing writes to an accumulated quantity alongside a computed value.
+-- A 'Writer' @w@ effect keeps track of a monoidal datum of type @w@ and strictly appends
+-- to that monoidal value with the 'tell' effect. Writes to that value can be detected and
+-- intercepted with the 'listen' and 'censor' effects.
+--
+-- Predefined carriers:
+--
+-- * "Control.Carrier.Writer.Strict.WriterC".
+--   (A lazy carrier is not provided due to the inherent space leaks associated with lazy writer monads.)
+-- * If 'Writer' @w@ is the last effect in a stack, it can be interpreted to a
+--   tuple @(w, a)@ given some result type @a@ and the presence of a 'Monoid' instance for @w@.
+--
 module Control.Effect.Writer
 ( -- * Writer effect
   Writer(..)


### PR DESCRIPTION
#240 mentioned, very correctly, that our documentation was a little sparse, and that’s a problem that only grew worse with the various reorganizations on the road to 1.0. This patch remedies that.

Fixes #244.