### PR TITLE
Remove Codensity-related benchmarks.

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -7,8 +7,7 @@ import Control.Algebra
 import Control.Carrier.Interpret
 import Control.Carrier.State.Strict
 import Control.Carrier.Writer.Strict
-import Control.Monad (ap, replicateM_)
-import Data.Functor.Identity
+import Control.Monad (replicateM_)
 import Data.Monoid (Sum(..))
 import Gauge
 
@@ -18,29 +17,15 @@ main :: IO ()
 main = defaultMain
   [ NonDet.benchmark
   , bgroup "WriterC"
-    [ bgroup "Cod"
-      [ bench "100"   $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 100
-      , bench "1000"  $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 1000
-      , bench "10000" $ whnf (run . runCod pure . execWriter @(Sum Int) . runCod pure . tellLoop) 10000
-      ]
-    , bgroup "standalone"
-      [ bench "100"   $ whnf (run . execWriter @(Sum Int) . tellLoop) 100
-      , bench "1000"  $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
-      , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
-      ]
+    [ bench "100"   $ whnf (run . execWriter @(Sum Int) . tellLoop) 100
+    , bench "1000"  $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
+    , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
     ]
   ,
     bgroup "Strict StateC"
-    [ bgroup "Cod"
-      [ bench "100"   $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 100
-      , bench "1000"  $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 1000
-      , bench "10000" $ whnf (run . runCod pure . execState @(Sum Int) 0 . runCod pure . modLoop) 10000
-      ]
-    , bgroup "standalone"
-      [ bench "100"   $ whnf (run . execState @(Sum Int) 0 . modLoop) 100
-      , bench "1000"  $ whnf (run . execState @(Sum Int) 0 . modLoop) 1000
-      , bench "10000" $ whnf (run . execState @(Sum Int) 0 . modLoop) 10000
-      ]
+    [ bench "100"   $ whnf (run . execState @(Sum Int) 0 . modLoop) 100
+    , bench "1000"  $ whnf (run . execState @(Sum Int) 0 . modLoop) 1000
+    , bench "10000" $ whnf (run . execState @(Sum Int) 0 . modLoop) 10000
     ]
   ,
     bgroup "InterpretC vs InterpretStateC vs StateC"
@@ -67,19 +52,3 @@ tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
 
 modLoop :: Has (State (Sum Int)) sig m => Int -> m ()
 modLoop i = replicateM_ i (modify (+ (Sum (1 :: Int))))
-
-newtype Cod m a = Cod { unCod :: forall b . (a -> m b) -> m b }
-  deriving (Functor)
-
-runCod :: (a -> m b) -> Cod m a -> m b
-runCod = flip unCod
-
-instance Applicative (Cod m) where
-  pure a = Cod (\ k -> k a)
-  (<*>) = ap
-
-instance Monad (Cod m) where
-  Cod a >>= f = Cod (\ k -> a (runCod k . f))
-
-instance (Algebra sig m, Effect sig) => Algebra sig (Cod m) where
-  alg op = Cod (\ k -> alg (thread (Identity ()) (runCod (pure . Identity) . runIdentity) op) >>= k . runIdentity)


### PR DESCRIPTION
These have served their purpose (at this point we know for a fact that
Codensity will not outperform handwritten carriers) and serve only to
clog up benchmark output.