### PR TITLE
repl/ghcide scripts

### DIFF
--- a/.ghci.fused-effects
+++ b/.ghci.fused-effects
@@ -1,0 +1,26 @@
+-- GHCI settings for fused-effects, collected by running cabal repl -v and checking out the flags cabal passes to ghc.
+-- These live here instead of script/repl for ease of commenting.
+-- These live here instead of .ghci so cabal repl remains unaffected.
+-- These live here instead of script/ghci-flags so ghcide remains unaffected.
+
+-- Basic verbosity
+:set -v1
+
+-- Compile to object code
+:set -fwrite-interface -fobject-code
+
+-- Bonus: silence “add these modules to your .cabal file” warnings for files we :load
+:set -Wno-missing-home-modules
+
+-- Warnings for code written in the repl
+:seti -Weverything
+:seti -Wno-all-missed-specialisations
+:seti -Wno-implicit-prelude
+:seti -Wno-missed-specialisations
+:seti -Wno-missing-import-lists
+:seti -Wno-missing-local-signatures
+:seti -Wno-monomorphism-restriction
+:seti -Wno-name-shadowing
+:seti -Wno-safe
+:seti -Wno-unsafe
+:seti -Wno-star-is-type

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist-newstyle
 stack.yaml
 cabal.project.local
 .ghci
-hie.yaml

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -12,7 +12,7 @@ import Data.Functor.Identity
 import Data.Monoid (Sum(..))
 import Gauge
 
-import qualified NonDet
+import qualified Bench.NonDet as NonDet
 
 main :: IO ()
 main = defaultMain

--- a/benchmark/Bench/NonDet.hs
+++ b/benchmark/Bench/NonDet.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE TypeApplications #-}
-module NonDet
+module Bench.NonDet
 ( benchmark
 ) where
 
 import Control.Algebra
 import qualified Control.Carrier.NonDet.Church as NonDet.Church
 import           Gauge hiding (benchmark)
-import qualified NonDet.NQueens as NQueens
+import qualified Bench.NonDet.NQueens as NQueens
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "NonDet"

--- a/benchmark/Bench/NonDet/NQueens.hs
+++ b/benchmark/Bench/NonDet/NQueens.hs
@@ -5,7 +5,7 @@
 -- Based largely on the implementation by Sreekar Shastry,
 -- available at https://github.com/sshastry/queenslogic
 
-module NonDet.NQueens (benchmark) where
+module Bench.NonDet.NQueens (benchmark) where
 
 import Control.Applicative
 import Control.Monad (guard)

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -177,8 +177,8 @@ benchmark benchmark
   hs-source-dirs: benchmark
   main-is:        Bench.hs
   other-modules:
-    NonDet
-    NonDet.NQueens
+    Bench.NonDet
+    Bench.NonDet.NQueens
   build-depends:
       base
     , fused-effects

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,4 @@
+cradle:
+  bios:
+    program: script/ghci-flags
+    dependency-program: script/ghci-flags-dependencies

--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -51,5 +51,5 @@ echo "-Wno-name-shadowing"
 echo "-Wno-safe"
 echo "-Wno-unsafe"
 
-[[ "$ghc_version" = 8.6.* ]] && echo "-Wno-star-is-type"
-[[ "$ghc_version" = 8.8.* ]] && echo "-Wno-missing-deriving-strategies"
+[[ "$ghc_version" = 8.6.* ]] && echo "-Wno-star-is-type" || true
+[[ "$ghc_version" = 8.8.* ]] && echo "-Wno-missing-deriving-strategies" || true

--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Computes the flags for ghcide to pass to ghci. You probably won’t be running this yourself, but rather ghcide will via configuration in hie.yaml.
+
+set -e
+
+cd $(dirname "$0")/..
+
+root="$(pwd)"
+ghc_version="$(ghc --numeric-version)"
+
+if [ "$1" == "--builddir" ]; then
+  repl_builddir="$2"
+  shift 2
+else
+  repl_builddir=dist-newstyle
+fi
+
+echo "-O0"
+echo "-ignore-dot-ghci"
+
+echo "-outputdir $repl_builddir/build/x86_64-osx/ghc-$ghc_version/fused-effects-1.0.0.0/build"
+echo "-odir $repl_builddir/build/x86_64-osx/ghc-$ghc_version/fused-effects-1.0.0.0/build"
+echo "-hidir $repl_builddir/build/x86_64-osx/ghc-$ghc_version/fused-effects-1.0.0.0/build"
+echo "-stubdir $repl_builddir/build/x86_64-osx/ghc-$ghc_version/fused-effects-1.0.0.0/build"
+
+echo "-i$root/src"
+echo "-i$root/benchmark"
+echo "-i$root/examples"
+echo "-i$root/test"
+
+echo "-optP-include"
+echo "-optP$root/$repl_builddir/build/x86_64-osx/ghc-$ghc_version/fused-effects-1.0.0.0/build/autogen/cabal_macros.h"
+
+echo "-hide-all-packages"
+
+# Emit package flags from the environment file, removing comments & prefixing with -
+cabal exec --builddir=$repl_builddir -v0 bash -- -c 'cat $GHC_ENVIRONMENT' | grep -v '^--' | sed -e 's/^/-/'
+
+echo "-XHaskell2010"
+
+echo "-Wwarn"
+
+echo "-Weverything"
+echo "-Wno-all-missed-specialisations"
+echo "-Wno-implicit-prelude"
+echo "-Wno-missed-specialisations"
+echo "-Wno-missing-import-lists"
+echo "-Wno-missing-local-signatures"
+echo "-Wno-monomorphism-restriction"
+echo "-Wno-name-shadowing"
+echo "-Wno-safe"
+echo "-Wno-unsafe"
+
+[[ "$ghc_version" = 8.6.* ]] && echo "-Wno-star-is-type"
+[[ "$ghc_version" = 8.8.* ]] && echo "-Wno-missing-deriving-strategies"

--- a/script/ghci-flags-dependencies
+++ b/script/ghci-flags-dependencies
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Computes the paths to files causing changes to the ghci flags. You probably won’t be running this yourself, but rather ghcide will via configuration in hie.yaml.
+
+set -e
+
+cd $(dirname "$0")/..
+
+echo "cabal.project"
+
+echo "fused-effects.cabal"

--- a/script/repl
+++ b/script/repl
@@ -11,5 +11,5 @@ repl_builddir=dist-repl
 if [[ ! -d $repl_builddir ]]; then
   echo "$repl_builddir does not exist, first run 'cabal repl --builddir=$repl_builddir', exit, and then re-run $0"
 else
-  cabal exec --builddir=$repl_builddir ghci -- -ghci-script=.ghci.fused-effects $(script/ghci-flags --builddir "$repl_builddir") -no-ignore-dot-ghci $@
+  cabal exec --builddir=$repl_builddir env -- -u GHC_ENVIRONMENT ghci -ghci-script=.ghci.fused-effects $(script/ghci-flags --builddir "$repl_builddir") -no-ignore-dot-ghci $@
 fi

--- a/script/repl
+++ b/script/repl
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Usage: script/repl [ARGS...]
+# Run a repl session capable of loading all of the components. Any passed arguments, e.g. module names or flags, will be passed to ghci.
+
+set -e
+
+cd $(dirname "$0")/..
+
+repl_builddir=dist-repl
+
+if [[ ! -d $repl_builddir ]]; then
+  echo "$repl_builddir does not exist, first run 'cabal repl --builddir=$repl_builddir', exit, and then re-run $0"
+else
+  cabal exec --builddir=$repl_builddir ghci -- -ghci-script=.ghci.fused-effects $(script/ghci-flags --builddir "$repl_builddir") -no-ignore-dot-ghci $@
+fi


### PR DESCRIPTION
This PR:

- [x] adds scripts for computing the flags to load all of the components in the REPL;
- [x] adds a script to actually load such a REPL;
- [x] adds configuration for `ghcide` to load all of the components; and
- [x] renames a couple of the benchmark modules to avoid conflicts with the tests.