### PR TITLE
Test laws compositionally

### DIFF
--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -15,7 +15,7 @@ gen
   => Gen e
   -> GenM m
   -> GenM m
-gen _ m a = label "catchError" catchError <*> m a <*> fn @e (m a)
+gen _ (GenM m) = GenM $ \ a -> label "catchError" catchError <*> m a <*> fn @e (m a)
 
 
 test
@@ -27,7 +27,7 @@ test
   -> Gen (f ())
   -> Run f (Either e) m
   -> [TestTree]
-test e m a _ i (Run runCatch) =
+test e (GenM m) a _ i (Run runCatch) =
   [ testProperty "catchError intercepts throwError" . forall (i :. e :. fn (m a) :. Nil) $
     \ i e h -> runCatch ((throwError e `catchError` h) <$ i) === runCatch (h e <$ i)
   ]

--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -15,7 +15,7 @@ gen
   => Gen e
   -> GenM m
   -> GenM m
-gen _ = genM $ \ m a -> label "catchError" catchError <*> m a <*> fn @e (m a)
+gen _ (GenM m) = GenM $ \ a -> label "catchError" catchError <*> m a <*> fn @e (m a)
 
 
 test

--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -16,7 +16,7 @@ genN
   -> GenM m
   -> Gen a
   -> [Gen (m a)]
-genN _ (GenM m) a = [ label "catchError" catchError <*> m a <*> fn @e (m a) ]
+genN _ m a = [ label "catchError" catchError <*> m a <*> fn @e (m a) ]
 
 
 test
@@ -28,7 +28,7 @@ test
   -> Gen (f ())
   -> Run f (Either e) m
   -> [TestTree]
-test e (GenM m) a _ i (Run runCatch) =
+test e m a _ i (Run runCatch) =
   [ testProperty "catchError intercepts throwError" . forall (i :. e :. fn (m a) :. Nil) $
     \ i e h -> runCatch ((throwError e `catchError` h) <$ i) === runCatch (h e <$ i)
   ]

--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -15,7 +15,7 @@ gen
   => Gen e
   -> GenM m
   -> GenM m
-gen _ (GenM m) = GenM $ \ a -> label "catchError" catchError <*> m a <*> fn @e (m a)
+gen _ = genM $ \ m a -> label "catchError" catchError <*> m a <*> fn @e (m a)
 
 
 test

--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RankNTypes, ScopedTypeVariables, TypeApplications #-}
 module Catch
-( gen
+( genN
 , test
 ) where
 
@@ -9,13 +9,14 @@ import Gen
 import Test.Tasty
 import Test.Tasty.Hedgehog
 
-gen
-  :: forall e m sig
+genN
+  :: forall e m a sig
   .  (Has (Catch e) sig m, Arg e, Show e, Vary e)
   => Gen e
   -> GenM m
-  -> GenM m
-gen _ (GenM m) = GenM $ \ a -> label "catchError" catchError <*> m a <*> fn @e (m a)
+  -> Gen a
+  -> [Gen (m a)]
+genN _ (GenM m) a = [ label "catchError" catchError <*> m a <*> fn @e (m a) ]
 
 
 test

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -29,7 +29,7 @@ tests = testGroup "Choose"
 
 
 genN :: Has Choose sig m => GenM m -> Gen a -> [Gen (m a)]
-genN (GenM m) a = [ addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a) ]
+genN m a = [ addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a) ]
 
 
 test
@@ -40,7 +40,7 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test (GenM m) a b i (Run runChoose) =
+test m a b i (Run runChoose) =
   [ testProperty ">>= distributes over <|>" . forall (i :. m a :. m a :. fn (m b) :. Nil) $
     \ i m n k -> runChoose (((m <|> n) >>= k) <$ i) === runChoose (((m >>= k) <|> (n >>= k)) <$ i)
   , testProperty "<|> is associative" . forall (i :. m a :. m a :. m a :. Nil) $

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -29,7 +29,7 @@ tests = testGroup "Choose"
 
 
 gen :: Has Choose sig m => GenM m -> GenM m
-gen = genM $ \ m a -> addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
+gen (GenM m) = GenM $ \ a -> addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
 
 
 test

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -23,9 +23,9 @@ tests = testGroup "Choose"
     ] >>= ($ runL (ChooseC.runChooseS (pure . pure)))
   , testGroup "NonEmpty" $ testChoose (runL (pure . toList))
   ] where
-  testMonad    run = Monad.test    (m (const []) genN) a b c initial run
-  testMonadFix run = MonadFix.test (m (const []) genN) a b   initial run
-  testChoose   run = Choose.test   (m (const []) genN) a b   initial run
+  testMonad    run = Monad.test    (m mempty genN) a b c initial run
+  testMonadFix run = MonadFix.test (m mempty genN) a b   initial run
+  testChoose   run = Choose.test   (m mempty genN) a b   initial run
   initial = identity <*> unit
 
 

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -23,9 +23,9 @@ tests = testGroup "Choose"
     ] >>= ($ runL (ChooseC.runChooseS (pure . pure)))
   , testGroup "NonEmpty" $ testChoose (runL (pure . toList))
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> []) genN) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (\ _ -> []) genN) a b   (identity <*> unit) run
-  testChoose   run = Choose.test   (m (\ _ -> []) genN) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (const []) genN) a b c (identity <*> unit) run
+  testMonadFix run = MonadFix.test (m (const []) genN) a b   (identity <*> unit) run
+  testChoose   run = Choose.test   (m (const []) genN) a b   (identity <*> unit) run
 
 
 genN :: Has Choose sig m => GenM m -> Gen a -> [Gen (m a)]

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -29,7 +29,7 @@ tests = testGroup "Choose"
 
 
 gen :: Has Choose sig m => GenM m -> GenM m
-gen m a = addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
+gen (GenM m) = GenM $ \ a -> addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
 
 
 test
@@ -40,7 +40,7 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test m a b i (Run runChoose) =
+test (GenM m) a b i (Run runChoose) =
   [ testProperty ">>= distributes over <|>" . forall (i :. m a :. m a :. fn (m b) :. Nil) $
     \ i m n k -> runChoose (((m <|> n) >>= k) <$ i) === runChoose (((m >>= k) <|> (n >>= k)) <$ i)
   , testProperty "<|> is associative" . forall (i :. m a :. m a :. m a :. Nil) $

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes #-}
 module Choose
 ( tests
-, gen
+, genN
 , test
 ) where
 
@@ -23,13 +23,13 @@ tests = testGroup "Choose"
     ] >>= ($ runL (ChooseC.runChooseS (pure . pure)))
   , testGroup "NonEmpty" $ testChoose (runL (pure . toList))
   ] where
-  testMonad    run = Monad.test    (m gen) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m gen) a b   (identity <*> unit) run
-  testChoose   run = Choose.test   (m gen) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> []) genN) a b c (identity <*> unit) run
+  testMonadFix run = MonadFix.test (m (\ _ -> []) genN) a b   (identity <*> unit) run
+  testChoose   run = Choose.test   (m (\ _ -> []) genN) a b   (identity <*> unit) run
 
 
-gen :: Has Choose sig m => GenM m -> GenM m
-gen (GenM m) = GenM $ \ a -> addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
+genN :: Has Choose sig m => GenM m -> Gen a -> [Gen (m a)]
+genN (GenM m) a = [ addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a) ]
 
 
 test

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -29,7 +29,7 @@ tests = testGroup "Choose"
 
 
 gen :: Has Choose sig m => GenM m -> GenM m
-gen (GenM m) = GenM $ \ a -> addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
+gen = genM $ \ m a -> addLabel "<|>" (infixL 3 "<|>" (<|>) <*> m a <*> m a)
 
 
 test

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -23,9 +23,10 @@ tests = testGroup "Choose"
     ] >>= ($ runL (ChooseC.runChooseS (pure . pure)))
   , testGroup "NonEmpty" $ testChoose (runL (pure . toList))
   ] where
-  testMonad    run = Monad.test    (m (const []) genN) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (const []) genN) a b   (identity <*> unit) run
-  testChoose   run = Choose.test   (m (const []) genN) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (const []) genN) a b c initial run
+  testMonadFix run = MonadFix.test (m (const []) genN) a b   initial run
+  testChoose   run = Choose.test   (m (const []) genN) a b   initial run
+  initial = identity <*> unit
 
 
 genN :: Has Choose sig m => GenM m -> Gen a -> [Gen (m a)]

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -25,9 +25,10 @@ tests = testGroup "Cull"
     , testCull
     ] >>= ($ runL CullC.runCullA)
   ] where
-  testMonad    run = Monad.test    (m (const NonDet.gen0) genN) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (const NonDet.gen0) genN) a b   (identity <*> unit) run
-  testCull     run = Cull.test     (m (const NonDet.gen0) genN) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (const NonDet.gen0) genN) a b c initial run
+  testMonadFix run = MonadFix.test (m (const NonDet.gen0) genN) a b   initial run
+  testCull     run = Cull.test     (m (const NonDet.gen0) genN) a b   initial run
+  initial = identity <*> unit
 
 
 genN :: (Has Cull sig m, Has NonDet sig m) => GenM m -> Gen a -> [Gen (m a)]

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -31,7 +31,7 @@ tests = testGroup "Cull"
 
 gen :: (Has Cull sig m, Has NonDet sig m) => GenM m -> GenM m
 gen = choiceM
-  [ \ (GenM m) -> GenM $ \ a -> label "cull" cull <*> m a
+  [ genM $ \ m a -> label "cull" cull <*> m a
   , NonDet.gen
   ]
 

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes #-}
 module Cull
 ( tests
-, NonDet.gen0
+, gen0
 , genN
 , test
 ) where
@@ -25,11 +25,14 @@ tests = testGroup "Cull"
     , testCull
     ] >>= ($ runL CullC.runCullA)
   ] where
-  testMonad    run = Monad.test    (m NonDet.gen0 genN) a b c initial run
-  testMonadFix run = MonadFix.test (m NonDet.gen0 genN) a b   initial run
-  testCull     run = Cull.test     (m NonDet.gen0 genN) a b   initial run
+  testMonad    run = Monad.test    (m gen0 genN) a b c initial run
+  testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run
+  testCull     run = Cull.test     (m gen0 genN) a b   initial run
   initial = identity <*> unit
 
+
+gen0 :: (Has Cull sig m, Has NonDet sig m) => Gen a -> [Gen (m a)]
+gen0 = NonDet.gen0
 
 genN :: (Has Cull sig m, Has NonDet sig m) => GenM m -> Gen a -> [Gen (m a)]
 genN m a = (label "cull" cull <*> m a) : NonDet.genN m a

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -30,9 +30,9 @@ tests = testGroup "Cull"
 
 
 gen :: (Has Cull sig m, Has NonDet sig m) => GenM m -> GenM m
-gen = choiceM
-  [ \ (GenM m) -> GenM $ \ a -> label "cull" cull <*> m a
-  , NonDet.gen
+gen (GenM m) = choiceM
+  [ GenM $ \ a -> label "cull" cull <*> m a
+  , NonDet.gen (GenM m)
   ]
 
 

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -30,9 +30,9 @@ tests = testGroup "Cull"
 
 
 gen :: (Has Cull sig m, Has NonDet sig m) => GenM m -> GenM m
-gen (GenM m) = GenM $ \ a -> choice
-  [ label "cull" cull <*> m a
-  , runGenM (NonDet.gen (GenM m)) a
+gen = choiceM
+  [ \ (GenM m) -> GenM $ \ a -> label "cull" cull <*> m a
+  , NonDet.gen
   ]
 
 

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes #-}
+-- GHC 8.2.2 warns that the Has Cull sig m constraint on gen0 is redundant, but doesn’t typecheck without it. Newer GHCs typecheck just fine either way and also don’t warn, so … whatever?
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 module Cull
 ( tests
 , gen0

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -31,7 +31,7 @@ tests = testGroup "Cull"
 
 
 genN :: (Has Cull sig m, Has NonDet sig m) => GenM m -> Gen a -> [Gen (m a)]
-genN (GenM m) a = (label "cull" cull <*> m a) : NonDet.genN (GenM m) a
+genN m a = (label "cull" cull <*> m a) : NonDet.genN m a
 
 
 test
@@ -42,7 +42,7 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test (GenM m) a b i (Run runCull)
+test m a b i (Run runCull)
   = testProperty "cull returns at most one success" (forall (i :. a :. m a :. m a :. Nil)
     (\ i a m n -> runCull ((cull (pure a <|> m) <|> n) <$ i) === runCull ((pure a <|> n) <$ i)))
-  : NonDet.test (GenM m) a b i (Run runCull)
+  : NonDet.test m a b i (Run runCull)

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -31,7 +31,7 @@ tests = testGroup "Cull"
 
 gen :: (Has Cull sig m, Has NonDet sig m) => GenM m -> GenM m
 gen = choiceM
-  [ genM $ \ m a -> label "cull" cull <*> m a
+  [ \ (GenM m) -> GenM $ \ a -> label "cull" cull <*> m a
   , NonDet.gen
   ]
 

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -25,9 +25,9 @@ tests = testGroup "Cull"
     , testCull
     ] >>= ($ runL CullC.runCullA)
   ] where
-  testMonad    run = Monad.test    (m (const NonDet.gen0) genN) a b c initial run
-  testMonadFix run = MonadFix.test (m (const NonDet.gen0) genN) a b   initial run
-  testCull     run = Cull.test     (m (const NonDet.gen0) genN) a b   initial run
+  testMonad    run = Monad.test    (m NonDet.gen0 genN) a b c initial run
+  testMonadFix run = MonadFix.test (m NonDet.gen0 genN) a b   initial run
+  testCull     run = Cull.test     (m NonDet.gen0 genN) a b   initial run
   initial = identity <*> unit
 
 

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -55,11 +55,12 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test hom m a b i (Run runCut)
-  = testProperty "cutfail annihilates >>=" (forall (i :. fn @a (m a) :. Nil)
+test hom m = (\ a _ i (Run runCut) ->
+  [ testProperty "cutfail annihilates >>=" (forall (i :. fn @a (m a) :. Nil)
     (\ i k -> runCut ((hom cutfail >>= k) <$ i) === runCut (hom cutfail <$ i)))
-  : testProperty "cutfail annihilates <|>" (forall (i :. m a :. Nil)
+  , testProperty "cutfail annihilates <|>" (forall (i :. m a :. Nil)
     (\ i m -> runCut ((hom cutfail <|> m) <$ i) === runCut (hom cutfail <$ i)))
-  : testProperty "call delimits cutfail" (forall (i :. m a :. Nil)
+  , testProperty "call delimits cutfail" (forall (i :. m a :. Nil)
     (\ i m -> runCut ((hom (call (hom cutfail)) <|> m) <$ i) === runCut (m <$ i)))
-  : NonDet.test m a b i (Run runCut)
+  ])
+  S.<> NonDet.test m

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -28,11 +28,11 @@ tests = testGroup "Cut"
   , testGroup "ReaderC · CutC" $
     [ Cut.test
     , testCutfailLocal
-    ] >>= \ f -> f (m genCutReader) a b (atom "(,)" (,) <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    ] >>= \ f -> f (m genCutReader) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
   , testGroup "CutC · ReaderC" $
     [ Cut.test
     , testCutfailLocal
-    ] >>= \ f -> f (m genCutReader) a b (atom "(,)" (,) <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+    ] >>= \ f -> f (m genCutReader) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
   testMonad    run = Monad.test    (m gen) a b c (identity <*> unit) run
   -- testMonadFix run = MonadFix.test (m gen) a b   (identity <*> unit) run

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -26,14 +26,13 @@ tests = testGroup "Cut"
     , testCut
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
-    Cut.test (Hom (local (id @R))) (m genCutReader) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    Cut.test (Hom (local (id @R))) (m (choiceM [gen, Reader.gen r])) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
   , testGroup "CutC · ReaderC" $
-    Cut.test (Hom (local (id @R))) (m genCutReader) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+    Cut.test (Hom (local (id @R))) (m (choiceM [gen, Reader.gen r])) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
   testMonad    run = Monad.test        (m gen) a b c (identity <*> unit) run
   -- testMonadFix run = MonadFix.test     (m gen) a b   (identity <*> unit) run
   testCut      run = Cut.test (Hom id) (m gen) a b   (identity <*> unit) run
-  genCutReader m = GenM $ \ a -> choice [runGenM (gen m) a, runGenM (Reader.gen r m) a]
 
 
 gen :: (Has Cut sig m, Has NonDet sig m) => GenM m -> GenM m

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -37,8 +37,8 @@ tests = testGroup "Cut"
 
 gen :: (Has Cut sig m, Has NonDet sig m) => GenM m -> GenM m
 gen = choiceM
-  [ genM $ \ m a -> label "call" call <*> m a
-  , genM $ \ _ _ -> label "cutfail" cutfail
+  [ \ (GenM m) -> GenM $ \ a -> label "call" call <*> m a
+  , \ _        -> GenM $ \ _ -> label "cutfail" cutfail
   , NonDet.gen
   ]
 

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -26,9 +26,9 @@ tests = testGroup "Cut"
     , testCut
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
-     Cut.test (m (\ m a -> choice [gen m a, Reader.gen r m a])) a b (atom "(,)" (,) <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    Cut.test (m (\ m a -> choice [gen m a, Reader.gen r m a])) a b (atom "(,)" (,) <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
   , testGroup "CutC · ReaderC" $
-     Cut.test (m (\ m a -> choice [gen m a, Reader.gen r m a])) a b (atom "(,)" (,) <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+    Cut.test (m (\ m a -> choice [gen m a, Reader.gen r m a])) a b (atom "(,)" (,) <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
   testMonad    run = Monad.test    (m gen) a b c (identity <*> unit) run
   -- testMonadFix run = MonadFix.test (m gen) a b   (identity <*> unit) run

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -37,8 +37,8 @@ tests = testGroup "Cut"
 
 gen :: (Has Cut sig m, Has NonDet sig m) => GenM m -> GenM m
 gen = choiceM
-  [ \ (GenM m) -> GenM $ \ a -> label "call" call <*> m a
-  , \ _        -> GenM $ \ _ -> label "cutfail" cutfail
+  [ genM $ \ m a -> label "call" call <*> m a
+  , genM $ \ _ _ -> label "cutfail" cutfail
   , NonDet.gen
   ]
 

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -43,12 +43,10 @@ genN :: (Has Cut sig m, Has NonDet sig m) => GenM m -> Gen a -> [Gen (m a)]
 genN m a = (label "call" call <*> m a) : NonDet.genN m a
 
 
-type Hom m = (forall a . m a -> m a)
-
 test
   :: forall a b m f sig
   .  (Has Cut sig m, Has NonDet sig m, Arg a, Eq a, Eq b, Show a, Show b, Vary a, Functor f)
-  => Hom m
+  => (forall a . m a -> m a)
   -> GenM m
   -> Gen a
   -> Gen b

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -11,6 +11,7 @@ import Control.Carrier.Reader
 import Control.Effect.Choose
 import Control.Effect.Cut (Cut, call, cutfail)
 import Control.Effect.NonDet (NonDet)
+import Data.Semigroup as S ((<>))
 import Gen
 import qualified Monad
 -- import qualified MonadFix
@@ -27,9 +28,9 @@ tests = testGroup "Cut"
     , testCut
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
-    Cut.test (local (id @R)) (m (\ a -> gen0 a ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    Cut.test (local (id @R)) (m (gen0 S.<> Reader.gen0 r) (\ m -> genN m S.<> Reader.genN r m)) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
   -- , testGroup "CutC · ReaderC" $
-  --   Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+  --   Cut.test (local (id @R)) (m (gen0 S.<> Reader.gen0 r) (\ m -> genN m S.<> Reader.genN r m)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
   testMonad    run = Monad.test    (m gen0 genN) a b c initial run
   -- testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -36,10 +36,10 @@ tests = testGroup "Cut"
 
 
 gen :: (Has Cut sig m, Has NonDet sig m) => GenM m -> GenM m
-gen (GenM m) = GenM $ \ a -> choice
-  [ label "call" call <*> m a
-  , label "cutfail" cutfail
-  , runGenM (NonDet.gen (GenM m)) a
+gen = choiceM
+  [ \ (GenM m) -> GenM $ \ a -> label "call" call <*> m a
+  , \ _        -> GenM $ \ _ -> label "cutfail" cutfail
+  , NonDet.gen
   ]
 
 

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -31,9 +31,10 @@ tests = testGroup "Cut"
   -- , testGroup "CutC · ReaderC" $
   --   Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
-  testMonad    run = Monad.test    (m (const gen0) genN) a b c (identity <*> unit) run
-  -- testMonadFix run = MonadFix.test (m (const gen0) genN) a b   (identity <*> unit) run
-  testCut      run = Cut.test id   (m (const gen0) genN) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (const gen0) genN) a b c initial run
+  -- testMonadFix run = MonadFix.test (m (const gen0) genN) a b   initial run
+  testCut      run = Cut.test id   (m (const gen0) genN) a b   initial run
+  initial = identity <*> unit
 
 
 gen0 :: (Has Cut sig m, Has NonDet sig m) => [Gen (m a)]

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -28,8 +28,8 @@ tests = testGroup "Cut"
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
     Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
-  , testGroup "CutC · ReaderC" $
-    Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+  -- , testGroup "CutC · ReaderC" $
+  --   Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
   testMonad    run = Monad.test    (m (const gen0) genN) a b c (identity <*> unit) run
   -- testMonadFix run = MonadFix.test (m (const gen0) genN) a b   (identity <*> unit) run

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -40,7 +40,7 @@ gen0 :: (Has Cut sig m, Has NonDet sig m) => [Gen (m a)]
 gen0 = label "cutfail" cutfail : NonDet.gen0
 
 genN :: (Has Cut sig m, Has NonDet sig m) => GenM m -> Gen a -> [Gen (m a)]
-genN (GenM m) a = (label "call" call <*> m a) : NonDet.genN (GenM m) a
+genN m a = (label "call" call <*> m a) : NonDet.genN m a
 
 
 newtype Hom m = Hom (forall a . m a -> m a)
@@ -55,11 +55,11 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test (Hom hom) (GenM m) a b i (Run runCut)
+test (Hom hom) m a b i (Run runCut)
   = testProperty "cutfail annihilates >>=" (forall (i :. fn @a (m a) :. Nil)
     (\ i k -> runCut ((hom cutfail >>= k) <$ i) === runCut (hom cutfail <$ i)))
   : testProperty "cutfail annihilates <|>" (forall (i :. m a :. Nil)
     (\ i m -> runCut ((hom cutfail <|> m) <$ i) === runCut (hom cutfail <$ i)))
   : testProperty "call delimits cutfail" (forall (i :. m a :. Nil)
     (\ i m -> runCut ((hom (call (hom cutfail)) <|> m) <$ i) === runCut (m <$ i)))
-  : NonDet.test (GenM m) a b i (Run runCut)
+  : NonDet.test m a b i (Run runCut)

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -27,18 +27,18 @@ tests = testGroup "Cut"
     , testCut
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
-    Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    Cut.test (local (id @R)) (m (\ a -> gen0 a ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
   -- , testGroup "CutC · ReaderC" $
   --   Cut.test (local (id @R)) (m (\ a -> gen0 ++ Reader.gen0 r a) (\ m a -> genN m a ++ Reader.genN r m a)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
-  testMonad    run = Monad.test    (m (const gen0) genN) a b c initial run
-  -- testMonadFix run = MonadFix.test (m (const gen0) genN) a b   initial run
-  testCut      run = Cut.test id   (m (const gen0) genN) a b   initial run
+  testMonad    run = Monad.test    (m gen0 genN) a b c initial run
+  -- testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run
+  testCut      run = Cut.test id   (m gen0 genN) a b   initial run
   initial = identity <*> unit
 
 
-gen0 :: (Has Cut sig m, Has NonDet sig m) => [Gen (m a)]
-gen0 = label "cutfail" cutfail : NonDet.gen0
+gen0 :: (Has Cut sig m, Has NonDet sig m) => Gen a -> [Gen (m a)]
+gen0 a = label "cutfail" cutfail : NonDet.gen0 a
 
 genN :: (Has Cut sig m, Has NonDet sig m) => GenM m -> Gen a -> [Gen (m a)]
 genN m a = (label "call" call <*> m a) : NonDet.genN m a

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -26,9 +26,9 @@ tests = testGroup "Cut"
     , testCut
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
-    Cut.test (Hom (local (id @R))) (m (choiceM [gen, Reader.gen r])) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    Cut.test (Hom (local (id @R))) (m (\ m -> choiceM [gen m, Reader.gen r m])) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
   , testGroup "CutC · ReaderC" $
-    Cut.test (Hom (local (id @R))) (m (choiceM [gen, Reader.gen r])) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+    Cut.test (Hom (local (id @R))) (m (\ m -> choiceM [gen m, Reader.gen r m])) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
   testMonad    run = Monad.test        (m gen) a b c (identity <*> unit) run
   -- testMonadFix run = MonadFix.test     (m gen) a b   (identity <*> unit) run
@@ -36,10 +36,10 @@ tests = testGroup "Cut"
 
 
 gen :: (Has Cut sig m, Has NonDet sig m) => GenM m -> GenM m
-gen = choiceM
-  [ \ (GenM m) -> GenM $ \ a -> label "call" call <*> m a
-  , \ _        -> GenM $ \ _ -> label "cutfail" cutfail
-  , NonDet.gen
+gen (GenM m) = choiceM
+  [ GenM $ \ a -> label "call" call <*> m a
+  , GenM $ \ _ -> label "cutfail" cutfail
+  , NonDet.gen (GenM m)
   ]
 
 

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -29,7 +29,7 @@ tests = testGroup "Empty"
 
 
 gen :: Has Empty sig m => GenM m -> GenM m
-gen _ = GenM $ \ _ -> label "empty" empty
+gen = genM $ \ _ _ -> label "empty" empty
 
 
 test

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables, TypeApplications #-}
 module Empty
 ( tests
-, gen
+, gen0
 , test
 ) where
 
@@ -23,13 +23,13 @@ tests = testGroup "Empty"
     ] >>= ($ runL (fmap maybeToList . EmptyC.runEmpty))
   , testGroup "Maybe"  $ testEmpty (runL (pure . maybeToList))
   ] where
-  testMonad    run = Monad.test    (m gen) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m gen) a b   (identity <*> unit) run
-  testEmpty    run = Empty.test    (m gen) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b c (identity <*> unit) run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0) (\ _ _ -> [])) a b   (identity <*> unit) run
+  testEmpty    run = Empty.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b   (identity <*> unit) run
 
 
-gen :: Has Empty sig m => GenM m -> GenM m
-gen _ = GenM $ \ _ -> label "empty" empty
+gen0 :: Has Empty sig m => [Gen (m a)]
+gen0 = [ label "empty" empty ]
 
 
 test

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -23,9 +23,10 @@ tests = testGroup "Empty"
     ] >>= ($ runL (fmap maybeToList . EmptyC.runEmpty))
   , testGroup "Maybe"  $ testEmpty (runL (pure . maybeToList))
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0) (\ _ _ -> [])) a b   (identity <*> unit) run
-  testEmpty    run = Empty.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0) (\ _ _ -> [])) a b   initial run
+  testEmpty    run = Empty.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b   initial run
+  initial = identity <*> unit
 
 
 gen0 :: Has Empty sig m => [Gen (m a)]

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -29,7 +29,7 @@ tests = testGroup "Empty"
 
 
 gen :: Has Empty sig m => GenM m -> GenM m
-gen = genM $ \ _ _ -> label "empty" empty
+gen _ = GenM $ \ _ -> label "empty" empty
 
 
 test

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -29,7 +29,7 @@ tests = testGroup "Empty"
 
 
 gen :: Has Empty sig m => GenM m -> GenM m
-gen _ _ = label "empty" empty
+gen _ = GenM $ \ _ -> label "empty" empty
 
 
 test
@@ -41,7 +41,7 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test m _ b i (Run runEmpty) =
+test (GenM m) _ b i (Run runEmpty) =
   [ testProperty "empty annihilates >>=" . forall (i :. fn @a (m b) :. Nil) $
     \ i k -> runEmpty ((empty >>= k) <$ i) === runEmpty (empty <$ i)
   ]

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -23,14 +23,14 @@ tests = testGroup "Empty"
     ] >>= ($ runL (fmap maybeToList . EmptyC.runEmpty))
   , testGroup "Maybe"  $ testEmpty (runL (pure . maybeToList))
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0) (\ _ _ -> [])) a b   initial run
-  testEmpty    run = Empty.test    (m (\ _ -> gen0) (\ _ _ -> [])) a b   initial run
+  testMonad    run = Monad.test    (m gen0 (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m gen0 (\ _ _ -> [])) a b   initial run
+  testEmpty    run = Empty.test    (m gen0 (\ _ _ -> [])) a b   initial run
   initial = identity <*> unit
 
 
-gen0 :: Has Empty sig m => [Gen (m a)]
-gen0 = [ label "empty" empty ]
+gen0 :: Has Empty sig m => Gen a -> [Gen (m a)]
+gen0 _ = [ label "empty" empty ]
 
 
 test

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -41,7 +41,7 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test (GenM m) _ b i (Run runEmpty) =
+test m _ b i (Run runEmpty) =
   [ testProperty "empty annihilates >>=" . forall (i :. fn @a (m b) :. Nil) $
     \ i k -> runEmpty ((empty >>= k) <$ i) === runEmpty (empty <$ i)
   ]

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -26,9 +26,10 @@ tests = testGroup "Error" $
   , testGroup "Either"  $ testError (runL pure)
   , testGroup "ExceptT" $ testError (runL ExceptT.runExceptT)
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (genN e)) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (genN e)) a b   (identity <*> unit) run
-  testError    run = Error.test e  (m (\ _ -> gen0 e) (genN e)) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (genN e)) a b c initial run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (genN e)) a b   initial run
+  testError    run = Error.test e  (m (\ _ -> gen0 e) (genN e)) a b   initial run
+  initial = identity <*> unit
 
 gen0 :: Has (Error e) sig m => Gen e -> [Gen (m a)]
 gen0 = Throw.gen0

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -35,8 +35,7 @@ gen0 :: Has (Error e) sig m => Gen e -> Gen a -> [Gen (m a)]
 gen0 = Throw.gen0
 
 genN
-  :: forall e m a sig
-  .  (Has (Error e) sig m, Arg e, Show e, Vary e)
+  :: (Has (Error e) sig m, Arg e, Show e, Vary e)
   => Gen e
   -> GenM m
   -> Gen a

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -31,7 +31,7 @@ tests = testGroup "Error" $
 
 
 gen :: (Has (Error e) sig m, Arg e, Show e, Vary e) => Gen e -> GenM m -> GenM m
-gen e = choiceM [ Throw.gen e, Catch.gen e ]
+gen e m = choiceM [ Throw.gen e m, Catch.gen e m ]
 
 
 test

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -31,9 +31,9 @@ tests = testGroup "Error" $
 
 
 gen :: (Has (Error e) sig m, Arg e, Show e, Vary e) => Gen e -> GenM m -> GenM m
-gen e m a = choice
-  [ Throw.gen e m a
-  , Catch.gen e m a
+gen e m = GenM $ \ a -> choice
+  [ runGenM (Throw.gen e m) a
+  , runGenM (Catch.gen e m) a
   ]
 
 

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -31,9 +31,9 @@ tests = testGroup "Error" $
 
 
 gen :: (Has (Error e) sig m, Arg e, Show e, Vary e) => Gen e -> GenM m -> GenM m
-gen e m = GenM $ \ a -> choice
-  [ runGenM (Throw.gen e m) a
-  , runGenM (Catch.gen e m) a
+gen e = choiceM
+  [ Throw.gen e
+  , Catch.gen e
   ]
 
 

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -31,10 +31,7 @@ tests = testGroup "Error" $
 
 
 gen :: (Has (Error e) sig m, Arg e, Show e, Vary e) => Gen e -> GenM m -> GenM m
-gen e = choiceM
-  [ Throw.gen e
-  , Catch.gen e
-  ]
+gen e = choiceM [ Throw.gen e, Catch.gen e ]
 
 
 test

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -26,12 +26,12 @@ tests = testGroup "Error" $
   , testGroup "Either"  $ testError (runL pure)
   , testGroup "ExceptT" $ testError (runL ExceptT.runExceptT)
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (genN e)) a b c initial run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (genN e)) a b   initial run
-  testError    run = Error.test e  (m (\ _ -> gen0 e) (genN e)) a b   initial run
+  testMonad    run = Monad.test    (m (gen0 e) (genN e)) a b c initial run
+  testMonadFix run = MonadFix.test (m (gen0 e) (genN e)) a b   initial run
+  testError    run = Error.test e  (m (gen0 e) (genN e)) a b   initial run
   initial = identity <*> unit
 
-gen0 :: Has (Error e) sig m => Gen e -> [Gen (m a)]
+gen0 :: Has (Error e) sig m => Gen e -> Gen a -> [Gen (m a)]
 gen0 = Throw.gen0
 
 genN

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -10,6 +10,7 @@ import qualified Control.Carrier.Error.Either as ErrorC
 import Control.Effect.Error
 import qualified Control.Monad.Trans.Except as ExceptT
 import qualified Catch
+import Data.Semigroup as S ((<>))
 import Gen
 import qualified Monad
 import qualified MonadFix
@@ -52,6 +53,4 @@ test
   -> Gen (f ())
   -> Run f (Either e) m
   -> [TestTree]
-test e m a b i runError
-  =  Throw.test e m a b i runError
-  ++ Catch.test e m a b i runError
+test e m = Throw.test e m S.<> Catch.test e m

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -29,7 +29,7 @@ tests = testGroup "Fail" $
 
 
 gen :: MonadFail m => Gen String -> GenM m -> GenM m
-gen e _ = GenM $ \ _ -> label "fail" Fail.fail <*> e
+gen e = genM $ \ _ _ -> label "fail" Fail.fail <*> e
 
 
 test

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -22,9 +22,10 @@ tests = testGroup "Fail" $
     , testFail
     ] >>= ($ runL FailC.runFail)
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
-  testFail     run = Fail.test e   (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
+  testFail     run = Fail.test e   (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
+  initial = identity <*> unit
   e = string (Range.linear 0 50) unicode
 
 

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -29,7 +29,7 @@ tests = testGroup "Fail" $
 
 
 gen :: MonadFail m => Gen String -> GenM m -> GenM m
-gen e = genM $ \ _ _ -> label "fail" Fail.fail <*> e
+gen e _ = GenM $ \ _ -> label "fail" Fail.fail <*> e
 
 
 test

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -29,7 +29,7 @@ tests = testGroup "Fail" $
 
 
 gen :: MonadFail m => Gen String -> GenM m -> GenM m
-gen e _ _ = label "fail" Fail.fail <*> e
+gen e _ = GenM $ \ _ -> label "fail" Fail.fail <*> e
 
 
 test
@@ -42,7 +42,7 @@ test
   -> Gen (f ())
   -> Run f (Either String) m
   -> [TestTree]
-test msg m _ b i (Run runFail) =
+test msg (GenM m) _ b i (Run runFail) =
   [ testProperty "fail annihilates >>=" . forall (i :. msg :. fn @a (m b) :. Nil) $
     \ i s k -> runFail ((Fail.fail s >>= k) <$ i) === runFail ((Fail.fail s) <$ i)
   ]

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -42,7 +42,7 @@ test
   -> Gen (f ())
   -> Run f (Either String) m
   -> [TestTree]
-test msg (GenM m) _ b i (Run runFail) =
+test msg m _ b i (Run runFail) =
   [ testProperty "fail annihilates >>=" . forall (i :. msg :. fn @a (m b) :. Nil) $
     \ i s k -> runFail ((Fail.fail s >>= k) <$ i) === runFail ((Fail.fail s) <$ i)
   ]

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -22,15 +22,15 @@ tests = testGroup "Fail" $
     , testFail
     ] >>= ($ runL FailC.runFail)
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
-  testFail     run = Fail.test e   (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
+  testMonad    run = Monad.test    (m (gen0 e) (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m (gen0 e) (\ _ _ -> [])) a b   initial run
+  testFail     run = Fail.test e   (m (gen0 e) (\ _ _ -> [])) a b   initial run
   initial = identity <*> unit
   e = string (Range.linear 0 50) unicode
 
 
-gen0 :: MonadFail m => Gen String -> [Gen (m a)]
-gen0 e = [ label "fail" Fail.fail <*> e ]
+gen0 :: MonadFail m => Gen String -> Gen a -> [Gen (m a)]
+gen0 e _ = [ label "fail" Fail.fail <*> e ]
 
 
 test

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables, TypeApplications #-}
 module Fail
 ( tests
-, gen
+, gen0
 , test
 ) where
 
@@ -22,14 +22,14 @@ tests = testGroup "Fail" $
     , testFail
     ] >>= ($ runL FailC.runFail)
   ] where
-  testMonad    run = Monad.test    (m (gen e)) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (gen e)) a b   (identity <*> unit) run
-  testFail     run = Fail.test e   (m (gen e)) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c (identity <*> unit) run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
+  testFail     run = Fail.test e   (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
   e = string (Range.linear 0 50) unicode
 
 
-gen :: MonadFail m => Gen String -> GenM m -> GenM m
-gen e _ = GenM $ \ _ -> label "fail" Fail.fail <*> e
+gen0 :: MonadFail m => Gen String -> [Gen (m a)]
+gen0 e = [ label "fail" Fail.fail <*> e ]
 
 
 test

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -22,9 +22,9 @@ tests = testGroup "Fresh"
     , testFresh
     ] >>= ($ runC FreshC.runFresh)
   ] where
-  testMonad    run = Monad.test    (m gen) a b c (atom "(,)" (,) <*> n <*> unit) run
-  testMonadFix run = MonadFix.test (m gen) a b   (atom "(,)" (,) <*> n <*> unit) run
-  testFresh    run = Fresh.test    (m gen) a     (atom "(,)" (,) <*> n <*> unit) run
+  testMonad    run = Monad.test    (m gen) a b c (pair <*> n <*> unit) run
+  testMonadFix run = MonadFix.test (m gen) a b   (pair <*> n <*> unit) run
+  testFresh    run = Fresh.test    (m gen) a     (pair <*> n <*> unit) run
   n = Gen.integral (R.linear 0 100)
 
 

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -29,7 +29,7 @@ tests = testGroup "Fresh"
 
 
 gen :: Has Fresh sig m => GenM m -> GenM m
-gen _ a = atom "fmap" fmap <*> fn a <*> label "fresh" fresh
+gen _ = GenM $ \ a -> atom "fmap" fmap <*> fn a <*> label "fresh" fresh
 
 
 test
@@ -39,7 +39,7 @@ test
   -> Gen (f ())
   -> Run f ((,) Int) m
   -> [TestTree]
-test m a i (Run runFresh) =
+test (GenM m) a i (Run runFresh) =
   [ testProperty "fresh yields unique values" . forall (i :. m a :. Nil) $
     \ i m -> runFresh ((m >> fresh) <$ i) /== runFresh ((m >> fresh >> fresh) <$ i)
   ]

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -22,14 +22,14 @@ tests = testGroup "Fresh"
     , testFresh
     ] >>= ($ runC FreshC.runFresh)
   ] where
-  testMonad    run = Monad.test    (m gen) a b c (pair <*> n <*> unit) run
-  testMonadFix run = MonadFix.test (m gen) a b   (pair <*> n <*> unit) run
-  testFresh    run = Fresh.test    (m gen) a     (pair <*> n <*> unit) run
+  testMonad    run = Monad.test    (m gen (\ _ _ -> [])) a b c (pair <*> n <*> unit) run
+  testMonadFix run = MonadFix.test (m gen (\ _ _ -> [])) a b   (pair <*> n <*> unit) run
+  testFresh    run = Fresh.test    (m gen (\ _ _ -> [])) a     (pair <*> n <*> unit) run
   n = Gen.integral (R.linear 0 100)
 
 
-gen :: Has Fresh sig m => GenM m -> GenM m
-gen _ = GenM $ \ a -> atom "fmap" fmap <*> fn a <*> label "fresh" fresh
+gen :: Has Fresh sig m => Gen a -> [Gen (m a)]
+gen a = [ atom "fmap" fmap <*> fn a <*> label "fresh" fresh ]
 
 
 test

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -29,7 +29,7 @@ tests = testGroup "Fresh"
 
 
 gen :: Has Fresh sig m => GenM m -> GenM m
-gen = genM $ \ _ a -> atom "fmap" fmap <*> fn a <*> label "fresh" fresh
+gen _ = GenM $ \ a -> atom "fmap" fmap <*> fn a <*> label "fresh" fresh
 
 
 test

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -29,7 +29,7 @@ tests = testGroup "Fresh"
 
 
 gen :: Has Fresh sig m => GenM m -> GenM m
-gen _ = GenM $ \ a -> atom "fmap" fmap <*> fn a <*> label "fresh" fresh
+gen = genM $ \ _ a -> atom "fmap" fmap <*> fn a <*> label "fresh" fresh
 
 
 test

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -22,9 +22,10 @@ tests = testGroup "Fresh"
     , testFresh
     ] >>= ($ runC FreshC.runFresh)
   ] where
-  testMonad    run = Monad.test    (m gen (\ _ _ -> [])) a b c (pair <*> n <*> unit) run
-  testMonadFix run = MonadFix.test (m gen (\ _ _ -> [])) a b   (pair <*> n <*> unit) run
-  testFresh    run = Fresh.test    (m gen (\ _ _ -> [])) a     (pair <*> n <*> unit) run
+  testMonad    run = Monad.test    (m gen (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m gen (\ _ _ -> [])) a b   initial run
+  testFresh    run = Fresh.test    (m gen (\ _ _ -> [])) a     initial run
+  initial = pair <*> n <*> unit
   n = Gen.integral (R.linear 0 100)
 
 

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -39,7 +39,7 @@ test
   -> Gen (f ())
   -> Run f ((,) Int) m
   -> [TestTree]
-test (GenM m) a i (Run runFresh) =
+test m a i (Run runFresh) =
   [ testProperty "fresh yields unique values" . forall (i :. m a :. Nil) $
     \ i m -> runFresh ((m >> fresh) <$ i) /== runFresh ((m >> fresh >> fresh) <$ i)
   ]

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -310,6 +310,3 @@ instance Applicative NestC where
 
 instance Monad NestC where
   NestC a >>= f = f a
-
-instance Carrier Nest NestC where
-  eff (Nest (NestC m) k) = k m

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -54,6 +54,7 @@ module Gen
   -- * Higher-order effects
 , Nest
 , nest
+, runNest
 , NestC(..)
 ) where
 
@@ -296,6 +297,9 @@ instance Effect   Nest where
 
 nest :: Has Nest sig m => m a -> m a
 nest m = send (Nest m pure)
+
+runNest :: NestC a -> a
+runNest (NestC a) = a
 
 newtype NestC a = NestC a
   deriving (Eq, Functor, Show)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, ExistentialQuantification, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
+{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-identities #-}
 module Gen
 ( module Control.Carrier.Pure
@@ -52,12 +52,9 @@ module Gen
 , Gen.fn
 , termFn
 , Fn.apply
-  -- * Higher-order effects
-, Nest
 ) where
 
 import Control.Applicative
-import Control.Carrier
 import Control.Carrier.Pure
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer
@@ -288,14 +285,3 @@ newtype Gen a = Gen { runGen :: WriterT (Set.Set LabelName) Hedgehog.Gen (Term a
 instance Applicative Gen where
   pure = Gen . pure . pure
   Gen m1 <*> Gen m2 = Gen ((<*>) <$> m1 <*> m2)
-
-
-data Nest m k = forall a . Nest (m a) (a -> m k)
-
-deriving instance Functor m => Functor (Nest m)
-
-instance HFunctor Nest where
-  hmap f (Nest m k) = Nest (f m) (f . k)
-
-instance Effect   Nest where
-  handle state handler (Nest m k) = Nest (handler (m <$ state)) (handler . fmap k)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -54,7 +54,6 @@ module Gen
   -- * Higher-order effects
 , Nest
 , nest
-, runNest
 , NestC(..)
 ) where
 
@@ -299,21 +298,10 @@ instance Effect   Nest where
 nest :: Has Nest sig m => m a -> m a
 nest m = send (Nest m pure)
 
-runNest :: NestC a -> a
-runNest (NestC a) = a
 
-newtype NestC a = NestC a
-  deriving (Eq, Functor, Show)
+newtype NestC m a = NestC { runNest :: m a }
+  deriving (Applicative, Eq, Functor, Monad, MonadFix, Show)
 
-instance Applicative NestC where
-  pure = NestC
-  NestC f <*> NestC a = NestC (f a)
-
-instance Monad NestC where
-  NestC a >>= f = f a
-
-instance MonadFix NestC where
-  mfix f = NestC (fix (runNest . f))
-
-instance Carrier Nest NestC where
-  eff (Nest (NestC m) k) = k m
+instance Carrier sig m => Carrier (Nest :+: sig) (NestC m) where
+  eff (L (Nest m k)) = m >>= k
+  eff (R other)      = NestC (eff (handleCoercible other))

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -53,7 +53,7 @@ module Gen
 , termFn
 , Fn.apply
   -- * Higher-order effects
-, Nest(..)
+, Nest
 ) where
 
 import Control.Applicative

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -5,7 +5,7 @@ module Gen
 , Identity(..)
   -- * Polymorphic generation & instantiation
 , m
-, GenM(..)
+, GenM
 , genT
 , T(..)
 , a
@@ -82,13 +82,13 @@ m
   -> GenM m                                      -- ^ A computation generator.
 m terminals nonterminals = m where
   m :: GenM m
-  m = GenM $ \ a -> Gen $ scale (`div` 2) $ recursive Hedgehog.Gen.choice
+  m = \ a -> Gen $ scale (`div` 2) $ recursive Hedgehog.Gen.choice
     (runGen <$> ((Gen.label "pure" pure <*> a) : terminals a))
-    ( (runGen (addLabel ">>" (infixL 1 ">>" (>>) <*> runGenM m a <*> runGenM m a)))
+    ( (runGen (addLabel ">>" (infixL 1 ">>" (>>) <*> m a <*> m a)))
     : (runGen <$> nonterminals m a))
 
 -- | Computation generators are higher-order generators of computations in some monad @m@.
-newtype GenM m = GenM { runGenM :: forall a . Gen a -> Gen (m a) }
+type GenM m = (forall a . Gen a -> Gen (m a))
 
 
 genT :: KnownSymbol s => Gen (T s)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -180,18 +180,18 @@ string range cs = Gen (showing <$> Hedgehog.Gen.string range (runTerm <$> runGen
 
 
 -- | This captures the shape of the handler function passed to the "Monad" & "MonadFix" tests.
-newtype Run f g m = Run (forall a . f (m a) -> PureC (g a))
+newtype Run f g m = Run (forall a . f (m a) -> NestC (g a))
 
 -- | Handlers with output state, but no input state (e.g. 'Control.Carrier.Error.Either.ErrorC').
-runL :: (forall a . m a -> PureC (f a)) -> Run Identity f m
+runL :: (forall a . m a -> NestC (f a)) -> Run Identity f m
 runL run = Run (run . runIdentity)
 
 -- | Handlers with input state, but no output state (e.g. 'Control.Carrier.Reader.ReaderC').
-runR :: (forall a . f (m a) -> PureC a) -> Run f Identity m
+runR :: (forall a . f (m a) -> NestC a) -> Run f Identity m
 runR run = Run (fmap Identity . run)
 
 -- | Handlers with curried input state (e.g. 'Control.Carrier.Reader.ReaderC', 'Control.Carrier.State.Strict.StateC').
-runC :: (forall a . s -> m a -> PureC (f a)) -> Run ((,) s) f m
+runC :: (forall a . s -> m a -> NestC (f a)) -> Run ((,) s) f m
 runC run = Run (uncurry run)
 
 

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -6,6 +6,7 @@ module Gen
   -- * Polymorphic generation & instantiation
 , m
 , GenM(..)
+, genM
 , genT
 , T(..)
 , a
@@ -92,6 +93,9 @@ m with = m where
 
 -- | Computation generators are higher-order generators of computations in some monad @m@.
 newtype GenM m = GenM { runGenM :: forall a . Gen a -> Gen (m a) }
+
+genM :: (forall a . (forall a . Gen a -> Gen (m a)) -> Gen a -> Gen (m a)) -> GenM m -> GenM m
+genM with (GenM m) = GenM (with m)
 
 
 genT :: KnownSymbol s => Gen (T s)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -241,7 +241,7 @@ pair :: Gen (a -> b -> (a, b))
 pair = Gen (pure Pair)
 
 addLabel :: String -> Gen a -> Gen a
-addLabel s = Gen . (>>= \ a -> a <$ tell (Set.singleton (fromString s))) . runGen
+addLabel s = Gen . (>>= (<$ tell (Set.singleton (fromString s)))) . runGen
 
 
 data Term a where

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -53,7 +53,7 @@ module Gen
 , termFn
 , Fn.apply
   -- * Higher-order effects
-, Nest
+, Nest(..)
 ) where
 
 import Control.Applicative

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -310,3 +310,6 @@ instance Applicative NestC where
 
 instance Monad NestC where
   NestC a >>= f = f a
+
+instance Carrier Nest NestC where
+  eff (Nest (NestC m) k) = k m

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -307,3 +307,6 @@ newtype NestC a = NestC a
 instance Applicative NestC where
   pure = NestC
   NestC f <*> NestC a = NestC (f a)
+
+instance Monad NestC where
+  NestC a >>= f = f a

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
+{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, ExistentialQuantification, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-identities #-}
 module Gen
 ( module Control.Carrier.Pure
@@ -52,9 +52,12 @@ module Gen
 , Gen.fn
 , termFn
 , Fn.apply
+  -- * Higher-order effects
+, Nest
 ) where
 
 import Control.Applicative
+import Control.Carrier
 import Control.Carrier.Pure
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer
@@ -285,3 +288,14 @@ newtype Gen a = Gen { runGen :: WriterT (Set.Set LabelName) Hedgehog.Gen (Term a
 instance Applicative Gen where
   pure = Gen . pure . pure
   Gen m1 <*> Gen m2 = Gen ((<*>) <$> m1 <*> m2)
+
+
+data Nest m k = forall a . Nest (m a) (a -> m k)
+
+deriving instance Functor m => Functor (Nest m)
+
+instance HFunctor Nest where
+  hmap f (Nest m k) = Nest (f m) (f . k)
+
+instance Effect   Nest where
+  handle state handler (Nest m k) = Nest (handler (m <$ state)) (handler . fmap k)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, ExistentialQuantification, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
+{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-identities #-}
 module Gen
 ( module Control.Carrier.Pure
@@ -51,12 +51,9 @@ module Gen
 , Gen.fn
 , termFn
 , Fn.apply
-  -- * Higher-order effects
-, Nest
 ) where
 
 import Control.Applicative
-import Control.Carrier
 import Control.Carrier.Pure
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer
@@ -280,14 +277,3 @@ newtype Gen a = Gen { runGen :: WriterT (Set.Set LabelName) Hedgehog.Gen (Term a
 instance Applicative Gen where
   pure = Gen . pure . pure
   Gen m1 <*> Gen m2 = Gen ((<*>) <$> m1 <*> m2)
-
-
-data Nest m k = forall a . Nest (m a) (a -> m k)
-
-deriving instance Functor m => Functor (Nest m)
-
-instance HFunctor Nest where
-  hmap f (Nest m k) = Nest (f m) (f . k)
-
-instance Effect   Nest where
-  handle state handler (Nest m k) = Nest (handler (m <$ state)) (handler . fmap k)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -303,7 +303,3 @@ runNest (NestC a) = a
 
 newtype NestC a = NestC a
   deriving (Eq, Functor, Show)
-
-instance Applicative NestC where
-  pure = NestC
-  NestC f <*> NestC a = NestC (f a)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
+{-# LANGUAGE DataKinds, DeriveFunctor, DeriveGeneric, ExistentialQuantification, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, KindSignatures, LambdaCase, PatternSynonyms, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances, ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-identities #-}
 module Gen
 ( module Control.Carrier.Pure
@@ -51,9 +51,12 @@ module Gen
 , Gen.fn
 , termFn
 , Fn.apply
+  -- * Higher-order effects
+, Nest
 ) where
 
 import Control.Applicative
+import Control.Carrier
 import Control.Carrier.Pure
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer
@@ -277,3 +280,14 @@ newtype Gen a = Gen { runGen :: WriterT (Set.Set LabelName) Hedgehog.Gen (Term a
 instance Applicative Gen where
   pure = Gen . pure . pure
   Gen m1 <*> Gen m2 = Gen ((<*>) <$> m1 <*> m2)
+
+
+data Nest m k = forall a . Nest (m a) (a -> m k)
+
+deriving instance Functor m => Functor (Nest m)
+
+instance HFunctor Nest where
+  hmap f (Nest m k) = Nest (f m) (f . k)
+
+instance Effect   Nest where
+  handle state handler (Nest m k) = Nest (handler (m <$ state)) (handler . fmap k)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -44,6 +44,7 @@ module Gen
 , (===)
 , (/==)
 , Gen.choice
+, choiceM
 , Gen.integral
 , Gen.unicode
 , Gen.string
@@ -162,6 +163,9 @@ termFn b = Gen $ recursive Hedgehog.Gen.choice
 
 choice :: [Gen a] -> Gen a
 choice = Gen . Hedgehog.Gen.choice . Prelude.map runGen
+
+choiceM :: [GenM a] -> GenM a
+choiceM cs = GenM $ \ a -> Gen.choice (Prelude.map runGenM cs <*> [a])
 
 integral :: (Integral a, Show a) => Range a -> Gen a
 integral range = Gen (showing <$> Hedgehog.Gen.integral range)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -307,6 +307,3 @@ newtype NestC a = NestC a
 instance Applicative NestC where
   pure = NestC
   NestC f <*> NestC a = NestC (f a)
-
-instance Monad NestC where
-  NestC a >>= f = f a

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -85,10 +85,8 @@ m terminals nonterminals = m where
   m :: GenM m
   m = GenM $ \ a -> Gen $ scale (`div` 2) $ recursive Hedgehog.Gen.choice
     (runGen <$> ((Gen.label "pure" pure <*> a) : terminals a))
-    [ frequency
-      $ (1, runGen (addLabel ">>" (infixL 1 ">>" (>>) <*> runGenM m a <*> runGenM m a)))
-      : ((,) 3 . runGen <$> nonterminals m a)
-    ]
+    ( (runGen (addLabel ">>" (infixL 1 ">>" (>>) <*> runGenM m a <*> runGenM m a)))
+    : (runGen <$> nonterminals m a))
 
 -- | Computation generators are higher-order generators of computations in some monad @m@.
 newtype GenM m = GenM { runGenM :: forall a . Gen a -> Gen (m a) }

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -164,8 +164,8 @@ termFn b = Gen $ recursive Hedgehog.Gen.choice
 choice :: [Gen a] -> Gen a
 choice = Gen . Hedgehog.Gen.choice . Prelude.map runGen
 
-choiceM :: [GenM a] -> GenM a
-choiceM cs = GenM $ \ a -> Gen.choice (Prelude.map runGenM cs <*> [a])
+choiceM :: [GenM m -> GenM m] -> GenM m -> GenM m
+choiceM cs m = GenM $ \ a -> Gen.choice (runGenM <$> (cs <*> [m]) <*> [a])
 
 integral :: (Integral a, Show a) => Range a -> Gen a
 integral range = Gen (showing <$> Hedgehog.Gen.integral range)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -6,7 +6,6 @@ module Gen
   -- * Polymorphic generation & instantiation
 , m
 , GenM(..)
-, genM
 , genT
 , T(..)
 , a
@@ -93,9 +92,6 @@ m with = m where
 
 -- | Computation generators are higher-order generators of computations in some monad @m@.
 newtype GenM m = GenM { runGenM :: forall a . Gen a -> Gen (m a) }
-
-genM :: (forall a . (forall a . Gen a -> Gen (m a)) -> Gen a -> Gen (m a)) -> GenM m -> GenM m
-genM with (GenM m) = GenM (with m)
 
 
 genT :: KnownSymbol s => Gen (T s)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -61,6 +61,7 @@ module Gen
 import Control.Applicative
 import Control.Carrier
 import Control.Carrier.Pure
+import Control.Monad.Fix
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer
 import Data.Foldable (traverse_)
@@ -310,6 +311,9 @@ instance Applicative NestC where
 
 instance Monad NestC where
   NestC a >>= f = f a
+
+instance MonadFix NestC where
+  mfix f = NestC (fix (runNest . f))
 
 instance Carrier Nest NestC where
   eff (Nest (NestC m) k) = k m

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -53,7 +53,6 @@ module Gen
 , Fn.apply
   -- * Higher-order effects
 , Nest
-, nest
 ) where
 
 import Control.Applicative
@@ -292,6 +291,3 @@ instance HFunctor Nest where
 
 instance Effect   Nest where
   handle state handler (Nest m k) = Nest (handler (m <$ state)) (handler . fmap k)
-
-nest :: Has Nest sig m => m a -> m a
-nest m = send (Nest m pure)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -54,7 +54,6 @@ module Gen
   -- * Higher-order effects
 , Nest
 , nest
-, runNest
 , NestC(..)
 ) where
 
@@ -297,9 +296,6 @@ instance Effect   Nest where
 
 nest :: Has Nest sig m => m a -> m a
 nest m = send (Nest m pure)
-
-runNest :: NestC a -> a
-runNest (NestC a) = a
 
 newtype NestC a = NestC a
   deriving (Eq, Functor, Show)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -180,18 +180,18 @@ string range cs = Gen (showing <$> Hedgehog.Gen.string range (runTerm <$> runGen
 
 
 -- | This captures the shape of the handler function passed to the "Monad" & "MonadFix" tests.
-newtype Run f g m = Run (forall a . f (m a) -> NestC (g a))
+newtype Run f g m = Run (forall a . f (m a) -> PureC (g a))
 
 -- | Handlers with output state, but no input state (e.g. 'Control.Carrier.Error.Either.ErrorC').
-runL :: (forall a . m a -> NestC (f a)) -> Run Identity f m
+runL :: (forall a . m a -> PureC (f a)) -> Run Identity f m
 runL run = Run (run . runIdentity)
 
 -- | Handlers with input state, but no output state (e.g. 'Control.Carrier.Reader.ReaderC').
-runR :: (forall a . f (m a) -> NestC a) -> Run f Identity m
+runR :: (forall a . f (m a) -> PureC a) -> Run f Identity m
 runR run = Run (fmap Identity . run)
 
 -- | Handlers with curried input state (e.g. 'Control.Carrier.Reader.ReaderC', 'Control.Carrier.State.Strict.StateC').
-runC :: (forall a . s -> m a -> NestC (f a)) -> Run ((,) s) f m
+runC :: (forall a . s -> m a -> PureC (f a)) -> Run ((,) s) f m
 runC run = Run (uncurry run)
 
 

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -5,7 +5,7 @@ module Gen
 , Identity(..)
   -- * Polymorphic generation & instantiation
 , m
-, GenM
+, GenM(..)
 , genT
 , T(..)
 , a
@@ -80,16 +80,16 @@ m
   -> GenM m             -- ^ A computation generator.
 m with = m where
   m :: GenM m
-  m a = Gen $ scale (`div` 2) $ recursive Hedgehog.Gen.choice
+  m = GenM $ \ a -> Gen $ scale (`div` 2) $ recursive Hedgehog.Gen.choice
     [ runGen (Gen.label "pure" pure <*> a) ]
     [ frequency
-      [ (3, runGen (with m a))
-      , (1, runGen (addLabel ">>" (infixL 1 ">>" (>>) <*> m a <*> m a)))
+      [ (3, runGen (runGenM (with m) a))
+      , (1, runGen (addLabel ">>" (infixL 1 ">>" (>>) <*> runGenM m a <*> runGenM m a)))
       ]
     ]
 
 -- | Computation generators are higher-order generators of computations in some monad @m@.
-type GenM m = (forall a . Gen a -> Gen (m a))
+newtype GenM m = GenM { runGenM :: forall a . Gen a -> Gen (m a) }
 
 
 genT :: KnownSymbol s => Gen (T s)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -54,6 +54,7 @@ module Gen
   -- * Higher-order effects
 , Nest
 , nest
+, NestC(..)
 ) where
 
 import Control.Applicative
@@ -295,3 +296,6 @@ instance Effect   Nest where
 
 nest :: Has Nest sig m => m a -> m a
 nest m = send (Nest m pure)
+
+newtype NestC a = NestC a
+  deriving (Eq, Functor, Show)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -54,7 +54,6 @@ module Gen
   -- * Higher-order effects
 , Nest
 , nest
-, NestC(..)
 ) where
 
 import Control.Applicative
@@ -296,6 +295,3 @@ instance Effect   Nest where
 
 nest :: Has Nest sig m => m a -> m a
 nest m = send (Nest m pure)
-
-newtype NestC a = NestC a
-  deriving (Eq, Functor, Show)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -164,8 +164,8 @@ termFn b = Gen $ recursive Hedgehog.Gen.choice
 choice :: [Gen a] -> Gen a
 choice = Gen . Hedgehog.Gen.choice . Prelude.map runGen
 
-choiceM :: [GenM m -> GenM m] -> GenM m -> GenM m
-choiceM cs m = GenM $ \ a -> Gen.choice (runGenM <$> (cs <*> [m]) <*> [a])
+choiceM :: [GenM m] -> GenM m
+choiceM cs = GenM $ \ a -> Gen.choice (runGenM <$> cs <*> [a])
 
 integral :: (Integral a, Show a) => Range a -> Gen a
 integral range = Gen (showing <$> Hedgehog.Gen.integral range)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -61,7 +61,6 @@ module Gen
 import Control.Applicative
 import Control.Carrier
 import Control.Carrier.Pure
-import Control.Monad.Fix
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer
 import Data.Foldable (traverse_)
@@ -311,9 +310,6 @@ instance Applicative NestC where
 
 instance Monad NestC where
   NestC a >>= f = f a
-
-instance MonadFix NestC where
-  mfix f = NestC (fix (runNest . f))
 
 instance Carrier Nest NestC where
   eff (Nest (NestC m) k) = k m

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -44,7 +44,6 @@ module Gen
 , (===)
 , (/==)
 , Gen.choice
-, choiceM
 , Gen.integral
 , Gen.unicode
 , Gen.string
@@ -161,9 +160,6 @@ termFn b = Gen $ recursive Hedgehog.Gen.choice
 
 choice :: [Gen a] -> Gen a
 choice = Gen . Hedgehog.Gen.choice . Prelude.map runGen
-
-choiceM :: [GenM m] -> GenM m
-choiceM cs = GenM $ \ a -> Gen.choice (runGenM <$> cs <*> [a])
 
 integral :: (Integral a, Show a) => Range a -> Gen a
 integral range = Gen (showing <$> Hedgehog.Gen.integral range)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -53,6 +53,7 @@ module Gen
 , Fn.apply
   -- * Higher-order effects
 , Nest
+, nest
 ) where
 
 import Control.Applicative
@@ -291,3 +292,6 @@ instance HFunctor Nest where
 
 instance Effect   Nest where
   handle state handler (Nest m k) = Nest (handler (m <$ state)) (handler . fmap k)
+
+nest :: Has Nest sig m => m a -> m a
+nest m = send (Nest m pure)

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -303,3 +303,7 @@ runNest (NestC a) = a
 
 newtype NestC a = NestC a
   deriving (Eq, Functor, Show)
+
+instance Applicative NestC where
+  pure = NestC
+  NestC f <*> NestC a = NestC (f a)

--- a/test/Monad.hs
+++ b/test/Monad.hs
@@ -17,7 +17,7 @@ test
   -> Gen (f ())
   -> Run f g m
   -> [TestTree]
-test m a b c s (Run run) =
+test (GenM m) a b c s (Run run) =
   [ testProperty "return is the left-identity of >>=" . forall (s :. a :. fn (m b) :. Nil) $
     \ s a k -> run ((return a >>= k) <$ s) === run ((k a) <$ s)
   , testProperty "return is the right-identity of >>=" . forall (s :. m a :. Nil) $

--- a/test/Monad.hs
+++ b/test/Monad.hs
@@ -17,7 +17,7 @@ test
   -> Gen (f ())
   -> Run f g m
   -> [TestTree]
-test (GenM m) a b c s (Run run) =
+test m a b c s (Run run) =
   [ testProperty "return is the left-identity of >>=" . forall (s :. a :. fn (m b) :. Nil) $
     \ s a k -> run ((return a >>= k) <$ s) === run ((k a) <$ s)
   , testProperty "return is the right-identity of >>=" . forall (s :. m a :. Nil) $

--- a/test/MonadFix.hs
+++ b/test/MonadFix.hs
@@ -17,7 +17,7 @@ test
   -> Gen (f ())
   -> Run f g m
   -> [TestTree]
-test (GenM m) a b s (Run run) =
+test m a b s (Run run) =
   [ testProperty "purity" . forall (s :. termFn a :. Nil) $
     \ s h -> run (mfix (return . h) <$ s) === run (return (fix h) <$ s)
   , testProperty "left-shrinking" . forall (s :. m a :. termFn (fn (m b)) :. Nil) $

--- a/test/MonadFix.hs
+++ b/test/MonadFix.hs
@@ -17,7 +17,7 @@ test
   -> Gen (f ())
   -> Run f g m
   -> [TestTree]
-test m a b s (Run run) =
+test (GenM m) a b s (Run run) =
   [ testProperty "purity" . forall (s :. termFn a :. Nil) $
     \ s h -> run (mfix (return . h) <$ s) === run (return (fix h) <$ s)
   , testProperty "left-shrinking" . forall (s :. m a :. termFn (fn (m b)) :. Nil) $

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes #-}
 module NonDet
 ( tests
-, gen
+, gen0
+, genN
 , test
 ) where
 
@@ -26,13 +27,16 @@ tests = testGroup "NonDet"
     ] >>= ($ runL Church.NonDetC.runNonDetA)
   , testGroup "[]" $ testNonDet (runL pure)
   ] where
-  testMonad    run = Monad.test    (m gen) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m gen) a b   (identity <*> unit) run
-  testNonDet   run = NonDet.test   (m gen) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (const gen0) genN) a b c (identity <*> unit) run
+  testMonadFix run = MonadFix.test (m (const gen0) genN) a b   (identity <*> unit) run
+  testNonDet   run = NonDet.test   (m (const gen0) genN) a b   (identity <*> unit) run
 
 
-gen :: Has NonDet sig m => GenM m -> GenM m
-gen m = choiceM [ Empty.gen m, Choose.gen m ]
+gen0 :: Has NonDet sig m => [Gen (m a)]
+gen0 = Empty.gen0
+
+genN :: Has NonDet sig m => GenM m -> Gen a -> [Gen (m a)]
+genN = Choose.genN
 
 
 test

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -27,13 +27,13 @@ tests = testGroup "NonDet"
     ] >>= ($ runL Church.NonDetC.runNonDetA)
   , testGroup "[]" $ testNonDet (runL pure)
   ] where
-  testMonad    run = Monad.test    (m (const gen0) genN) a b c initial run
-  testMonadFix run = MonadFix.test (m (const gen0) genN) a b   initial run
-  testNonDet   run = NonDet.test   (m (const gen0) genN) a b   initial run
+  testMonad    run = Monad.test    (m gen0 genN) a b c initial run
+  testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run
+  testNonDet   run = NonDet.test   (m gen0 genN) a b   initial run
   initial = identity <*> unit
 
 
-gen0 :: Has NonDet sig m => [Gen (m a)]
+gen0 :: Has NonDet sig m => Gen a -> [Gen (m a)]
 gen0 = Empty.gen0
 
 genN :: Has NonDet sig m => GenM m -> Gen a -> [Gen (m a)]

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -11,6 +11,7 @@ import qualified Control.Carrier.NonDet.Church as Church.NonDetC
 import Control.Effect.Choose
 import Control.Effect.Empty
 import Control.Effect.NonDet (NonDet)
+import Data.Semigroup as S ((<>))
 import qualified Empty
 import Gen
 import qualified Monad
@@ -48,10 +49,12 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test m a b i (Run runNonDet)
-  =  testProperty "empty is the left identity of <|>"  (forall (i :. m a :. Nil)
-    (\ i m -> runNonDet ((empty <|> m) <$ i) === runNonDet (m <$ i)))
-  :  testProperty "empty is the right identity of <|>" (forall (i :. m a :. Nil)
-    (\ i m -> runNonDet ((m <|> empty) <$ i) === runNonDet (m <$ i)))
-  :  Empty.test  m a b i (Run runNonDet)
-  ++ Choose.test m a b i (Run runNonDet)
+test m
+  = (\ a _ i (Run runNonDet) ->
+    [ testProperty "empty is the left identity of <|>"  (forall (i :. m a :. Nil)
+      (\ i m -> runNonDet ((empty <|> m) <$ i) === runNonDet (m <$ i)))
+    ,  testProperty "empty is the right identity of <|>" (forall (i :. m a :. Nil)
+      (\ i m -> runNonDet ((m <|> empty) <$ i) === runNonDet (m <$ i)))
+    ])
+  S.<> Empty.test  m
+  S.<> Choose.test m

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -32,7 +32,7 @@ tests = testGroup "NonDet"
 
 
 gen :: Has NonDet sig m => GenM m -> GenM m
-gen m a = choice [ Empty.gen m a, Choose.gen m a ]
+gen m = GenM $ \ a -> choice [ runGenM (Empty.gen m) a, runGenM (Choose.gen m) a ]
 
 
 test
@@ -43,10 +43,10 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test m a b i (Run runNonDet)
+test (GenM m) a b i (Run runNonDet)
   =  testProperty "empty is the left identity of <|>"  (forall (i :. m a :. Nil)
     (\ i m -> runNonDet ((empty <|> m) <$ i) === runNonDet (m <$ i)))
   :  testProperty "empty is the right identity of <|>" (forall (i :. m a :. Nil)
     (\ i m -> runNonDet ((m <|> empty) <$ i) === runNonDet (m <$ i)))
-  :  Empty.test  m a b i (Run runNonDet)
-  ++ Choose.test m a b i (Run runNonDet)
+  :  Empty.test  (GenM m) a b i (Run runNonDet)
+  ++ Choose.test (GenM m) a b i (Run runNonDet)

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -32,7 +32,7 @@ tests = testGroup "NonDet"
 
 
 gen :: Has NonDet sig m => GenM m -> GenM m
-gen m = GenM $ \ a -> choice [ runGenM (Empty.gen m) a, runGenM (Choose.gen m) a ]
+gen = choiceM [ Empty.gen, Choose.gen ]
 
 
 test

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -32,7 +32,7 @@ tests = testGroup "NonDet"
 
 
 gen :: Has NonDet sig m => GenM m -> GenM m
-gen = choiceM [ Empty.gen, Choose.gen ]
+gen m = choiceM [ Empty.gen m, Choose.gen m ]
 
 
 test

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -27,9 +27,10 @@ tests = testGroup "NonDet"
     ] >>= ($ runL Church.NonDetC.runNonDetA)
   , testGroup "[]" $ testNonDet (runL pure)
   ] where
-  testMonad    run = Monad.test    (m (const gen0) genN) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (const gen0) genN) a b   (identity <*> unit) run
-  testNonDet   run = NonDet.test   (m (const gen0) genN) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (const gen0) genN) a b c initial run
+  testMonadFix run = MonadFix.test (m (const gen0) genN) a b   initial run
+  testNonDet   run = NonDet.test   (m (const gen0) genN) a b   initial run
+  initial = identity <*> unit
 
 
 gen0 :: Has NonDet sig m => [Gen (m a)]

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -47,10 +47,10 @@ test
   -> Gen (f ())
   -> Run f [] m
   -> [TestTree]
-test (GenM m) a b i (Run runNonDet)
+test m a b i (Run runNonDet)
   =  testProperty "empty is the left identity of <|>"  (forall (i :. m a :. Nil)
     (\ i m -> runNonDet ((empty <|> m) <$ i) === runNonDet (m <$ i)))
   :  testProperty "empty is the right identity of <|>" (forall (i :. m a :. Nil)
     (\ i m -> runNonDet ((m <|> empty) <$ i) === runNonDet (m <$ i)))
-  :  Empty.test  (GenM m) a b i (Run runNonDet)
-  ++ Choose.test (GenM m) a b i (Run runNonDet)
+  :  Empty.test  m a b i (Run runNonDet)
+  ++ Choose.test m a b i (Run runNonDet)

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -43,7 +43,7 @@ gen
   => Gen r
   -> GenM m
   -> GenM m
-gen r (GenM m) = GenM $ \ a -> choice
+gen r = genM $ \ m a -> choice
   [ label "asks" (asks @r) <*> fn a
   , label "local" local <*> fn r <*> m a
   ]

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -43,7 +43,7 @@ gen
   => Gen r
   -> GenM m
   -> GenM m
-gen r = genM $ \ m a -> choice
+gen r (GenM m) = GenM $ \ a -> choice
   [ label "asks" (asks @r) <*> fn a
   , label "local" local <*> fn r <*> m a
   ]

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -47,8 +47,7 @@ gen0
 gen0 _ a = [ label "asks" (asks @r) <*> fn a ]
 
 genN
-  :: forall r m a sig
-  .  (Has (Reader r) sig m, Arg r, Show r, Vary r)
+  :: (Has (Reader r) sig m, Arg r, Show r, Vary r)
   => Gen r
   -> GenM m
   -> Gen a

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -43,7 +43,7 @@ gen
   => Gen r
   -> GenM m
   -> GenM m
-gen r m a = choice
+gen r (GenM m) = GenM $ \ a -> choice
   [ label "asks" (asks @r) <*> fn a
   , label "local" local <*> fn r <*> m a
   ]
@@ -57,7 +57,7 @@ test
   -> Gen (f ())
   -> Run (f :.: (,) r) Identity m
   -> [TestTree]
-test r m a i (Run runReader) =
+test r (GenM m) a i (Run runReader) =
   [ testProperty "ask returns the environment variable" . forall (i :. r :. fn (m a) :. Nil) $
     \ i r k -> runReader (Comp1 ((r, ask >>= k) <$ i)) === runReader (Comp1 ((r, k r) <$ i))
   , testProperty "local modifies the environment variable" . forall (i :. r :. fn r :. m a :. Nil) $

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -30,9 +30,9 @@ tests = testGroup "Reader"
   , testGroup "RWST (Lazy)"   $ testReader (runR (uncurry (runRWST LazyRWST.runRWST)   . lower))
   , testGroup "RWST (Strict)" $ testReader (runR (uncurry (runRWST StrictRWST.runRWST) . lower))
   ] where
-  testMonad    run = Monad.test    (m (gen r)) a b c (Comp1 <$> (identity <*> (atom "(,)" (,) <*> r <*> unit))) run
-  testMonadFix run = MonadFix.test (m (gen r)) a b   (Comp1 <$> (identity <*> (atom "(,)" (,) <*> r <*> unit))) run
-  testReader   run = Reader.test r (m (gen r)) a                (identity <*>                           unit)   run
+  testMonad    run = Monad.test    (m (gen r)) a b c (Comp1 <$> (identity <*> (pair <*> r <*> unit))) run
+  testMonadFix run = MonadFix.test (m (gen r)) a b   (Comp1 <$> (identity <*> (pair <*> r <*> unit))) run
+  testReader   run = Reader.test r (m (gen r)) a                (identity <*>                 unit)   run
   runRWST f r m = (\ (a, _, ()) -> a) <$> f m r r
   lower = runIdentity . unComp1
 

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -53,7 +53,7 @@ genN
   -> GenM m
   -> Gen a
   -> [Gen (m a)]
-genN r (GenM m) a = [ label "local" local <*> fn r <*> m a ]
+genN r m a = [ label "local" local <*> fn r <*> m a ]
 
 
 test
@@ -64,7 +64,7 @@ test
   -> Gen (f ())
   -> Run (f :.: (,) r) Identity m
   -> [TestTree]
-test r (GenM m) a i (Run runReader) =
+test r m a i (Run runReader) =
   [ testProperty "ask returns the environment variable" . forall (i :. r :. fn (m a) :. Nil) $
     \ i r k -> runReader (Comp1 ((r, ask >>= k) <$ i)) === runReader (Comp1 ((r, k r) <$ i))
   , testProperty "local modifies the environment variable" . forall (i :. r :. fn r :. m a :. Nil) $

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -25,7 +25,7 @@ tests = testGroup "Reader"
     , testMonadFix
     , testReader
     ] >>= ($ runR (uncurry ReaderC.runReader . lower))
-  , testGroup "(->)"          $ testReader (runR (uncurry (fmap PureC . (&))           . lower))
+  , testGroup "(->)"          $ testReader (runR (uncurry (fmap pure . (&))            . lower))
   , testGroup "ReaderT"       $ testReader (runR (uncurry (flip ReaderT.runReaderT)    . lower))
   , testGroup "RWST (Lazy)"   $ testReader (runR (uncurry (runRWST LazyRWST.runRWST)   . lower))
   , testGroup "RWST (Strict)" $ testReader (runR (uncurry (runRWST StrictRWST.runRWST) . lower))

--- a/test/State.hs
+++ b/test/State.hs
@@ -48,7 +48,7 @@ gen
   => Gen s
   -> GenM m
   -> GenM m
-gen s _ a = choice
+gen s _ = GenM $ \ a -> choice
   [ label "gets" (gets @s) <*> fn a
   , infixL 4 "<$" (<$) <*> a <*> (label "put" put <*> s)
   ]
@@ -61,7 +61,7 @@ test
   -> Gen s
   -> Run ((,) s) ((,) s) m
   -> [TestTree]
-test m a s (Run runState) =
+test (GenM m) a s (Run runState) =
   [ testProperty "get returns the state variable" . forall (s :. fn (m a) :. Nil) $
     \ s k -> runState (s, get >>= k) === runState (s, k s)
   , testProperty "put updates the state variable" . forall (s :. s :. m a :. Nil) $

--- a/test/State.hs
+++ b/test/State.hs
@@ -61,7 +61,7 @@ test
   -> Gen s
   -> Run ((,) s) ((,) s) m
   -> [TestTree]
-test (GenM m) a s (Run runState) =
+test m a s (Run runState) =
   [ testProperty "get returns the state variable" . forall (s :. fn (m a) :. Nil) $
     \ s k -> runState (s, get >>= k) === runState (s, k s)
   , testProperty "put updates the state variable" . forall (s :. s :. m a :. Nil) $

--- a/test/State.hs
+++ b/test/State.hs
@@ -48,7 +48,7 @@ gen
   => Gen s
   -> GenM m
   -> GenM m
-gen s _ = GenM $ \ a -> choice
+gen s = genM $ \ _ a -> choice
   [ label "gets" (gets @s) <*> fn a
   , infixL 4 "<$" (<$) <*> a <*> (label "put" put <*> s)
   ]

--- a/test/State.hs
+++ b/test/State.hs
@@ -36,9 +36,9 @@ tests = testGroup "State"
   , testGroup "RWST (Lazy)"     $ testState (runC (runRWST LazyRWST.runRWST))
   , testGroup "RWST (Strict)"   $ testState (runC (runRWST StrictRWST.runRWST))
   ] where
-  testMonad    run = Monad.test    (m (gen s)) a b c (atom "(,)" (,) <*> s <*> unit) run
-  testMonadFix run = MonadFix.test (m (gen s)) a b   (atom "(,)" (,) <*> s <*> unit) run
-  testState    run = State.test    (m (gen s)) a                         s           run
+  testMonad    run = Monad.test    (m (gen s)) a b c (pair <*> s <*> unit) run
+  testMonadFix run = MonadFix.test (m (gen s)) a b   (pair <*> s <*> unit) run
+  testState    run = State.test    (m (gen s)) a               s           run
   runRWST f s m = (\ (a, s, ()) -> (s, a)) <$> f m s s
 
 

--- a/test/State.hs
+++ b/test/State.hs
@@ -48,7 +48,7 @@ gen
   => Gen s
   -> GenM m
   -> GenM m
-gen s = genM $ \ _ a -> choice
+gen s _ = GenM $ \ a -> choice
   [ label "gets" (gets @s) <*> fn a
   , infixL 4 "<$" (<$) <*> a <*> (label "put" put <*> s)
   ]

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -27,7 +27,7 @@ tests = testGroup "Throw" $
 
 
 gen :: Has (Throw e) sig m => Gen e -> GenM m -> GenM m
-gen e _ _ = label "throwError" throwError <*> e
+gen e _ = GenM $ \ _ -> label "throwError" throwError <*> e
 
 
 test
@@ -40,7 +40,7 @@ test
   -> Gen (f ())
   -> Run f (Either e) m
   -> [TestTree]
-test e m _ b i (Run runThrow) =
+test e (GenM m) _ b i (Run runThrow) =
   [ testProperty "throwError annihilates >>=" . forall (i :. e :. fn @a (m b) :. Nil) $
     \ i e k -> runThrow ((throwError e >>= k) <$ i) === runThrow ((throwError e) <$ i)
   ]

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables, TypeApplications #-}
 module Throw
 ( tests
-, gen
+, gen0
 , test
 ) where
 
@@ -21,13 +21,13 @@ tests = testGroup "Throw" $
     , testThrow
     ] >>= ($ runL ThrowC.runThrow)
   ] where
-  testMonad    run = Monad.test    (m (gen e)) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (gen e)) a b   (identity <*> unit) run
-  testThrow    run = Throw.test e  (m (gen e)) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c (identity <*> unit) run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
+  testThrow    run = Throw.test e  (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
 
 
-gen :: Has (Throw e) sig m => Gen e -> GenM m -> GenM m
-gen e _ = GenM $ \ _ -> label "throwError" throwError <*> e
+gen0 :: Has (Throw e) sig m => Gen e -> [Gen (m a)]
+gen0 e = [ label "throwError" throwError <*> e ]
 
 
 test

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -21,14 +21,14 @@ tests = testGroup "Throw" $
     , testThrow
     ] >>= ($ runL ThrowC.runThrow)
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
-  testThrow    run = Throw.test e  (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
+  testMonad    run = Monad.test    (m (gen0 e) (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m (gen0 e) (\ _ _ -> [])) a b   initial run
+  testThrow    run = Throw.test e  (m (gen0 e) (\ _ _ -> [])) a b   initial run
   initial = identity <*> unit
 
 
-gen0 :: Has (Throw e) sig m => Gen e -> [Gen (m a)]
-gen0 e = [ label "throwError" throwError <*> e ]
+gen0 :: Has (Throw e) sig m => Gen e -> Gen a -> [Gen (m a)]
+gen0 e _ = [ label "throwError" throwError <*> e ]
 
 
 test

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -27,7 +27,7 @@ tests = testGroup "Throw" $
 
 
 gen :: Has (Throw e) sig m => Gen e -> GenM m -> GenM m
-gen e = genM $ \ _ _ -> label "throwError" throwError <*> e
+gen e _ = GenM $ \ _ -> label "throwError" throwError <*> e
 
 
 test

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -27,7 +27,7 @@ tests = testGroup "Throw" $
 
 
 gen :: Has (Throw e) sig m => Gen e -> GenM m -> GenM m
-gen e _ = GenM $ \ _ -> label "throwError" throwError <*> e
+gen e = genM $ \ _ _ -> label "throwError" throwError <*> e
 
 
 test

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -40,7 +40,7 @@ test
   -> Gen (f ())
   -> Run f (Either e) m
   -> [TestTree]
-test e (GenM m) _ b i (Run runThrow) =
+test e m _ b i (Run runThrow) =
   [ testProperty "throwError annihilates >>=" . forall (i :. e :. fn @a (m b) :. Nil) $
     \ i e k -> runThrow ((throwError e >>= k) <$ i) === runThrow ((throwError e) <$ i)
   ]

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -21,9 +21,10 @@ tests = testGroup "Throw" $
     , testThrow
     ] >>= ($ runL ThrowC.runThrow)
   ] where
-  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
-  testThrow    run = Throw.test e  (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   (identity <*> unit) run
+  testMonad    run = Monad.test    (m (\ _ -> gen0 e) (\ _ _ -> [])) a b c initial run
+  testMonadFix run = MonadFix.test (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
+  testThrow    run = Throw.test e  (m (\ _ -> gen0 e) (\ _ _ -> [])) a b   initial run
+  initial = identity <*> unit
 
 
 gen0 :: Has (Throw e) sig m => Gen e -> [Gen (m a)]

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -46,7 +46,7 @@ gen
   -> Gen b
   -> GenM m
   -> GenM m
-gen w b (GenM m) = GenM $ \ a -> choice
+gen w b = genM $ \ m a -> choice
   [ infixL 4 "<$" (<$) <*> a <*> (label "tell" tell <*> w)
   , atom "fmap" fmap <*> fn a <*> (label "listen" (listen @w) <*> m b)
   , label "censor" censor <*> fn w <*> m a

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -41,11 +41,7 @@ tests = testGroup "Writer"
   runRWST f m = (\ (a, _, w) -> (w, a)) <$> f m () ()
 
 
-gen0
-  :: Has (Writer w) sig m
-  => Gen w
-  -> Gen a
-  -> [Gen (m a)]
+gen0 :: Has (Writer w) sig m => Gen w -> Gen a -> [Gen (m a)]
 gen0 w a = [ infixL 4 "<$" (<$) <*> a <*> (label "tell" tell <*> w) ]
 
 genN

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -34,9 +34,10 @@ tests = testGroup "Writer"
   , testGroup "RWST (Lazy)"      $ testWriter (runL (runRWST LazyRWST.runRWST))
   , testGroup "RWST (Strict)"    $ testWriter (runL (runRWST StrictRWST.runRWST))
   ] where
-  testMonad    run = Monad.test    (m (gen0 w) (genN w b)) a b c (identity <*> unit) run
-  testMonadFix run = MonadFix.test (m (gen0 w) (genN w b)) a b   (identity <*> unit) run
-  testWriter   run = Writer.test w (m (gen0 w) (genN w b)) a     (identity <*> unit) run
+  testMonad    run = Monad.test    (m (gen0 w) (genN w b)) a b c initial run
+  testMonadFix run = MonadFix.test (m (gen0 w) (genN w b)) a b   initial run
+  testWriter   run = Writer.test w (m (gen0 w) (genN w b)) a     initial run
+  initial = identity <*> unit
   runRWST f m = (\ (a, _, w) -> (w, a)) <$> f m () ()
 
 

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -55,7 +55,7 @@ genN
   -> GenM m
   -> Gen a
   -> [Gen (m a)]
-genN w b (GenM m) a =
+genN w b m a =
   [ atom "fmap" fmap <*> fn a <*> (label "listen" (listen @w) <*> m b)
   , label "censor" censor <*> fn w <*> m a
   ]
@@ -69,7 +69,7 @@ test
   -> Gen (f ())
   -> Run f ((,) w) m
   -> [TestTree]
-test w (GenM m) a i (Run runWriter) =
+test w m a i (Run runWriter) =
   [ testProperty "tell appends a value to the log" . forall (i :. w :. m a :. Nil) $
     \ i w m -> runWriter ((tell w >> m) <$ i) === fmap (first (mappend w)) (runWriter (m <$ i))
   , testProperty "listen eavesdrops on written output" . forall (i :. m a :. Nil) $

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -46,7 +46,7 @@ gen
   -> Gen b
   -> GenM m
   -> GenM m
-gen w b = genM $ \ m a -> choice
+gen w b (GenM m) = GenM $ \ a -> choice
   [ infixL 4 "<$" (<$) <*> a <*> (label "tell" tell <*> w)
   , atom "fmap" fmap <*> fn a <*> (label "listen" (listen @w) <*> m b)
   , label "censor" censor <*> fn w <*> m a

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -46,7 +46,7 @@ gen
   -> Gen b
   -> GenM m
   -> GenM m
-gen w b m a = choice
+gen w b (GenM m) = GenM $ \ a -> choice
   [ infixL 4 "<$" (<$) <*> a <*> (label "tell" tell <*> w)
   , atom "fmap" fmap <*> fn a <*> (label "listen" (listen @w) <*> m b)
   , label "censor" censor <*> fn w <*> m a
@@ -61,7 +61,7 @@ test
   -> Gen (f ())
   -> Run f ((,) w) m
   -> [TestTree]
-test w m a i (Run runWriter) =
+test w (GenM m) a i (Run runWriter) =
   [ testProperty "tell appends a value to the log" . forall (i :. w :. m a :. Nil) $
     \ i w m -> runWriter ((tell w >> m) <$ i) === fmap (first (mappend w)) (runWriter (m <$ i))
   , testProperty "listen eavesdrops on written output" . forall (i :. m a :. Nil) $


### PR DESCRIPTION
This PR does a bunch of legwork to test the various laws compositionally, i.e. in relation to other effects & carriers, and spikes this out in particular for `CutC`, as part of investigation into #279.

I’ve also made some effort to split up the generators for each effect’s actions into recursive & nonrecursive portions so we get better coverage of first-order operations.