### PR TITLE
Rename eff to alg

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,7 +24,7 @@
 
 ## Backwards-incompatible changes
 
-- Renames the `Carrier` class to `Algebra`, and moved the responsibilities of `Control.Carrier` to `Control.Algebra`. This makes the library more consistent with the literature and encourages a style of naming that focuses on morphisms rather than objects.
+- Renames the `Carrier` class to `Algebra` and its `eff` method to `alg`, and moved the responsibilities of `Control.Carrier` to `Control.Algebra`. This makes the library more consistent with the literature and encourages a style of naming that focuses on morphisms rather than objects.
 
 - Fixes unlawful behaviour in the `Applicative` instance for `ErrorC`, which had different behaviour between `<*>` and `ap` in the presence of a divergent rhs. In order to accomplish this, `ErrorC` has been defined as a wrapper around `Control.Monad.Trans.Except.ExceptT`. ([#228](https://github.com/fused-effects/fused-effects/pull/228))
 

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -82,4 +82,4 @@ instance Monad (Cod m) where
   Cod a >>= f = Cod (\ k -> a (runCod k . f))
 
 instance (Algebra sig m, Effect sig) => Algebra sig (Cod m) where
-  eff op = Cod (\ k -> eff (handle (Identity ()) (runCod (pure . Identity) . runIdentity) op) >>= k . runIdentity)
+  alg op = Cod (\ k -> alg (handle (Identity ()) (runCod (pure . Identity) . runIdentity) op) >>= k . runIdentity)

--- a/docs/defining_effects.md
+++ b/docs/defining_effects.md
@@ -72,7 +72,7 @@ instance (Algebra sig m, MonadIO m) => Algebra (Teletype :+: sig) (TeletypeIOC m
   alg (R other)       = TeletypeIOC (alg (handleCoercible other))
 ```
 
-Here, `eff` is responsible for handling effectful computations. Since the `Algebra` instance handles a sum (`:+:`) of `Teletype` and the remaining signature, `eff` has two parts: a handler for `Teletype`, and a handler for teletype effects that might be embedded inside other effects in the signature.
+Here, `alg` is responsible for handling effectful computations. Since the `Algebra` instance handles a sum (`:+:`) of `Teletype` and the remaining signature, `alg` has two parts: a handler for `Teletype`, and a handler for teletype effects that might be embedded inside other effects in the signature.
 
 In this case, since the `Teletype` carrier is just a thin wrapper around the underlying computation, we can use `handleCoercible` to handle any embedded `TeletypeIOC` carriers by simply mapping `coerce` over them.
 

--- a/docs/defining_effects.md
+++ b/docs/defining_effects.md
@@ -67,9 +67,9 @@ Following from the above section, we can define a carrier for the `Teletype` eff
 newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
 
 instance (Algebra sig m, MonadIO m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
-  eff (L (Read    k)) = TeletypeIOC (liftIO getLine      >>= runTeletypeIOC . k)
-  eff (L (Write s k)) = TeletypeIOC (liftIO (putStrLn s) >>  runTeletypeIOC   k)
-  eff (R other)       = TeletypeIOC (eff (handleCoercible other))
+  alg (L (Read    k)) = TeletypeIOC (liftIO getLine      >>= runTeletypeIOC . k)
+  alg (L (Write s k)) = TeletypeIOC (liftIO (putStrLn s) >>  runTeletypeIOC   k)
+  alg (R other)       = TeletypeIOC (alg (handleCoercible other))
 ```
 
 Here, `eff` is responsible for handling effectful computations. Since the `Algebra` instance handles a sum (`:+:`) of `Teletype` and the remaining signature, `eff` has two parts: a handler for `Teletype`, and a handler for teletype effects that might be embedded inside other effects in the signature.
@@ -96,7 +96,7 @@ This allows us to use `liftIO` directly on the carrier itself, instead of only i
 
 ```haskell
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
-  eff (L (Read    k)) = liftIO getLine      >>= k
-  eff (L (Write s k)) = liftIO (putStrLn s) >>  k
-  eff (R other)       = TeletypeIOC (eff (handleCoercible other))
+  alg (L (Read    k)) = liftIO getLine      >>= k
+  alg (L (Write s k)) = liftIO (putStrLn s) >>  k
+  alg (R other)       = TeletypeIOC (alg (handleCoercible other))
 ```

--- a/examples/Inference.hs
+++ b/examples/Inference.hs
@@ -44,4 +44,4 @@ newtype HasEnv env m a = HasEnv { runHasEnv :: m a }
 
 -- | The 'Carrier' instance for 'HasEnv' simply delegates all effects to the underlying carrier.
 instance Algebra sig m => Algebra sig (HasEnv env m) where
-  eff = HasEnv . eff . handleCoercible
+  alg = HasEnv . alg . handleCoercible

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -103,13 +103,13 @@ newtype ParseC m a = ParseC { runParseC :: StateC String m a }
   deriving newtype (Alternative, Applicative, Functor, Monad)
 
 instance (Alternative m, Algebra sig m, Effect sig) => Algebra (Symbol :+: sig) (ParseC m) where
-  eff (L (Satisfy p k)) = do
+  alg (L (Satisfy p k)) = do
     input <- ParseC get
     case input of
       c:cs | p c -> ParseC (put cs) *> k c
       _          -> empty
-  eff (R other)         = ParseC (eff (R (handleCoercible other)))
-  {-# INLINE eff #-}
+  alg (R other)         = ParseC (alg (R (handleCoercible other)))
+  {-# INLINE alg #-}
 
 
 expr :: (Alternative m, Has Cut sig m, Has Symbol sig m) => m Int

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -136,15 +136,15 @@ instance
      -- ... the 'LogStdoutC m' monad can interpret 'Log String :+: sig' effects
   => Algebra (Log String :+: sig) (LogStdoutC m) where
 
-  eff :: (Log String :+: sig) (LogStdoutC m) a -> LogStdoutC m a
-  eff = \case
+  alg :: (Log String :+: sig) (LogStdoutC m) a -> LogStdoutC m a
+  alg = \case
     L (Log message k) ->
       LogStdoutC $ do
         liftIO (putStrLn message)
         runLogStdout k
 
     R other ->
-      LogStdoutC (eff (hmap runLogStdout other))
+      LogStdoutC (alg (hmap runLogStdout other))
 
 -- The 'LogStdoutC' runner.
 runLogStdout ::
@@ -168,10 +168,10 @@ instance
      -- effects
   => Algebra (Log s :+: sig) (ReinterpretLogC s t m) where
 
-  eff ::
+  alg ::
        (Log s :+: sig) (ReinterpretLogC s t m) a
     -> ReinterpretLogC s t m a
-  eff = \case
+  alg = \case
     L (Log s k) ->
       ReinterpretLogC $ do
         f <- ask @(s -> t)
@@ -179,7 +179,7 @@ instance
         unReinterpretLogC k
 
     R other ->
-      ReinterpretLogC (eff (R (handleCoercible other)))
+      ReinterpretLogC (alg (R (handleCoercible other)))
 
 -- The 'ReinterpretLogC' runner.
 reinterpretLog ::
@@ -206,17 +206,17 @@ instance
      -- effects
   => Algebra (Log s :+: sig) (CollectLogMessagesC s m) where
 
-  eff ::
+  alg ::
        (Log s :+: sig) (CollectLogMessagesC s m) a
     -> CollectLogMessagesC s m a
-  eff = \case
+  alg = \case
     L (Log s k) ->
       CollectLogMessagesC $ do
         tell [s]
         unCollectLogMessagesC k
 
     R other ->
-      CollectLogMessagesC (eff (R (handleCoercible other)))
+      CollectLogMessagesC (alg (R (handleCoercible other)))
 
 -- The 'CollectLogMessagesC' runner.
 collectLogMessages ::

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -47,9 +47,9 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
   deriving newtype (Applicative, Functor, Monad, MonadIO)
 
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
-  eff (L (Read    k)) = liftIO getLine      >>= k
-  eff (L (Write s k)) = liftIO (putStrLn s) >>  k
-  eff (R other)       = TeletypeIOC (eff (handleCoercible other))
+  alg (L (Read    k)) = liftIO getLine      >>= k
+  alg (L (Write s k)) = liftIO (putStrLn s) >>  k
+  alg (R other)       = TeletypeIOC (alg (handleCoercible other))
 
 
 runTeletypeRet :: [String] -> TeletypeRetC m a -> m ([String], ([String], a))
@@ -59,10 +59,10 @@ newtype TeletypeRetC m a = TeletypeRetC { runTeletypeRetC :: StateC [String] (Wr
   deriving newtype (Applicative, Functor, Monad)
 
 instance (Algebra sig m, Effect sig) => Algebra (Teletype :+: sig) (TeletypeRetC m) where
-  eff (L (Read    k)) = do
+  alg (L (Read    k)) = do
     i <- TeletypeRetC get
     case i of
       []  -> k ""
       h:t -> TeletypeRetC (put t) *> k h
-  eff (L (Write s k)) = TeletypeRetC (tell [s]) *> k
-  eff (R other)       = TeletypeRetC (eff (R (R (handleCoercible other))))
+  alg (L (Write s k)) = TeletypeRetC (tell [s]) *> k
+  alg (R other)       = TeletypeRetC (alg (R (R (handleCoercible other))))

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -45,7 +45,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Semigroup as S
 import Data.Tuple (swap)
 
--- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'eff' method.
+-- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'alg' method.
 --
 -- @since 1.0.0.0
 class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -81,6 +81,6 @@ instance MonadTrans ChooseC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Choose :+: sig) (ChooseC m) where
-  eff (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
-  eff (R other)      = ChooseC $ \ fork leaf -> eff (handle (pure ()) (runChoose (liftA2 (<|>)) (runChoose (liftA2 (<|>)) (pure . pure))) other) >>= runChoose fork leaf
-  {-# INLINE eff #-}
+  alg (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
+  alg (R other)      = ChooseC $ \ fork leaf -> alg (handle (pure ()) (runChoose (liftA2 (<|>)) (runChoose (liftA2 (<|>)) (pure . pure))) other) >>= runChoose fork leaf
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -69,8 +69,8 @@ instance MonadTrans CullC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Cull :+: NonDet :+: sig) (CullC m) where
-  eff (L (Cull (CullC m) k)) = CullC (local (const True) m) >>= k
-  eff (R (L (L Empty)))      = empty
-  eff (R (L (R (Choose k)))) = k True <|> k False
-  eff (R (R other))          = CullC (eff (R (R (handleCoercible other))))
-  {-# INLINE eff #-}
+  alg (L (Cull (CullC m) k)) = CullC (local (const True) m) >>= k
+  alg (R (L (L Empty)))      = empty
+  alg (R (L (R (Choose k)))) = k True <|> k False
+  alg (R (R other))          = CullC (alg (R (R (handleCoercible other))))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -87,9 +87,9 @@ instance MonadTrans CutC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
-  eff (L Cutfail)    = CutC $ \ _    _   fail -> fail
-  eff (L (Call m k)) = CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (k a)) nil nil m
-  eff (R (L (L Empty)))      = empty
-  eff (R (L (R (Choose k)))) = k True <|> k False
-  eff (R (R other))          = CutC $ \ cons nil fail -> eff (handle (pure ()) (runCut (fmap . (<|>)) (pure empty) (pure cutfail)) other) >>= runCut cons nil fail
-  {-# INLINE eff #-}
+  alg (L Cutfail)    = CutC $ \ _    _   fail -> fail
+  alg (L (Call m k)) = CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (k a)) nil nil m
+  alg (R (L (L Empty)))      = empty
+  alg (R (L (R (Choose k)))) = k True <|> k False
+  alg (R (R other))          = CutC $ \ cons nil fail -> alg (handle (pure ()) (runCut (fmap . (<|>)) (pure empty) (pure cutfail)) other) >>= runCut cons nil fail
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -47,6 +47,6 @@ instance Fail.MonadFail m => Fail.MonadFail (EmptyC m) where
   {-# INLINE fail #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Empty :+: sig) (EmptyC m) where
-  eff (L Empty) = EmptyC (MaybeT (pure Nothing))
-  eff (R other) = EmptyC (MaybeT (eff (handle (Just ()) (maybe (pure Nothing) runEmpty) other)))
-  {-# INLINE eff #-}
+  alg (L Empty) = EmptyC (MaybeT (pure Nothing))
+  alg (R other) = EmptyC (MaybeT (alg (handle (Just ()) (maybe (pure Nothing) runEmpty) other)))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -52,5 +52,5 @@ instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
 instance (Alternative m, Monad m) => MonadPlus (ErrorC e m)
 
 instance (Algebra sig m, Effect sig) => Algebra (Error e :+: sig) (ErrorC e m) where
-  eff = ErrorC . eff . handleCoercible
-  {-# INLINE eff #-}
+  alg = ErrorC . alg . handleCoercible
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -43,5 +43,5 @@ instance (Algebra sig m, Effect sig) => Fail.MonadFail (FailC m) where
   {-# INLINE fail #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Fail :+: sig) (FailC m) where
-  eff = FailC . eff . handleCoercible
-  {-# INLINE eff #-}
+  alg = FailC . alg . handleCoercible
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -53,6 +53,6 @@ newtype FreshC m a = FreshC (StateC Int m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Fresh :+: sig) (FreshC m) where
-  eff (L (Fresh k)) = FreshC (get <* modify (+ (1 :: Int))) >>= k
-  eff (R other)     = FreshC (eff (R (handleCoercible other)))
-  {-# INLINE eff #-}
+  alg (L (Fresh k)) = FreshC (get <* modify (+ (1 :: Int))) >>= k
+  alg (R other)     = FreshC (alg (R (handleCoercible other)))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -89,5 +89,5 @@ instance MonadUnliftIO m => MonadUnliftIO (InterpretC s sig m) where
   {-# INLINE withRunInIO #-}
 
 instance (HFunctor eff, HFunctor sig, Reifies s (Handler eff m), Monad m, Algebra sig m) => Algebra (eff :+: sig) (InterpretC s eff m) where
-  eff (L eff)   = runHandler (getConst (reflect @s)) eff
-  eff (R other) = InterpretC (eff (handleCoercible other))
+  alg (L eff)   = runHandler (getConst (reflect @s)) eff
+  alg (R other) = InterpretC (alg (handleCoercible other))

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -35,7 +35,7 @@ instance MonadTrans LiftC where
   lift = LiftC
 
 instance Monad m => Algebra (Lift m) (LiftC m) where
-  eff = LiftC . (>>= runM) . unLift
+  alg = LiftC . (>>= runM) . unLift
 
 instance MonadUnliftIO m => MonadUnliftIO (LiftC m) where
   askUnliftIO = LiftC $ withUnliftIO $ \u -> return (UnliftIO (unliftIO u . runM))

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -106,7 +106,7 @@ instance MonadTrans NonDetC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (NonDet :+: sig) (NonDetC m) where
-  eff (L (L Empty))      = empty
-  eff (L (R (Choose k))) = k True <|> k False
-  eff (R other)          = NonDetC $ \ fork leaf nil -> eff (handle (pure ()) (runNonDet (liftA2 (<|>)) runNonDetA (pure empty)) other) >>= runNonDet fork leaf nil
-  {-# INLINE eff #-}
+  alg (L (L Empty))      = empty
+  alg (L (R (Choose k))) = k True <|> k False
+  alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (pure ()) (runNonDet (liftA2 (<|>)) runNonDetA (pure empty)) other) >>= runNonDet fork leaf nil
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Pure.hs
+++ b/src/Control/Carrier/Pure.hs
@@ -63,5 +63,5 @@ instance MonadFix PureC where
   {-# INLINE mfix #-}
 
 instance Algebra Pure PureC where
-  eff v = case v of {}
-  {-# INLINE eff #-}
+  alg v = case v of {}
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -87,7 +87,7 @@ instance MonadUnliftIO m => MonadUnliftIO (ReaderC r m) where
   {-# INLINE withRunInIO #-}
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
-  eff (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))
-  eff (L (Local f m k)) = ReaderC (\ r -> runReader (f r) m) >>= k
-  eff (R other)         = ReaderC (\ r -> eff (hmap (runReader r) other))
-  {-# INLINE eff #-}
+  alg (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))
+  alg (L (Local f m k)) = ReaderC (\ r -> runReader (f r) m) >>= k
+  alg (R other)         = ReaderC (\ r -> alg (hmap (runReader r) other))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -114,7 +114,7 @@ instance MonadTrans (StateC s) where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
-  eff (L (Get   k)) = StateC (\ s -> runState s (k s))
-  eff (L (Put s k)) = StateC (\ _ -> runState s k)
-  eff (R other)     = StateC (\ s -> eff (handle (s, ()) (uncurry runState) other))
-  {-# INLINE eff #-}
+  alg (L (Get   k)) = StateC (\ s -> runState s (k s))
+  alg (L (Put s k)) = StateC (\ _ -> runState s k)
+  alg (R other)     = StateC (\ s -> alg (handle (s, ()) (uncurry runState) other))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -113,7 +113,7 @@ instance MonadTrans (StateC s) where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
-  eff (L (Get   k)) = StateC (\ s -> runState s (k s))
-  eff (L (Put s k)) = StateC (\ _ -> runState s k)
-  eff (R other)     = StateC (\ s -> eff (handle (s, ()) (uncurry runState) other))
-  {-# INLINE eff #-}
+  alg (L (Get   k)) = StateC (\ s -> runState s (k s))
+  alg (L (Put s k)) = StateC (\ _ -> runState s k)
+  alg (R other)     = StateC (\ s -> alg (handle (s, ()) (uncurry runState) other))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -30,5 +30,5 @@ newtype ThrowC e m a = ThrowC (ErrorC e m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Throw e :+: sig) (ThrowC e m) where
-  eff (L (Throw e)) = ThrowC (throwError e)
-  eff (R other)     = ThrowC (eff (R (handleCoercible other)))
+  alg (L (Throw e)) = ThrowC (throwError e)
+  alg (R other)     = ThrowC (alg (R (handleCoercible other)))

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -49,6 +49,6 @@ instance MonadUnliftIO m => MonadUnliftIO (TraceC m) where
   {-# INLINE withRunInIO #-}
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
-  eff (L trace) = traceCont trace
-  eff (R other) = TraceC (eff (handleCoercible other))
-  {-# INLINE eff #-}
+  alg (L trace) = traceCont trace
+  alg (R other) = TraceC (alg (handleCoercible other))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -50,6 +50,6 @@ instance MonadUnliftIO m => MonadUnliftIO (TraceC m) where
   {-# INLINE withRunInIO #-}
 
 instance (MonadIO m, Algebra sig m) => Algebra (Trace :+: sig) (TraceC m) where
-  eff (L (Trace s k)) = liftIO (hPutStrLn stderr s) *> k
-  eff (R other)       = TraceC (eff (handleCoercible other))
-  {-# INLINE eff #-}
+  alg (L (Trace s k)) = liftIO (hPutStrLn stderr s) *> k
+  alg (R other)       = TraceC (alg (handleCoercible other))
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -41,5 +41,5 @@ newtype TraceC m a = TraceC (WriterC (Endo [String]) m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Trace :+: sig) (TraceC m) where
-  eff (L (Trace m k)) = TraceC (tell (Endo (m :))) *> k
-  eff (R other)       = TraceC (eff (R (handleCoercible other)))
+  alg (L (Trace m k)) = TraceC (tell (Endo (m :))) *> k
+  alg (R other)       = TraceC (alg (R (handleCoercible other)))

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -55,16 +55,16 @@ newtype WriterC w m a = WriterC (StateC w m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Monoid w, Algebra sig m, Effect sig) => Algebra (Writer w :+: sig) (WriterC w m) where
-  eff (L (Tell w     k)) = WriterC (modify (`mappend` w)) >> k
-  eff (L (Listen   m k)) = WriterC (StateC (\ w -> do
+  alg (L (Tell w     k)) = WriterC (modify (`mappend` w)) >> k
+  alg (L (Listen   m k)) = WriterC (StateC (\ w -> do
     (w', a) <- runWriter m
     let w'' = mappend w w'
     w'' `seq` pure (w'', (w', a))))
     >>= uncurry k
-  eff (L (Censor f m k)) = WriterC (StateC (\ w -> do
+  alg (L (Censor f m k)) = WriterC (StateC (\ w -> do
     (w', a) <- runWriter m
     let w'' = mappend w (f w')
     w'' `seq` pure (w'', a)))
     >>= k
-  eff (R other)          = WriterC (eff (R (handleCoercible other)))
-  {-# INLINE eff #-}
+  alg (R other)          = WriterC (alg (R (handleCoercible other)))
+  {-# INLINE alg #-}

--- a/test/Fusion.hs
+++ b/test/Fusion.hs
@@ -22,8 +22,8 @@ tests = testGroup "fusion"
   , testCase "eliminates catch and throw" $
     failureOf $(inspectTest $ 'throwing `doesNotUse` ''ErrorC)
     @?= Nothing
-  , testCase "eliminates calls to eff" $
-    failureOf $(inspectTest $ 'countDown `doesNotUse` 'eff)
+  , testCase "eliminates calls to alg" $
+    failureOf $(inspectTest $ 'countDown `doesNotUse` 'alg)
     @?= Nothing
   ]
 


### PR DESCRIPTION
This PR renames the `eff` method to `alg`.