### PR TITLE
Add and audit @since annotations (#276)

### DIFF
--- a/src/Control/Carrier.hs
+++ b/src/Control/Carrier.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+-- | @since 1.0.0.0
 module Control.Carrier
 ( -- * Effect requests
   Has

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -3,6 +3,8 @@
 {- | A carrier for 'Choose' effects (nondeterminism without failure).
 
 Under the hood, it uses a Church-encoded binary tree to avoid the problems associated with a naïve list-based implementation (see ["ListT done right"](http://wiki.haskell.org/ListT_done_right)).
+
+@since 1.0.0.0
 -}
 
 module Control.Carrier.Choose.Church

--- a/src/Control/Carrier/Class.hs
+++ b/src/Control/Carrier/Class.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DeriveFunctor, EmptyCase, FlexibleInstances, FunctionalDependencies, TypeOperators, UndecidableInstances #-}
+-- | An instance of the 'Carrier' class defines an interpretation of an effect signature atop a given monad.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Class
 ( Carrier(..)
 ) where
@@ -32,6 +35,8 @@ import qualified Data.Semigroup as S
 import Data.Tuple (swap)
 
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
+--
+-- @since 1.0.0.0
 class (HFunctor sig, Monad m) => Carrier sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   eff :: sig m a -> m a

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for 'Cull' and 'NonDet' effects used in tandem (@Cull :+: NonDet@).
+--
+-- @since 1.0.0.0
 module Control.Carrier.Cull.Church
 ( -- * Cull carrier
   runCull

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for 'Cut' and 'NonDet' effects used in tandem (@Cut :+: NonDet@).
+--
+-- @since 1.0.0.0
 module Control.Carrier.Cut.Church
 ( -- * Cut carrier
   runCut

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -3,6 +3,8 @@
 {- | A carrier for an 'Empty' effect, indicating failure with a 'Nothing' value. Users that need access to an error message should use the 'Control.Effect.Fail.Fail' effect.
 
 Note that 'Empty' effects can, when they are the last effect in a stack, be interpreted directly to a 'Maybe' without a call to 'runEmpty'.
+
+@since 1.0.0.0
 -}
 
 module Control.Carrier.Empty.Maybe

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for an 'Error' effect.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Error.Either
 ( -- * Error carrier
   runError
@@ -31,7 +33,7 @@ import Control.Monad.Trans.Except
 -- 'runError' ('throwError' e `catchError` 'pure') = 'pure' ('Right' e)
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.0.0
 runError :: ErrorC exc m a -> m (Either exc a)
 runError = runExceptT . runErrorC
 

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -37,6 +37,7 @@ import Control.Monad.Trans.Except
 runError :: ErrorC exc m a -> m (Either exc a)
 runError = runExceptT . runErrorC
 
+-- | @since 0.1.0.0
 newtype ErrorC e m a = ErrorC { runErrorC :: ExceptT e m a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
 

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -33,7 +33,7 @@ import Control.Monad.Trans.Except
 -- 'runError' ('throwError' e `catchError` 'pure') = 'pure' ('Right' e)
 -- @
 --
--- @since 1.0.0.0
+-- @since 0.1.0.0
 runError :: ErrorC exc m a -> m (Either exc a)
 runError = runExceptT . runErrorC
 

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Fail.fail'.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Fail.Either
 ( -- * Fail carrier
   runFail

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Fresh.Strict
 ( -- * Fresh carrier
   runFresh

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -98,6 +98,7 @@ runInterpretState handler state m =
     (\e -> StateC (\s -> handler s e))
     m
 
+-- | @since 1.0.0.0
 newtype InterpretC s (sig :: (* -> *) -> * -> *) m a =
   InterpretC { runInterpretC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
 
 -- | A carrier for 'Lift' allowing monadic actions to be lifted into a larger context with 'sendM'.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Lift
 ( -- * Lift carrier
   runM

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -3,6 +3,8 @@
 {- | Provides 'NonDetC', a carrier for 'NonDet' effects providing choice and failure.
 
 Under the hood, it uses a Church-encoded structure and a binary tree to prevent the problems associated with a naïve list-based implementation.
+
+@since 1.0.0.0
 -}
 
 module Control.Carrier.NonDet.Church

--- a/src/Control/Carrier/Pure.hs
+++ b/src/Control/Carrier/Pure.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE EmptyCase, MultiParamTypeClasses #-}
 
 -- | A carrier for pure effects, used to kick off a stack of effects with 'run'.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Pure
 ( -- * Pure carrier
   run

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for 'Reader' effects.
-
+--
+-- @since 1.0.0.0
 module Control.Carrier.Reader
 ( -- * Reader carrier
   runReader

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -3,6 +3,8 @@
 {- | A carrier for the 'State' effect that refrains from evaluating its state until necessary. This is less efficient than "Control.Carrier.State.Strict" but allows some cyclic computations to terminate that would loop infinitely in a strict state carrier.
 
 Note that the parameter order in 'runState', 'evalState', and 'execState' is reversed compared the equivalent functions provided by @transformers@. This is an intentional decision made to enable the composition of effect handlers with '.' without invoking 'flip'.
+
+@since 1.0.0.0
 -}
 
 module Control.Carrier.State.Lazy

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -3,6 +3,8 @@
 {- | A carrier for the 'State' effect. It evaluates its inner state strictly, which is the correct choice for the majority of use cases.
 
 Note that the parameter order in 'runState', 'evalState', and 'execState' is reversed compared the equivalent functions provided by @transformers@. This is an intentional decision made to enable the composition of effect handlers with '.' without invoking 'flip'.
+
+@since 1.0.0.0
 -}
 module Control.Carrier.State.Strict
 ( -- * Strict state carrier

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+
+-- | An 'Either'-based carrier for the 'Throw' effect.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Throw.Either
 ( -- * Throw carrier
   runThrow
@@ -21,6 +25,7 @@ import Control.Monad.Trans.Class
 runThrow :: ThrowC e m a -> m (Either e a)
 runThrow = runError . runThrowC
 
+-- | @since 1.0.0.0
 newtype ThrowC e m a = ThrowC { runThrowC :: ErrorC e m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful when you wish to disable tracing without removing all trace statements.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Trace.Ignoring
 ( -- * Trace carrier
   runTrace

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Trace.Printing
 ( -- * Trace carrier
   runTrace

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 -- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
+--
+-- @since 1.0.0.0
 module Control.Carrier.Trace.Returning
 ( -- * Trace carrier
   runTrace

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -3,6 +3,8 @@
 {- | A carrier for 'Writer' effects. This carrier performs its append operations strictly and thus avoids the space leaks inherent in lazy writer monads.
 
 This implementation is based on a post Gabriel Gonzalez made to the Haskell mailing list: <https://mail.haskell.org/pipermail/libraries/2013-March/019528.html>
+
+@since 1.0.0.0
 -}
 
 module Control.Carrier.Writer.Strict
@@ -47,6 +49,8 @@ execWriter = fmap fst . runWriter
 
 
 -- | A space-efficient carrier for 'Writer' effects, implemented atop "Control.Carrier.State.Strict".
+--
+-- @since 1.0.0.0
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -5,6 +5,8 @@
 Predefined carriers:
 
 * "Control.Carrier.Error.Either" (with 'Control.Effect.Throw.Throw')
+
+@since 1.0.0.0
 -}
 module Control.Effect.Catch
 ( -- * Catch effect
@@ -19,6 +21,8 @@ module Control.Effect.Catch
 import Control.Carrier
 
 -- | 'Catch' effects can be used alongside 'Control.Effect.Throw.Throw' to provide recoverable exceptions.
+--
+-- @since 1.0.0.0
 data Catch e m k
   = forall b . Catch (m b) (e -> m b) (b -> m k)
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -8,6 +8,8 @@ Predefined carriers:
 
 * "Control.Carrier.Choose.Church".
 * If 'Choose' is the last effect in a stack, it can be interpreted directly to a 'NonEmpty'.
+
+@since 1.0.0.0
 -}
 
 module Control.Effect.Choose

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DefaultSignatures, EmptyCase, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators #-}
 
 -- | Provides the 'HFunctor' and 'Effect' classes that effect types implement.
+--
+-- @since 1.0.0.0
 module Control.Effect.Class
 ( HFunctor(..)
 , handleCoercible

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -6,6 +6,8 @@ Computations run inside a call to 'cull' will return at most one result.
 Predefined carriers:
 
 * "Control.Carrier.Cull.Church"
+
+@since 0.1.2.0
 -}
 module Control.Effect.Cull
 ( -- * Cull effect

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -7,6 +7,8 @@ Computations that signal failure with 'cutfail' prevent backtracking within the 
 Predefined carriers:
 
 * "Control.Carrier.Cut.Church"
+
+@since 0.1.2.0
 -}
 
 module Control.Effect.Cut

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -8,6 +8,8 @@ Predefined carriers:
 
 * "Control.Carrier.Empty.Maybe".
 * If 'Empty' is the last effect in a stack, it can be interpreted directly to a 'Maybe'.
+
+@since 1.0.0.0
 -}
 
 module Control.Effect.Empty

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -24,5 +24,5 @@ import Control.Carrier
 import Control.Effect.Catch
 import Control.Effect.Throw
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 type Error e = Throw e :+: Catch e

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -9,6 +9,8 @@ Predefined carriers:
 * "Control.Carrier.Error.Either".
 * "Control.Monad.Trans.Except".
 * If 'Error' @e@ is the last effect in a stack, it can be interpreted directly to an 'Either' @e@.
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.Error
@@ -22,5 +24,5 @@ import Control.Carrier
 import Control.Effect.Catch
 import Control.Effect.Throw
 
--- | @since 0.1.0.0
+-- | @since 1.0.0.0
 type Error e = Throw e :+: Catch e

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -7,6 +7,8 @@ This effect is invoked through the 'Fail.fail' method from 'Fail.MonadFail'.
 Predefined carriers:
 
 * "Control.Carrier.Fail.Either"
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.Fail

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -24,5 +24,5 @@ module Control.Effect.Fail
 import Control.Effect.Throw
 import qualified Control.Monad.Fail as Fail
 
--- | @since 1.0.0.0
+-- | @since 0.1.0.0
 type Fail = Throw String

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -8,6 +8,8 @@ Predefined carriers:
 
 * "Control.Carrier.Lift"
 * 'IO'
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.Lift

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -8,6 +8,8 @@ Predefined carriers:
 
 * "Control.Carrier.NonDet.Church", which collects all branches' results using an @Alternative@ functor.
 * If 'NonDet' is the last effect in a stack, it can be interpreted directly into a @[]@.
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.NonDet

--- a/src/Control/Effect/Pure.hs
+++ b/src/Control/Effect/Pure.hs
@@ -8,6 +8,8 @@ Predefined carriers:
 
 * "Control.Carrier.Pure"
 * 'Data.Functor.Identity.Identity'
+
+@since 0.3.0.0
 -}
 
 module Control.Effect.Pure

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -11,6 +11,8 @@ Predefined carriers:
 * "Control.Monad.Trans.RWS.Lazy"
 * "Control.Monad.Trans.RWS.Strict"
 * If 'Reader' @r@ is the last effect in a stack, it can be interpreted directly to @(-> r)@ (a function taking an @r@).
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.Reader

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -12,6 +12,8 @@ Predefined carriers:
 * "Control.Monad.Trans.RWS.Strict"
 * "Control.Monad.Trans.State.Lazy"
 * "Control.Monad.Trans.State.Strict"
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.State

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeFamilies, TypeOperators, UndecidableInstances #-}
 
 -- | Operations on /sums/, combining effects into a /signature/.
+--
+-- @since 0.1.0.0
 module Control.Effect.Sum
 ( -- * Membership
   Member(..)
@@ -30,6 +32,8 @@ instance (Effect f, Effect g)     => Effect   (f :+: g)
 --   This is based on Wouter Swierstra’s design described in [Data types à la carte](http://www.cs.ru.nl/~W.Swierstra/Publications/DataTypesALaCarte.pdf). As described therein, overlapping instances are required in order to distinguish e.g. left-occurrence from right-recursion.
 --
 --   It should not generally be necessary for you to define new 'Member' instances, but these are not specifically prohibited if you wish to get creative.
+--
+-- @since 0.1.0.0
 class Member (sub :: (* -> *) -> (* -> *)) sup where
   -- | Inject a member of a signature into the signature.
   inj :: sub m a -> sup m a
@@ -62,6 +66,8 @@ instance {-# OVERLAPPABLE #-}
 -- | Decompose sums on the left into multiple 'Member' constraints.
 --
 -- Note that while this, and by extension 'Control.Carrier.Has', can be used to group together multiple membership checks into a single (composite) constraint, large signatures on the left can slow compiles down due to [a problem with recursive type families](https://gitlab.haskell.org/ghc/ghc/issues/8095).
+--
+-- @since 1.0.0.0
 type family Members sub sup :: Constraint where
   Members (l :+: r) u = (Members l u, Members r u)
   Members t         u = Member t u

--- a/src/Control/Effect/Throw.hs
+++ b/src/Control/Effect/Throw.hs
@@ -6,6 +6,8 @@ Predefined carriers:
 
 * "Control.Carrier.Throw.Either"
 * "Control.Carrier.Error.Either" (with 'Control.Effect.Catch.Catch')
+
+@since 1.0.0.0
 -}
 module Control.Effect.Throw
 ( -- * Throw effect
@@ -20,6 +22,7 @@ module Control.Effect.Throw
 import Control.Carrier
 import GHC.Generics (Generic1)
 
+-- | @since 1.0.0.0
 data Throw e (m :: * -> *) k
   = Throw e
   deriving (Functor, Generic1)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -7,6 +7,8 @@ Predefined carriers:
 * "Control.Carrier.Trace.Printing", which logs to stderr in a 'Control.Monad.IO.Class.MonadIO' context.
 * "Control.Carrier.Trace.Returning", which aggregates all traces in a @[String].
 * "Control.Carrier.Trace.Ignoring", which discards all traced values.
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.Trace

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -10,6 +10,8 @@ Predefined carriers:
 * "Control.Monad.Trans.Writer.Lazy"
 * "Control.Monad.Trans.Writer.Strict"
 * If 'Writer' @w@ is the last effect in a stack, it can be interpreted to a tuple @(w, a)@ given some result type @a@ and the presence of a 'Monoid' instance for @w@.
+
+@since 0.1.0.0
 -}
 
 module Control.Effect.Writer


### PR DESCRIPTION
I did not annotate every typeclass instance, though I could—I think we should only `@since` instances that we add in versions following 1.0.