### PR TITLE
Simpler ChooseC/NonDetC/CutC context functors

### DIFF
--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -85,5 +85,6 @@ instance MonadTrans ChooseC where
 instance Algebra sig m => Algebra (Choose :+: sig) (ChooseC m) where
   alg (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
   alg (R other)      = ChooseC $ \ fork leaf -> alg (handle (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf) where
+    dst :: Applicative m => ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -23,6 +23,8 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Data.Coerce (coerce)
+import Data.Functor.Identity
 import Data.List.NonEmpty (NonEmpty(..), head, tail)
 import qualified Data.Semigroup as S
 import Prelude hiding (head, tail)
@@ -82,5 +84,6 @@ instance MonadTrans ChooseC where
 
 instance Algebra sig m => Algebra (Choose :+: sig) (ChooseC m) where
   alg (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
-  alg (R other)      = ChooseC $ \ fork leaf -> alg (handle (pure ()) (runChoose (liftA2 (<|>)) (runChoose (liftA2 (<|>)) (pure . pure))) other) >>= runChoose fork leaf
+  alg (R other)      = ChooseC $ \ fork leaf -> alg (handle (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf) where
+    dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -16,12 +16,15 @@ module Control.Carrier.Cut.Church
 ) where
 
 import Control.Algebra
+import Control.Applicative (liftA2)
 import Control.Effect.Cut
 import Control.Effect.NonDet
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Data.Coerce (coerce)
+import Data.Functor.Identity
 
 -- | Run a 'Cut' effect with continuations respectively interpreting 'pure' / '<|>', 'empty', and 'cutfail'.
 --
@@ -91,5 +94,6 @@ instance Algebra sig m => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
   alg (L (Call m k)) = CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (k a)) nil nil m
   alg (R (L (L Empty)))      = empty
   alg (R (L (R (Choose k)))) = k True <|> k False
-  alg (R (R other))          = CutC $ \ cons nil fail -> alg (handle (pure ()) (runCut (fmap . (<|>)) (pure empty) (pure cutfail)) other) >>= runCut cons nil fail
+  alg (R (R other))          = CutC $ \ cons nil fail -> alg (handle (pure ()) dst other) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail) where
+    dst = runIdentity . runCut (fmap . liftA2 (<|>) . runCut (fmap . (<|>) . pure) (pure empty) (pure cutfail)) (pure (pure empty)) (pure (pure cutfail))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -95,5 +95,6 @@ instance Algebra sig m => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
   alg (R (L (L Empty)))      = empty
   alg (R (L (R (Choose k)))) = k True <|> k False
   alg (R (R other))          = CutC $ \ cons nil fail -> alg (handle (pure ()) dst other) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail) where
+    dst :: Applicative m => CutC Identity (CutC m a) -> m (CutC Identity a)
     dst = runIdentity . runCut (fmap . liftA2 (<|>) . runCut (fmap . (<|>) . pure) (pure empty) (pure cutfail)) (pure (pure empty)) (pure (pure cutfail))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -111,5 +111,6 @@ instance Algebra sig m => Algebra (NonDet :+: sig) (NonDetC m) where
   alg (L (L Empty))      = empty
   alg (L (R (Choose k))) = k True <|> k False
   alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (pure ()) dst other) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil) where
+    dst :: Applicative m => NonDetC Identity (NonDetC m a) -> m (NonDetC Identity a)
     dst = runIdentity . runNonDet (liftA2 (liftA2 (<|>))) (Identity . runNonDetA) (pure (pure empty))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -24,6 +24,8 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Data.Coerce (coerce)
+import Data.Functor.Identity
 
 -- | Run a 'NonDet' effect, using the provided functions to interpret choice, leaf results, and failure.
 --
@@ -108,5 +110,6 @@ instance MonadTrans NonDetC where
 instance Algebra sig m => Algebra (NonDet :+: sig) (NonDetC m) where
   alg (L (L Empty))      = empty
   alg (L (R (Choose k))) = k True <|> k False
-  alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (pure ()) (runNonDet (liftA2 (<|>)) runNonDetA (pure empty)) other) >>= runNonDet fork leaf nil
+  alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (pure ()) dst other) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil) where
+    dst = runIdentity . runNonDet (liftA2 (liftA2 (<|>))) (Identity . runNonDetA) (pure (pure empty))
   {-# INLINE alg #-}


### PR DESCRIPTION
This PR uses simpler context functors for `ChooseC`, `NonDetC`, & `CutC`, using `Identity` instead of `m` as the underlying monad for the context.

This is independent of #296, but is motivated by that PR due to the `CanHandle` constraints making the context functor visible. `CanHandle sig (NonDetC (ReaderC r (StateC s …)))` is a completely unacceptable constraint, while `CanHandle sig (NonDetC Identity)` _might_ be acceptable.

Further to that, the existing code was simply too clever. The new code is longer, but by avoiding the use of the monad as its own context functor, avoids the potential for buggy (tho type-safe) rewrites of the distributive law as e.g. `join . runNonDetA`.