### PR TITLE
Add additional UnliftIO instances for valid carriers.

### DIFF
--- a/src/Control/Carrier/Resumable/Resume.hs
+++ b/src/Control/Carrier/Resumable/Resume.hs
@@ -20,6 +20,7 @@ import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given handler.
@@ -45,6 +46,12 @@ newtype ResumableC err m a = ResumableC { runResumableC :: ReaderC (Handler err 
 instance MonadTrans (ResumableC err) where
   lift = ResumableC . lift
   {-# INLINE lift #-}
+
+instance MonadUnliftIO m => MonadUnliftIO (ResumableC err m) where
+  askUnliftIO = ResumableC $ withUnliftIO $ \u -> return (UnliftIO (unliftIO u . runResumableC))
+  {-# INLINE askUnliftIO #-}
+  withRunInIO inner = ResumableC $ withRunInIO $ \run -> inner (run . runResumableC)
+  {-# INLINE withRunInIO #-}
 
 newtype Handler err m = Handler { runHandler :: forall x . err x -> m x }
 

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -19,6 +19,7 @@ import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 
 -- | Run a 'Trace' effect, ignoring all traces.
@@ -36,6 +37,12 @@ newtype TraceC m a = TraceC { runTraceC :: m a }
 instance MonadTrans TraceC where
   lift = TraceC
   {-# INLINE lift #-}
+
+instance MonadUnliftIO m => MonadUnliftIO (TraceC m) where
+  askUnliftIO = TraceC $ withUnliftIO $ \u -> return (UnliftIO (unliftIO u . runTraceC))
+  {-# INLINE askUnliftIO #-}
+  withRunInIO inner = TraceC $ withRunInIO $ \run -> inner (run . runTraceC)
+  {-# INLINE withRunInIO #-}
 
 instance Carrier sig m => Carrier (Trace :+: sig) (TraceC m) where
   eff (L trace) = traceCont trace

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -19,6 +19,7 @@ import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 import System.IO
 
@@ -33,6 +34,12 @@ newtype TraceC m a = TraceC { runTraceC :: m a }
 instance MonadTrans TraceC where
   lift = TraceC
   {-# INLINE lift #-}
+
+instance MonadUnliftIO m => MonadUnliftIO (TraceC m) where
+  askUnliftIO = TraceC $ withUnliftIO $ \u -> return (UnliftIO (unliftIO u . runTraceC))
+  {-# INLINE askUnliftIO #-}
+  withRunInIO inner = TraceC $ withRunInIO $ \run -> inner (run . runTraceC)
+  {-# INLINE withRunInIO #-}
 
 instance (MonadIO m, Carrier sig m) => Carrier (Trace :+: sig) (TraceC m) where
   eff (L (Trace s k)) = liftIO (hPutStrLn stderr s) *> k


### PR DESCRIPTION
This is pretty straightforward I think. I've just added `MonadUnliftIO` support for any carriers that look to be valid instances.