### PR TITLE
Simplify ResourceC using MonadUnliftIO

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,8 @@
 
 - Removes `prj` from `Member`, as it was only used in `InterposeC` (see above), and was generally inadvisable due to its lack of modularity. ([#223](https://github.com/fused-effects/fused-effects/pull/223))
 
+- Simplifies `ResourceC` by moving the `MonadUnliftIO` constraint on its `Carrier` instance instead of on the `runResource` handler, obviating the need for it to wrap a `ReaderC` carrier. This should not impact usage except in code manually constructing/eliminating `ResourceC` values. ([#254](https://github.com/fused-effects/fused-effects/pull/254))
+
 # v0.5.0.1
 
 - Adds support for ghc 8.8.1.

--- a/src/Control/Carrier/Resource.hs
+++ b/src/Control/Carrier/Resource.hs
@@ -32,10 +32,8 @@ import           Control.Monad.Trans.Class
 --   . runState @Int 1
 --   $ myComputation
 -- @
-runResource :: MonadUnliftIO m
-            => ResourceC m a
-            -> m a
-runResource r = withRunInIO (\f -> f (runResourceC r))
+runResource :: ResourceC m a -> m a
+runResource = runResourceC
 
 newtype ResourceC m a = ResourceC { runResourceC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)

--- a/src/Control/Carrier/Resource.hs
+++ b/src/Control/Carrier/Resource.hs
@@ -38,11 +38,11 @@ runResource = runResourceC
 newtype ResourceC m a = ResourceC { runResourceC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
-instance MonadUnliftIO m => MonadUnliftIO (ResourceC m) where
-  withRunInIO f = ResourceC (withRunInIO (\ runInIO -> f (runInIO . runResourceC)))
-
 instance MonadTrans ResourceC where
   lift = ResourceC
+
+instance MonadUnliftIO m => MonadUnliftIO (ResourceC m) where
+  withRunInIO f = ResourceC (withRunInIO (\ runInIO -> f (runInIO . runResourceC)))
 
 instance (Carrier sig m, MonadUnliftIO m) => Carrier (Resource :+: sig) (ResourceC m) where
   eff (L (Resource acquire release use k)) = do

--- a/src/Control/Carrier/Resource.hs
+++ b/src/Control/Carrier/Resource.hs
@@ -12,7 +12,6 @@ module Control.Carrier.Resource
 
 import           Control.Applicative (Alternative(..))
 import           Control.Carrier
-import           Control.Carrier.Reader
 import           Control.Effect.Resource
 import qualified Control.Exception as Exc
 import           Control.Monad (MonadPlus(..))
@@ -21,12 +20,6 @@ import           Control.Monad.Fix
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Class
-
--- Not exposed due to its potential to silently drop effects (#180).
-unliftResource :: (forall x . m x -> IO x) -- ^ "unlifting" function to run the carrier in 'IO'
-            -> ResourceC m a
-            -> m a
-unliftResource handler = runReader (UnliftIO handler) . runResourceC
 
 -- | Executes a 'Resource' effect. Because this runs using 'MonadUnliftIO',
 -- invocations of 'runResource' must happen at the "bottom" of a stack of
@@ -42,17 +35,16 @@ unliftResource handler = runReader (UnliftIO handler) . runResourceC
 runResource :: MonadUnliftIO m
             => ResourceC m a
             -> m a
-runResource r = withRunInIO (\f -> f (runReader (UnliftIO f) (runResourceC r)))
+runResource r = withRunInIO (\f -> f (runResourceC r))
 
-newtype ResourceC m a = ResourceC { runResourceC :: ReaderC (UnliftIO m) m a }
+newtype ResourceC m a = ResourceC { runResourceC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadUnliftIO m => MonadUnliftIO (ResourceC m) where
-  askUnliftIO = ResourceC . ReaderC $ \(UnliftIO h) ->
-    withUnliftIO $ \u -> pure (UnliftIO $ \r -> unliftIO u (unliftResource h r))
+  withRunInIO f = ResourceC (withRunInIO (\ runInIO -> f (runInIO . runResourceC)))
 
 instance MonadTrans ResourceC where
-  lift = ResourceC . lift
+  lift = ResourceC
 
 instance (Carrier sig m, MonadUnliftIO m) => Carrier (Resource :+: sig) (ResourceC m) where
   eff (L (Resource acquire release use k)) = do
@@ -69,4 +61,4 @@ instance (Carrier sig m, MonadUnliftIO m) => Carrier (Resource :+: sig) (Resourc
       (unliftIO handler . release)
       (unliftIO handler . use))
     k a
-  eff (R other) = ResourceC (eff (R (handleCoercible other)))
+  eff (R other) = ResourceC (eff (handleCoercible other))


### PR DESCRIPTION
This PR simplifies `ResourceC` by using `MonadUnliftIO` to define the `Carrier` instance, rather than using a `Reader` to carry the handler along.