### PR TITLE
Address hlint suggestions.

### DIFF
--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -29,7 +29,7 @@ runChoose fork leaf m = runChooseC m fork leaf
 
 -- | Run a 'Choose' effect, passing results to the supplied function, and merging branches together using 'S.<>'.
 runChooseS :: (S.Semigroup b, Applicative m) => (a -> m b) -> ChooseC m a -> m b
-runChooseS leaf = runChoose (liftA2 (S.<>)) leaf
+runChooseS = runChoose (liftA2 (S.<>))
 
 -- | A carrier for 'Choose' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype ChooseC m a = ChooseC

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Carrier.State.Lazy
 ( -- * State effect
   module State

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -20,7 +20,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Semigroup as S
 import GHC.Generics (Generic1)
 
-data Choose m k
+newtype Choose m k
   = Choose (Bool -> m k)
   deriving (Functor, Generic1)
 


### PR DESCRIPTION
Most of the suggestions were invalid (e.g. suggesting the use of *>
inside a definition of *>), or ones that I disagreed with
philosophically (like using infix brackets to avoid lambdas or a call
to `flip`). These are good, though.

Fixes #255.