### PR TITLE
Audit haddocks for coverage (#246).

### DIFF
--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
--- | A carrier for a 'Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Fail.fail'.
+-- | A carrier for a 'Control.Effect.Fail.Fail' effect, returning the result as an 'Either' 'String'. Failed computations will return a 'Left' containing the 'String' value passed to 'Fail.fail'.
 --
 -- @since 1.0.0.0
 module Control.Carrier.Fail.Either
@@ -21,13 +21,13 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
--- | Run a 'Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
+-- | Run a 'Control.Effect.Fail.Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
 --
 -- @
 -- 'runFail' ('pure' a) = 'pure' ('Right' a)
 -- @
 -- @
--- 'runFail' ('fail' s) = 'pure' ('Left' s)
+-- 'runFail' ('Fail.fail' s) = 'pure' ('Left' s)
 -- @
 --
 -- @since 1.0.0.0

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -24,7 +24,7 @@ import Control.Effect.Catch.Internal (Catch(..))
 -- Errors thrown by the handler will escape up to the nearest enclosing 'catchError' (if any). Note that this effect does /not/ handle errors thrown from impure contexts such as IO, nor will it handle exceptions thrown from pure code. If you need to handle IO-based errors, consider if @fused-effects-exceptions@ fits your use case; if not, use 'Control.Monad.IO.Class.liftIO' with 'Control.Exception.try' or use 'Control.Exception.catch' from outside the effect invocation.
 --
 -- @
--- runError ('throwError' e `catchError` f) = runError (f e)
+-- runError ('Control.Effect.Throw.throwError' e `catchError` f) = runError (f e)
 -- @
 --
 -- @since 0.1.0.0

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -21,7 +21,7 @@ module Control.Effect.Cull
 
 import Control.Algebra
 
--- | 'Cull' effects are used with 'Choose' to provide control over branching.
+-- | 'Cull' effects are used with 'Control.Effect.Choose' to provide control over branching.
 --
 -- @since 0.1.2.0
 data Cull m k

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -26,7 +26,7 @@ module Control.Effect.Cut
 import Control.Algebra
 import Control.Applicative (Alternative(..))
 
--- | 'Cut' effects are used with 'Choose' to provide control over backtracking.
+-- | 'Cut' effects are used with 'Control.Effect.Choose' to provide control over backtracking.
 --
 -- @since 0.1.2.0
 data Cut m k

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -2,7 +2,7 @@
 
 {- | An effect providing failure with an error message.
 
-This effect is invoked through the 'Fail.fail' method from 'Fail.MonadFail'.
+This effect is invoked through the 'Control.Monad.Fail.fail' method from 'Control.Monad.Fail.MonadFail'.
 
 Predefined carriers:
 

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -38,7 +38,7 @@ sendM m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
 
 -- | Run actions in an outer context.
 --
--- This can be used to provide interoperation with @base@ functionality like @"Control.Exception".'catch'@:
+-- This can be used to provide interoperation with @base@ functionality like @"Control.Exception".'Control.Exception.catch'@:
 --
 -- @
 -- 'liftWith' $ \ ctx hdl -> 'Control.Exception.catch' (hdl (m <$ ctx)) (hdl . (<$ ctx) . h)
@@ -46,7 +46,7 @@ sendM m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
 --
 -- The higher-order function takes both an initial context, and a handler phrased as the same sort of distributive law as described in the documentation for 'thread'. This handler takes actions lifted into a context functor, which can be either the initial context, or the derived context produced by handling a previous action.
 --
--- As with @MonadBaseControl@, care must be taken when lifting functions like @"Control.Exception".'finally'@ which don’t use the return value of one of their actions, as this can lead to dropped effects.
+-- As with @MonadBaseControl@, care must be taken when lifting functions like @"Control.Exception".'Control.Exception.finally'@ which don’t use the return value of one of their actions, as this can lead to dropped effects.
 --
 -- @since 1.0.0.0
 liftWith

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -33,7 +33,7 @@ import Control.Effect.Writer.Internal (Writer(..))
 -- | Write a value to the log.
 --
 -- @
--- runWriter ('tell' w '>>' m) = 'first' ('mappend' w) '<$>' runWriter m
+-- runWriter ('tell' w '>>' m) = 'Data.Bifunctor.first' ('mappend' w) '<$>' runWriter m
 -- @
 --
 -- @since 0.1.0.0
@@ -55,7 +55,7 @@ listen m = send (Listen m (curry pure))
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
 -- @
--- 'listens' f m = 'fmap' ('first' f) ('listen' m)
+-- 'listens' f m = 'fmap' ('Data.Bifunctor.first' f) ('listen' m)
 -- @
 --
 -- @since 0.2.0.0
@@ -66,7 +66,7 @@ listens f m = send (Listen m (curry pure . f))
 -- | Run a computation, modifying its output with the passed function.
 --
 -- @
--- runWriter ('censor' f m) = 'fmap' ('first' f) (runWriter m)
+-- runWriter ('censor' f m) = 'fmap' ('Data.Bifunctor.first' f) (runWriter m)
 -- @
 --
 -- @since 0.2.0.0

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -44,7 +44,7 @@ tell w = send (Tell w (pure ()))
 -- | Run a computation, returning the pair of its output and its result.
 --
 -- @
--- runWriter ('listen' m) = 'fmap' ('fst' '&&&' 'id') (runWriter m)
+-- runWriter ('listen' m) = 'fmap' ('fst' 'Control.Arrow.&&&' 'id') (runWriter m)
 -- @
 --
 -- @since 0.2.0.0


### PR DESCRIPTION
This brings us down to two warnings: one in `Control.Carrier.Fail.Either`, where it can’t disambiguate which `Fail` effect I mean, but I’ve linked to it qualified, so I think that it’s a bug. The other issue is the `Reifies` class from `Interpret`, which has no documentation; I have no idea what that does, or if we should export it at all, so I’ll defer to @robrix and/or @ocharles.