### PR TITLE
Add passthrough Algebra instances for Alt and Ap.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+- Adds passthrough `Algebra` instances for `Ap` and `Alt`, allowing the invocation of effects inside these structures without extraneous constructor applications.
+
 # v1.0.0.0
 
 - Adds an `Empty` effect, modelling nondeterminism without choice ([#196](https://github.com/fused-effects/fused-effects/pull/196)).

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -41,6 +41,7 @@ import qualified Control.Monad.Trans.State.Strict as State.Strict
 import qualified Control.Monad.Trans.Writer.Lazy as Writer.Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Writer.Strict
 import Data.List.NonEmpty (NonEmpty)
+import Data.Monoid
 import qualified Data.Semigroup as S
 import Data.Tuple (swap)
 

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -117,6 +117,12 @@ instance (Algebra sig m, Effect sig) => Algebra (Error e :+: sig) (Except.Except
 instance Algebra sig m => Algebra sig (Identity.IdentityT m) where
   alg = Identity.IdentityT . alg . handleCoercible
 
+instance Algebra sig m => Algebra sig (Ap m) where
+  alg = Ap . alg . handleCoercible
+
+instance Algebra sig m => Algebra sig (Alt m) where
+  alg = Alt . alg . handleCoercible
+
 instance Algebra sig m => Algebra (Reader r :+: sig) (Reader.ReaderT r m) where
   alg (L (Ask       k)) = Reader.ask >>= k
   alg (L (Local f m k)) = Reader.local f m >>= k

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, DeriveFunctor, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE CPP, ConstraintKinds, DeriveFunctor, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
 
 {- | The 'Algebra' class is the mechanism with which effects are interpreted.
 
@@ -118,8 +118,10 @@ instance (Algebra sig m, Effect sig) => Algebra (Error e :+: sig) (Except.Except
 instance Algebra sig m => Algebra sig (Identity.IdentityT m) where
   alg = Identity.IdentityT . alg . handleCoercible
 
+#if MIN_VERSION_base(4,12,0)
 instance Algebra sig m => Algebra sig (Ap m) where
   alg = Ap . alg . handleCoercible
+#endif
 
 instance Algebra sig m => Algebra sig (Alt m) where
   alg = Alt . alg . handleCoercible


### PR DESCRIPTION
This enables an exceptionally fluid style of effectful programming
when working with monoidal return types.

Fixes #342.