### PR TITLE
Fix strict StateC's Applicative instance.

### DIFF
--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -76,7 +76,7 @@ instance Monad m => Applicative (StateC s m) where
     (s', f') <- f s
     (s'', a') <- a s'
     let fa = f' a'
-    fa `seq` pure (s'', fa)
+    pure (s'', fa)
   {-# INLINE (<*>) #-}
   m *> k = m >>= \_ -> k
   {-# INLINE (*>) #-}

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -75,8 +75,7 @@ instance Monad m => Applicative (StateC s m) where
   StateC f <*> StateC a = StateC $ \ s -> do
     (s', f') <- f s
     (s'', a') <- a s'
-    let fa = f' a'
-    pure (s'', fa)
+    pure (s'', f' a')
   {-# INLINE (<*>) #-}
   m *> k = m >>= \_ -> k
   {-# INLINE (*>) #-}
@@ -90,8 +89,7 @@ instance (Alternative m, Monad m) => Alternative (StateC s m) where
 instance Monad m => Monad (StateC s m) where
   StateC m >>= f = StateC $ \ s -> do
     (s', a) <- m s
-    let fa = f a
-    fa `seq` runState s' fa
+    runState s' (f a)
   {-# INLINE (>>=) #-}
 
 instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where


### PR DESCRIPTION
The presence of `seq` inside a state monad provides speed boosts but
enables unlawful behavior with respect to passing undefined values.
In practice this probably provides a speed improvement, but if you
need to do that you can do it on your own; we're not interested in
providing unlawful monads.