### PR TITLE
Test laziness properties of State carriers.

### DIFF
--- a/test/State.hs
+++ b/test/State.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, RankNTypes, ScopedTypeVariables, TypeApplications #-}
+{-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables, TypeApplications #-}
 module State
 ( tests
 , gen0

--- a/test/State.hs
+++ b/test/State.hs
@@ -87,7 +87,7 @@ lazy
   -> [TestTree]
 lazy s (Run run) =
   [ testProperty "fmap is non-strict" . forall (a :. s :. Nil) $
-    \ a s -> void . eval . run $ (const a <$> pure (error "insufficiently lazy")) <$ s
+    \ a s -> void . eval . run $ (const a <$> problematic) <$ s
   , testProperty "pure and <*> are non-strict" . forall (s :. Nil) $
     \ s -> void . eval . run $ problematic <$ s
   ]


### PR DESCRIPTION
With some carefully-calibrated uses of `error`, we can test properties associated with how strictly a state monad sequences its values.

This was my first time working with @robrix’s new testing technique and it’s spectacular. [Unstoppable](http://mnftiu.cc/blog/images/fighting.010.gif) even.

This has raised some questions:
* Should the strict `StateC`’s `fmap` be strict?

Fixes #282.