### PR TITLE
Labelled effects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,8 +6,8 @@
 
 - Adds labelled effects in `Control.Effect.Labelled`. Labelled effects allow flexible disambiguation and dependency for parametric effects, enabling better type inference, restricted usage, and associated type parameters. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
 
-
 - Adds a `sendIO` operation for the `Lift IO` effect ([#360](https://github.com/fused-effects/fused-effects/pull/360)).
+
 
 # v1.0.0.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 - Inlines `inj`. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
 
+- Adds labelled effects in `Control.Effect.Labelled`. Labelled effects allow flexible disambiguation and dependency for parametric effects, enabling better type inference, restricted usage, and associated type parameters. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
+
 
 # v1.0.0.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Adds labelled effects in `Control.Effect.Labelled`. Labelled effects allow flexible disambiguation and dependency for parametric effects, enabling better type inference, restricted usage, and associated type parameters. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
 
+- Adds labelled interface for `Reader` and `State` effects in `Control.Effect.Reader.Labelled` and `Control.Effect.State.Labelled`. The functions in this interface are identical to their parent effect save that they accept a label parameter as an explicit type argument, suitable for use with an explicit type application; this can clean up code that would otherwise need an invocation of `runUnderLabel` to associate a labelled operation with its label.
+
 - Adds a `sendIO` operation for the `Lift IO` effect ([#360](https://github.com/fused-effects/fused-effects/pull/360)).
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 - Adds a `state` operation for the `State` effect.
 
+- Adds a function reassociating sums leftwards to `Control.Effect.Sum`. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
+
+
 # v1.0.0.1
 
 - Adds passthrough `Algebra` instances for `Ap` and `Alt`, allowing the invocation of effects inside these structures without extraneous constructor applications.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 - Adds a function reassociating sums leftwards to `Control.Effect.Sum`. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
 
+- Inlines `inj`. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
+
 
 # v1.0.0.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 
 - Adds passthrough `Algebra` instances for `Ap` and `Alt`, allowing the invocation of effects inside these structures without extraneous constructor applications.
 
+
 # v1.0.0.0
 
 - Adds an `Empty` effect, modelling nondeterminism without choice ([#196](https://github.com/fused-effects/fused-effects/pull/196)).
@@ -87,6 +88,7 @@
 
 - Adds support for ghc 8.8.1.
 
+
 # v0.5.0.0
 
 - Derives `Generic1` instances for all non-existentially-quantified effect datatypes.
@@ -98,6 +100,7 @@
 - Re-exports `run`, `:+:`, and `Member` from `Control.Effect.Carrier`, reducing the number of imports needed when defining new effects.
 
 - Re-exports `Carrier`, `Member`, and `run` from the various effect modules, reducing the number of imports needed when using existing effects.
+
 
 ## Backwards-incompatible changes
 
@@ -117,22 +120,26 @@
 
 - Deprecates `handlePure` in favour of `hmap`.
 
+
 # v0.4.0.0
 
 ## Backwards-incompatible changes
 
 - Removes APIs deprecated in 0.3.0.0, including `Eff`, `interpret`, `ret`, and the `handle*` family of helper functions.
 
+
 ## Other changes
 
 - Adds the ability to derive default instances of `HFunctor` and `Effect` for first-order effects, using the `-XDeriveAnyClass` extension.
 - Adds a generic `Interpose` effect that enables arbitrary "eavesdropping" on other effects.
+
 
 # 0.3.1.0
 
 - Improved speed of `Reader`, `State`, `Writer`, and `Pure` effects by defining and inlining auxiliary `Applicative` methods.
 - Adds `runInterpret` & `runInterpretState` handlers in `Control.Effect.Interpret` as a convenient way to experiment with effect handlers without defining a new carrier type and `Carrier` instance. Such handlers are somewhat less efficient than custom `Carrier`s, but allow for a smooth upgrade path when more efficiency is required.
 - Added `unliftio-core` as a dependency so as to provide a blessed API for unlift-style effects and a solution to the cubic-caller problem.
+
 
 # 0.3.0.0
 
@@ -147,6 +154,7 @@
 - Renames `Control.Effect.Void`, `Void`, and `VoidC` to `Control.Effect.Pure`, `Pure`, and `PureC` respectively.
   This is a backwards-incompatible change for code mentioning `VoidC`; it should be updated to reference `PureC` instead.
 
+
 ## Deprecations
 
 - `Eff` and `interpret`, in favour of computing directly in the carriers. This enables the compiler to perform significant optimizations; see the benchmarks for details.
@@ -157,6 +165,7 @@
 
 All deprecated APIs will be removed in the next release.
 
+
 ## Other changes
 
 - Adds a lazy `State` carrier in `Control.Effect.State.Lazy`
@@ -165,13 +174,16 @@ All deprecated APIs will be removed in the next release.
 - Moves `OnceC` from `Control.Effect.NonDet` to `Control.Effect.Cull` to avoid cyclic dependencies.
 - Adds a `runCutAll` handler for `Cut` effects, returning a collection of all results.
 
+
 # 0.2.0.2
 
 - Loosens the bounds on QuickCheck to accommodate 2.x.
 
+
 # 0.2.0.1
 
 - Fixes the benchmarks, and builds them in CI to avoid regressing them again.
+
 
 # 0.2.0.0
 
@@ -186,9 +198,11 @@ All deprecated APIs will be removed in the next release.
 - Adds `bracketOnError`, `finally`, and `onException` to `Resource`.
 - Adds `sendM` to `Lift`.
 
+
 # 0.1.2.1
 
 - Loosens the bounds on QuickCheck to accommodate 0.12.
+
 
 # 0.1.2.0
 
@@ -198,9 +212,11 @@ All deprecated APIs will be removed in the next release.
 - Adds an example of using `NonDet`, `Cut`, and a character parser effect to define parsers.
 - Fixes the table of contents links in the README.
 
+
 # 0.1.1.0
 
 - Adds a `runNonDetOnce` handler which terminates immediately upon finding a solution.
+
 
 # 0.1.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-- Adds a `state` operation for the `State` effect.
+- Adds a `state` operation for the `State` effect. ([#353](https://github.com/fused-effects/fused-effects/pull/353))
 
 - Adds a function reassociating sums leftwards to `Control.Effect.Sum`. ([#354](https://github.com/fused-effects/fused-effects/pull/354))
 

--- a/examples/Labelled.hs
+++ b/examples/Labelled.hs
@@ -1,0 +1,8 @@
+module Labelled
+( example
+) where
+
+import Test.Tasty
+
+example :: TestTree
+example = testGroup "labelled" []

--- a/examples/Labelled.hs
+++ b/examples/Labelled.hs
@@ -10,6 +10,9 @@ import Test.Tasty.HUnit
 import Control.Applicative
 import Control.Effect.Labelled
 import Control.Carrier.Reader
+import Control.Carrier.State.Strict
+import qualified Control.Effect.Reader.Labelled as L
+import qualified Control.Effect.State.Labelled as L
 
 sample :: ( HasLabelled "fore" (Reader Int) sig m
           , HasLabelled "aft" (Reader Int) sig m
@@ -17,7 +20,54 @@ sample :: ( HasLabelled "fore" (Reader Int) sig m
        => m Int
 sample = liftA2 (+) (runUnderLabel @"fore" ask) (runUnderLabel @"aft" ask)
 
-example :: TestTree
-example = testGroup "labelled"
-  [ testCase "labelled reader" ((run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" sample))))) @=? 15)
+withHelpers :: ( HasLabelled "fore" (Reader Int) sig m
+               , HasLabelled "aft" (Reader Int) sig m
+               )
+            => m Int
+withHelpers = liftA2 (+) (L.ask @"fore") (L.ask @"aft")
+
+numerically :: ( HasLabelled 1 (Reader Int) sig m
+               , HasLabelled 2 (Reader Int) sig m
+               )
+            => m Int
+numerically = liftA2 (+) (L.ask @1) (L.ask @2)
+
+readerExamples :: TestTree
+readerExamples = testGroup "Reader"
+  [ testCase "runUnderLabel"           ((run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" sample))))) @=? 15)
+  , testCase "Reader.Labelled helpers" ((run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" withHelpers))))) @=? 15)
+  , testCase "Nat labels"              ((run (runReader (5 :: Int) (runLabelled @1 (runReader (10 :: Int) (runLabelled @2 numerically))))) @=? 15)
   ]
+
+sampleS :: ( HasLabelled "fore" (State Int) sig m
+          , HasLabelled "aft" (State Int) sig m
+          )
+       => m Int
+sampleS = liftA2 (+) (runUnderLabel @"fore" get) (runUnderLabel @"aft" get)
+
+helpersS :: ( HasLabelled "fore" (State Int) sig m
+               , HasLabelled "aft" (State Int) sig m
+               )
+            => m Int
+helpersS = liftA2 (+) (L.get @"fore") (L.get @"aft")
+
+boolean :: ( HasLabelled 'True (State Int) sig m
+           , HasLabelled 'False (State Int) sig m
+           )
+            => m Int
+boolean = liftA2 (+) (L.get @'True) (L.get @'False)
+
+stateExamples :: TestTree
+stateExamples = testGroup "State"
+  [ testCase "runUnderLabel"          ((run (evalState (5 :: Int) (runLabelled @"fore" (evalState (10 :: Int) (runLabelled @"aft" sampleS))))) @=? 15)
+  , testCase "State.Labelled helpers" ((run (evalState (5 :: Int) (runLabelled @"fore" (evalState (10 :: Int) (runLabelled @"aft" helpersS))))) @=? 15)
+  , testCase "Boolean labels"         ((run (evalState (5 :: Int) (runLabelled @'True (evalState (10 :: Int) (runLabelled @'False boolean))))) @=? 15)
+  ]
+
+
+example :: TestTree
+example = testGroup "Control.Effect.Labelled"
+  [ readerExamples
+  , stateExamples
+  ]
+

--- a/examples/Labelled.hs
+++ b/examples/Labelled.hs
@@ -1,8 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
 module Labelled
 ( example
 ) where
 
 import Test.Tasty
+import Test.Tasty.HUnit
+import Control.Applicative
+import Control.Effect.Labelled
+import Control.Carrier.Reader
+
+sample :: ( HasLabelled "fore" (Reader Int) sig m
+          , HasLabelled "aft" (Reader Int) sig m
+          )
+       => m Int
+sample = liftA2 (+) (runUnderLabel @"fore" ask) (runUnderLabel @"aft" ask)
 
 example :: TestTree
-example = testGroup "labelled" []
+example = testGroup "labelled"
+  [ testCase "labelled reader" ((run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" sample))))) @=? 15)
+  ]

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -3,6 +3,7 @@ module Main
 ) where
 
 import qualified Inference
+import qualified Labelled
 import qualified Parser
 import qualified ReinterpretLog
 import qualified Teletype
@@ -14,4 +15,5 @@ main = defaultMain $ testGroup "examples"
   , Parser.example
   , ReinterpretLog.example
   , Teletype.example
+  , Labelled.example
   ]

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -78,6 +78,7 @@ library
     Control.Effect.Lift
     Control.Effect.NonDet
     Control.Effect.Reader
+    Control.Effect.Reader.Labelled
     Control.Effect.State
     Control.Effect.Sum
     Control.Effect.Throw

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -108,6 +108,7 @@ test-suite examples
   main-is:        Main.hs
   other-modules:
     Inference
+    Labelled
     Parser
     ReinterpretLog
     Teletype

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -74,6 +74,7 @@ library
     Control.Effect.Error
     Control.Effect.Fail
     Control.Effect.Fresh
+    Control.Effect.Labelled
     Control.Effect.Lift
     Control.Effect.NonDet
     Control.Effect.Reader

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -80,6 +80,7 @@ library
     Control.Effect.Reader
     Control.Effect.Reader.Labelled
     Control.Effect.State
+    Control.Effect.State.Labelled
     Control.Effect.Sum
     Control.Effect.Throw
     Control.Effect.Trace

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Control.Effect.Labelled

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -69,6 +69,7 @@ type HasLabelled label eff sig m = (LabelledMember label eff sig, Algebra sig m)
 
 sendLabelled :: HasLabelled label eff sig m => Labelled label eff m a -> m a
 sendLabelled = alg . injLabelled
+{-# INLINABLE sendLabelled #-}
 
 
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -14,6 +14,7 @@ module Control.Effect.Labelled
 , Labelled(Labelled)
 , LabelledMember(..)
 , HasLabelled
+, sendLabelled
 , runUnderLabel
 , UnderLabel(UnderLabel)
 , module Control.Algebra
@@ -65,6 +66,9 @@ instance {-# OVERLAPPABLE #-}
 --
 -- Note that if @eff@ is a sum, it will /not/ be decomposed into multiple 'LabelledMember' constraints. While this technically is possible, it results in unsolvable constraints, as the functional dependencies in 'Labelled' prevent assocating the same label with multiple distinct effects within a signature.
 type HasLabelled label eff sig m = (LabelledMember label eff sig, Algebra sig m)
+
+sendLabelled :: HasLabelled label eff sig m => Labelled label eff m a -> m a
+sendLabelled = alg . injLabelled
 
 
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -80,5 +80,5 @@ instance MonadTrans (UnderLabel sub label) where
 
 instance (LabelledMember label sub sig, HFunctor sub, Algebra sig m) => Algebra (sub :+: sig) (UnderLabel label sub m) where
   alg = \case
-    L sub -> UnderLabel (alg (injLabelled @label (Labelled (handleCoercible sub))))
+    L sub -> UnderLabel (sendLabelled @label (Labelled (handleCoercible sub)))
     R sig -> UnderLabel (send (handleCoercible sig))

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -69,6 +69,7 @@ instance {-# OVERLAPPABLE #-}
 -- Note that if @eff@ is a sum, it will /not/ be decomposed into multiple 'LabelledMember' constraints. While this technically is possible, it results in unsolvable constraints, as the functional dependencies in 'Labelled' prevent assocating the same label with multiple distinct effects within a signature.
 type HasLabelled label eff sig m = (LabelledMember label eff sig, Algebra sig m)
 
+-- | Construct a request for a labelled effect to be interpreted by some handler later on.
 sendLabelled :: forall label eff sig m a . HasLabelled label eff sig m => eff m a -> m a
 sendLabelled = alg . injLabelled @label . Labelled
 {-# INLINABLE sendLabelled #-}

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -25,6 +25,7 @@ module Control.Effect.Labelled
 ) where
 
 import Control.Algebra
+import Control.Applicative (Alternative)
 import Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -33,7 +34,7 @@ import Control.Monad.Trans.Class
 --
 -- @since 1.0.2.0
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
-  deriving (Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadTrans)
+  deriving (Alternative, Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadTrans)
 
 instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
   alg = \case
@@ -94,7 +95,7 @@ sendLabelled = alg . injLabelled @label . Labelled
 --
 -- @since 1.0.2.0
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }
-  deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
 
 instance MonadTrans (UnderLabel sub label) where
   lift = UnderLabel

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- | Labelled effects, allowing flexible disambiguation and dependency of parametric effects.
+--
+-- @since 1.0.2.0
 module Control.Effect.Labelled
 ( runLabelled
 , Labelled(Labelled)

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -26,6 +26,7 @@ module Control.Effect.Labelled
 
 import Control.Algebra
 import Control.Applicative (Alternative)
+import Control.Effect.Sum (reassociateSumL)
 import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
@@ -61,11 +62,7 @@ instance LabelledMember label t (Labelled label t) where
 instance {-# OVERLAPPABLE #-}
          LabelledMember label t (l1 :+: l2 :+: r)
       => LabelledMember label t ((l1 :+: l2) :+: r) where
-  injLabelled = reassoc . injLabelled where
-    reassoc = \case
-      L l     -> L (L l)
-      R (L l) -> L (R l)
-      R (R r) -> R r
+  injLabelled = reassociateSumL . injLabelled
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -31,11 +31,12 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Data.Kind (Type)
 
 -- | An effect transformer turning effects into labelled effects, and a carrier transformer turning carriers into labelled carriers for the same (labelled) effects.
 --
 -- @since 1.0.2.0
-newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
+newtype Labelled (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) m a = Labelled { runLabelled :: sub m a }
   deriving (Alternative, Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
@@ -48,7 +49,7 @@ instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra 
 -- | The class of labelled types present in a signature.
 --
 -- @since 1.0.2.0
-class LabelledMember label (sub :: (* -> *) -> (* -> *)) sup | label sup -> sub where
+class LabelledMember label (sub :: (Type -> Type) -> (Type -> Type)) sup | label sup -> sub where
   -- | Inject a member of a signature into the signature.
   --
   -- @since 1.0.2.0

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- | Labelled effects, allowing flexible disambiguation and dependency of parametric effects.
 module Control.Effect.Labelled
 ( runLabelled
 , Labelled(Labelled)

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -12,6 +12,14 @@
 {-# LANGUAGE UndecidableInstances #-}
 -- | Labelled effects, allowing flexible disambiguation and dependency of parametric effects.
 --
+-- Among other things, this can be used to:
+--
+-- * Improve inference by relating parametric effect types to some arbitrary label. This can be used to lift existing effect operations, or to define new ones; cf "Control.Effect.Reader.Labelled", "Control.Effect.State.Labelled" for examples of lifting effect operations into labelled effect operations.
+--
+-- * Express stronger relationships between an effect and the context it’s run in, e.g. to give an effect shadowing semantics, allowing only one instance of it to be active at a time in a given context.
+--
+-- * Resolve ambiguous types by relating parameters to a concrete label type.
+--
 -- @since 1.0.2.0
 module Control.Effect.Labelled
 ( runLabelled

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -103,6 +103,7 @@ newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = 
 
 instance MonadTrans (UnderLabel sub label) where
   lift = UnderLabel
+  {-# INLINE lift #-}
 
 instance (LabelledMember label sub sig, HFunctor sub, Algebra sig m) => Algebra (sub :+: sig) (UnderLabel label sub m) where
   alg = \case

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -57,23 +57,27 @@ class LabelledMember label (sub :: (* -> *) -> (* -> *)) sup | label sup -> sub 
 -- | Reflexivity: @t@ is a member of itself.
 instance LabelledMember label t (Labelled label t) where
   injLabelled = id
+  {-# INLINE injLabelled #-}
 
 -- | Left-recursion: if @t@ is a member of @l1 ':+:' l2 ':+:' r@, then we can inject it into @(l1 ':+:' l2) ':+:' r@ by injection into a right-recursive signature, followed by left-association.
 instance {-# OVERLAPPABLE #-}
          LabelledMember label t (l1 :+: l2 :+: r)
       => LabelledMember label t ((l1 :+: l2) :+: r) where
   injLabelled = reassociateSumL . injLabelled
+  {-# INLINE injLabelled #-}
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}
          LabelledMember label l (Labelled label l :+: r) where
   injLabelled = L
+  {-# INLINE injLabelled #-}
 
 -- | Right-recursion: if @t@ is a member of @r@, we can inject it into @r@ in O(n), followed by lifting that into @l ':+:' r@ in O(1).
 instance {-# OVERLAPPABLE #-}
          LabelledMember label l r
       => LabelledMember label l (l' :+: r) where
   injLabelled = R . injLabelled
+  {-# INLINE injLabelled #-}
 
 
 -- | @m@ is a carrier for @sig@ containing @eff@ associated with @label@.

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -99,7 +99,7 @@ sendLabelled = alg . injLabelled @label . Labelled
 -- | A transformer to lift effectful actions to labelled effectful actions.
 --
 -- @since 1.0.2.0
-newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }
+newtype UnderLabel (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) (m :: Type -> Type) a = UnderLabel { runUnderLabel :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus)
 
 instance MonadTrans (UnderLabel sub label) where

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -21,11 +21,12 @@ module Control.Effect.Labelled
 ) where
 
 import Control.Algebra
+import Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
-  deriving (Applicative, Effect, Functor, HFunctor, Monad, MonadFail, MonadIO, MonadTrans)
+  deriving (Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadTrans)
 
 instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
   alg = \case
@@ -73,7 +74,7 @@ sendLabelled = alg . injLabelled
 
 
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }
-  deriving (Applicative, Functor, Monad, MonadFail, MonadIO)
+  deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
 
 instance MonadTrans (UnderLabel sub label) where
   lift = UnderLabel

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -41,6 +41,7 @@ instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra 
   alg = \case
     L eff -> Labelled (send (handleCoercible (runLabelled eff)))
     R sig -> Labelled (send (handleCoercible sig))
+  {-# INLINE alg #-}
 
 
 -- | The class of labelled types present in a signature.

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -99,8 +99,12 @@ sendLabelled = alg . injLabelled @label . Labelled
 -- | A transformer to lift effectful actions to labelled effectful actions.
 --
 -- @since 1.0.2.0
-newtype UnderLabel (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) (m :: Type -> Type) a = UnderLabel { runUnderLabel :: m a }
+newtype UnderLabel (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) (m :: Type -> Type) a = UnderLabel (m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus)
+
+-- | @since 1.0.2.0
+runUnderLabel :: forall label sub m a . UnderLabel label sub m a -> m a
+runUnderLabel (UnderLabel l) = l
 
 instance MonadTrans (UnderLabel sub label) where
   lift = UnderLabel

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -29,6 +29,7 @@ import Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
+-- | An effect transformer turning effects into labelled effects, and a carrier transformer turning carriers into labelled carriers for the same (labelled) effects.
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
   deriving (Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadTrans)
 

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -62,9 +62,10 @@ instance {-# OVERLAPPABLE #-}
          LabelledMember label t (l1 :+: l2 :+: r)
       => LabelledMember label t ((l1 :+: l2) :+: r) where
   injLabelled = reassoc . injLabelled where
-    reassoc (L l)     = L (L l)
-    reassoc (R (L l)) = L (R l)
-    reassoc (R (R r)) = R r
+    reassoc = \case
+      L l     -> L (L l)
+      R (L l) -> L (R l)
+      R (R r) -> R r
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -68,8 +69,8 @@ instance {-# OVERLAPPABLE #-}
 -- Note that if @eff@ is a sum, it will /not/ be decomposed into multiple 'LabelledMember' constraints. While this technically is possible, it results in unsolvable constraints, as the functional dependencies in 'Labelled' prevent assocating the same label with multiple distinct effects within a signature.
 type HasLabelled label eff sig m = (LabelledMember label eff sig, Algebra sig m)
 
-sendLabelled :: HasLabelled label eff sig m => Labelled label eff m a -> m a
-sendLabelled = alg . injLabelled
+sendLabelled :: forall label eff sig m a . HasLabelled label eff sig m => eff m a -> m a
+sendLabelled = alg . injLabelled @label . Labelled
 {-# INLINABLE sendLabelled #-}
 
 
@@ -81,5 +82,5 @@ instance MonadTrans (UnderLabel sub label) where
 
 instance (LabelledMember label sub sig, HFunctor sub, Algebra sig m) => Algebra (sub :+: sig) (UnderLabel label sub m) where
   alg = \case
-    L sub -> UnderLabel (sendLabelled @label (Labelled (handleCoercible sub)))
+    L sub -> UnderLabel (sendLabelled @label (handleCoercible sub))
     R sig -> UnderLabel (send (handleCoercible sig))

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -38,6 +38,7 @@ instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra 
     R sig -> Labelled (send (handleCoercible sig))
 
 
+-- | The class of labelled types present in a signature.
 class LabelledMember label (sub :: (* -> *) -> (* -> *)) sup | label sup -> sub where
   -- | Inject a member of a signature into the signature.
   injLabelled :: Labelled label sub m a -> sup m a

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -30,6 +30,8 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | An effect transformer turning effects into labelled effects, and a carrier transformer turning carriers into labelled carriers for the same (labelled) effects.
+--
+-- @since 1.0.2.0
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
   deriving (Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadTrans)
 
@@ -40,8 +42,12 @@ instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra 
 
 
 -- | The class of labelled types present in a signature.
+--
+-- @since 1.0.2.0
 class LabelledMember label (sub :: (* -> *) -> (* -> *)) sup | label sup -> sub where
   -- | Inject a member of a signature into the signature.
+  --
+  -- @since 1.0.2.0
   injLabelled :: Labelled label sub m a -> sup m a
 
 -- | Reflexivity: @t@ is a member of itself.
@@ -72,15 +78,21 @@ instance {-# OVERLAPPABLE #-}
 -- | @m@ is a carrier for @sig@ containing @eff@ associated with @label@.
 --
 -- Note that if @eff@ is a sum, it will /not/ be decomposed into multiple 'LabelledMember' constraints. While this technically is possible, it results in unsolvable constraints, as the functional dependencies in 'Labelled' prevent assocating the same label with multiple distinct effects within a signature.
+--
+-- @since 1.0.2.0
 type HasLabelled label eff sig m = (LabelledMember label eff sig, Algebra sig m)
 
 -- | Construct a request for a labelled effect to be interpreted by some handler later on.
+--
+-- @since 1.0.2.0
 sendLabelled :: forall label eff sig m a . HasLabelled label eff sig m => eff m a -> m a
 sendLabelled = alg . injLabelled @label . Labelled
 {-# INLINABLE sendLabelled #-}
 
 
 -- | A transformer to lift effectful actions to labelled effectful actions.
+--
+-- @since 1.0.2.0
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
 

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -44,8 +44,12 @@ import Data.Kind (Type)
 -- | An effect transformer turning effects into labelled effects, and a carrier transformer turning carriers into labelled carriers for the same (labelled) effects.
 --
 -- @since 1.0.2.0
-newtype Labelled (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) m a = Labelled { runLabelled :: sub m a }
+newtype Labelled (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) m a = Labelled (sub m a)
   deriving (Alternative, Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
+
+-- | @since 1.0.2.0
+runLabelled :: forall label sub m a . Labelled label sub m a -> sub m a
+runLabelled (Labelled l) = l
 
 instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
   alg = \case

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -26,6 +26,7 @@ module Control.Effect.Labelled
 
 import Control.Algebra
 import Control.Applicative (Alternative)
+import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
@@ -34,7 +35,7 @@ import Control.Monad.Trans.Class
 --
 -- @since 1.0.2.0
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
-  deriving (Alternative, Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadTrans)
+  deriving (Alternative, Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
   alg = \case
@@ -95,7 +96,7 @@ sendLabelled = alg . injLabelled @label . Labelled
 --
 -- @since 1.0.2.0
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus)
 
 instance MonadTrans (UnderLabel sub label) where
   lift = UnderLabel

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -106,3 +106,4 @@ instance (LabelledMember label sub sig, HFunctor sub, Algebra sig m) => Algebra 
   alg = \case
     L sub -> UnderLabel (sendLabelled @label (handleCoercible sub))
     R sig -> UnderLabel (send (handleCoercible sig))
+  {-# INLINE alg #-}

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -79,6 +79,7 @@ sendLabelled = alg . injLabelled @label . Labelled
 {-# INLINABLE sendLabelled #-}
 
 
+-- | A transformer to lift effectful actions to labelled effectful actions.
 newtype UnderLabel (label :: k) (sub :: (* -> *) -> (* -> *)) (m :: * -> *) a = UnderLabel { runUnderLabel :: m a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadIO)
 

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeApplications #-}
 -- | Labelled 'Reader' operations.
 --

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -25,7 +25,7 @@ import           Control.Effect.Reader.Internal
 -- | Retrieve the environment value.
 --
 -- @
--- runReader a ('runLabelled' @_ @label ('ask' @label) '>>=' k) = runReader a (k a)
+-- runReader a ('runLabelled' @label ('ask' @label) '>>=' k) = runReader a (k a)
 -- @
 --
 -- @since 1.0.2.0
@@ -45,7 +45,7 @@ asks f = runUnderLabel @label (R.asks f)
 -- | Run a computation with an environment value locally modified by the passed function.
 --
 -- @
--- runReader a ('runLabelled' @_ @label ('local' @label f m)) = runReader (f a) m
+-- runReader a ('runLabelled' @label ('local' @label f m)) = runReader (f a) m
 -- @
 --
 -- @since 1.0.2.0

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Control.Effect.Reader.Labelled
 ( -- * Reader effect
   Reader
+, ask
   -- * Re-exports
 , Algebra
 , Effect
@@ -10,3 +15,13 @@ module Control.Effect.Reader.Labelled
 
 import Control.Effect.Labelled
 import Control.Effect.Reader.Internal
+
+-- | Retrieve the environment value.
+--
+-- @
+-- runReader a ('ask' '>>=' k) = runReader a (k a)
+-- @
+--
+-- @since 0.1.0.0
+ask :: forall label r m sig . HasLabelled label (Reader r) sig m => m r
+ask = sendLabelled @label (Ask pure)

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -30,7 +30,7 @@ import           Control.Effect.Reader.Internal
 --
 -- @since 1.0.2.0
 ask :: forall label r m sig . HasLabelled label (Reader r) sig m => m r
-ask = runUnderLabel @_ @label R.ask
+ask = runUnderLabel @label R.ask
 
 -- | Project a function out of the current environment value.
 --
@@ -40,7 +40,7 @@ ask = runUnderLabel @_ @label R.ask
 --
 -- @since 1.0.2.0
 asks :: forall label r m a sig . HasLabelled label (Reader r) sig m => (r -> a) -> m a
-asks f = runUnderLabel @_ @label (R.asks f)
+asks f = runUnderLabel @label (R.asks f)
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
@@ -50,4 +50,4 @@ asks f = runUnderLabel @_ @label (R.asks f)
 --
 -- @since 1.0.2.0
 local :: forall label r m a sig . HasLabelled label (Reader r) sig m => (r -> r) -> m a -> m a
-local f m = runUnderLabel @_ @label (R.local f (UnderLabel m))
+local f m = runUnderLabel @label (R.local f (UnderLabel m))

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -1,0 +1,2 @@
+module Control.Effect.Reader.Labelled
+() where

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -7,6 +7,7 @@ module Control.Effect.Reader.Labelled
   Reader
 , ask
 , asks
+, local
   -- * Re-exports
 , Algebra
 , Effect
@@ -37,3 +38,13 @@ ask = runUnderLabel @_ @label R.ask
 -- @since 1.0.2.0
 asks :: forall label r m a sig . HasLabelled label (Reader r) sig m => (r -> a) -> m a
 asks f = runUnderLabel @_ @label (R.asks f)
+
+-- | Run a computation with an environment value locally modified by the passed function.
+--
+-- @
+-- runReader a ('runLabelled' @_ @label ('local' @label f m)) = runReader (f a) m
+-- @
+--
+-- @since 1.0.2.0
+local :: forall label r m a sig . HasLabelled label (Reader r) sig m => (r -> r) -> m a -> m a
+local f m = runUnderLabel @_ @label (R.local f (UnderLabel m))

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+-- | Labelled 'Reader' operations.
+--
+-- @since 1.0.2.0
 module Control.Effect.Reader.Labelled
 ( -- * Reader effect
   Reader

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -6,6 +6,7 @@ module Control.Effect.Reader.Labelled
 ( -- * Reader effect
   Reader
 , ask
+, asks
   -- * Re-exports
 , Algebra
 , Effect
@@ -26,3 +27,13 @@ import           Control.Effect.Reader.Internal
 -- @since 1.0.2.0
 ask :: forall label r m sig . HasLabelled label (Reader r) sig m => m r
 ask = runUnderLabel @_ @label R.ask
+
+-- | Project a function out of the current environment value.
+--
+-- @
+-- 'asks' @label f = 'fmap' f ('ask' @label)
+-- @
+--
+-- @since 1.0.2.0
+asks :: forall label r m a sig . HasLabelled label (Reader r) sig m => (r -> a) -> m a
+asks f = runUnderLabel @_ @label (R.asks f)

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -13,15 +13,16 @@ module Control.Effect.Reader.Labelled
 , run
 ) where
 
-import Control.Effect.Labelled
-import Control.Effect.Reader.Internal
+import           Control.Effect.Labelled
+import qualified Control.Effect.Reader as R
+import           Control.Effect.Reader.Internal
 
 -- | Retrieve the environment value.
 --
 -- @
--- runReader a ('ask' '>>=' k) = runReader a (k a)
+-- runReader a ('runLabelled' @_ @label ('ask' @label) '>>=' k) = runReader a (k a)
 -- @
 --
 -- @since 0.1.0.0
 ask :: forall label r m sig . HasLabelled label (Reader r) sig m => m r
-ask = sendLabelled @label (Ask pure)
+ask = runUnderLabel @_ @label R.ask

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -1,2 +1,12 @@
 module Control.Effect.Reader.Labelled
-() where
+( -- * Reader effect
+  Reader
+  -- * Re-exports
+, Algebra
+, Effect
+, Has
+, run
+) where
+
+import Control.Effect.Labelled
+import Control.Effect.Reader.Internal

--- a/src/Control/Effect/Reader/Labelled.hs
+++ b/src/Control/Effect/Reader/Labelled.hs
@@ -23,6 +23,6 @@ import           Control.Effect.Reader.Internal
 -- runReader a ('runLabelled' @_ @label ('ask' @label) '>>=' k) = runReader a (k a)
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.2.0
 ask :: forall label r m sig . HasLabelled label (Reader r) sig m => m r
 ask = runUnderLabel @_ @label R.ask

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -103,3 +103,4 @@ state :: Has (State s) sig m => (s -> (s, a)) -> m a
 state f = do
   (s', a) <- gets f
   a <$ put s'
+{-# INLINEABLE state #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Control.Effect.State.Labelled
 ( -- * State effect
-  S.State
+  State
+, get
   -- * Re-exports
 , Algebra
 , Effect
@@ -10,3 +15,15 @@ module Control.Effect.State.Labelled
 
 import           Control.Effect.Labelled
 import qualified Control.Effect.State as S
+import           Control.Effect.State.Internal
+
+-- | Get the current state value.
+--
+-- @
+-- runState a ('runLabelled' @_ @label ('get' @label) '>>=' k) = runState a (k a)
+-- @
+--
+-- @since 1.0.2.0
+get :: forall label s m sig . HasLabelled label (State s) sig m => m s
+get = runUnderLabel @_ @label S.get
+{-# INLINEABLE get #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 -- | Labelled 'State' operations.

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -1,2 +1,12 @@
 module Control.Effect.State.Labelled
-() where
+( -- * State effect
+  S.State
+  -- * Re-exports
+, Algebra
+, Effect
+, Has
+, run
+) where
+
+import           Control.Effect.Labelled
+import qualified Control.Effect.State as S

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -9,6 +9,7 @@ module Control.Effect.State.Labelled
 , gets
 , put
 , modify
+, modifyLazy
   -- * Re-exports
 , Algebra
 , Effect
@@ -64,3 +65,15 @@ put s = runUnderLabel @_ @label (S.put s)
 modify :: forall label s m sig . HasLabelled label (State s) sig m => (s -> s) -> m ()
 modify f = runUnderLabel @_ @label (S.modify f)
 {-# INLINEABLE modify #-}
+
+-- | Replace the state value with the result of applying a function to the current state value.
+--   This is lazy in the new state; injudicious use of this function may lead to space leaks.
+--
+-- @
+-- 'modifyLazy' f = 'get' '>>=' 'put' . f
+-- @
+--
+-- @since 1.0.2.0
+modifyLazy :: forall label s m sig . HasLabelled label (State s) sig m => (s -> s) -> m ()
+modifyLazy f = runUnderLabel @_ @label (S.modifyLazy f)
+{-# INLINEABLE modifyLazy #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -28,7 +28,7 @@ import           Control.Effect.State.Internal
 -- | Get the current state value.
 --
 -- @
--- runState a ('runLabelled' @_ @label ('get' @label) '>>=' k) = runState a (k a)
+-- runState a ('runLabelled' @label ('get' @label) '>>=' k) = runState a (k a)
 -- @
 --
 -- @since 1.0.2.0
@@ -50,7 +50,7 @@ gets f = runUnderLabel @label (S.gets f)
 -- | Replace the state value with a new value.
 --
 -- @
--- runState a ('runLabelled' @_ @label ('put' @label b) '>>' m) = runState b m
+-- runState a ('runLabelled' @label ('put' @label b) '>>' m) = runState b m
 -- @
 --
 -- @since 1.0.2.0

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -33,7 +33,7 @@ import           Control.Effect.State.Internal
 --
 -- @since 1.0.2.0
 get :: forall label s m sig . HasLabelled label (State s) sig m => m s
-get = runUnderLabel @_ @label S.get
+get = runUnderLabel @label S.get
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
@@ -44,7 +44,7 @@ get = runUnderLabel @_ @label S.get
 --
 -- @since 1.0.2.0
 gets :: forall label s m a sig . HasLabelled label (State s) sig m => (s -> a) -> m a
-gets f = runUnderLabel @_ @label (S.gets f)
+gets f = runUnderLabel @label (S.gets f)
 {-# INLINEABLE gets #-}
 
 -- | Replace the state value with a new value.
@@ -55,7 +55,7 @@ gets f = runUnderLabel @_ @label (S.gets f)
 --
 -- @since 1.0.2.0
 put :: forall label s m sig . HasLabelled label (State s) sig m => s -> m ()
-put s = runUnderLabel @_ @label (S.put s)
+put s = runUnderLabel @label (S.put s)
 {-# INLINEABLE put #-}
 
 -- | Replace the state value with the result of applying a function to the current state value.
@@ -67,7 +67,7 @@ put s = runUnderLabel @_ @label (S.put s)
 --
 -- @since 1.0.2.0
 modify :: forall label s m sig . HasLabelled label (State s) sig m => (s -> s) -> m ()
-modify f = runUnderLabel @_ @label (S.modify f)
+modify f = runUnderLabel @label (S.modify f)
 {-# INLINEABLE modify #-}
 
 -- | Replace the state value with the result of applying a function to the current state value.
@@ -79,7 +79,7 @@ modify f = runUnderLabel @_ @label (S.modify f)
 --
 -- @since 1.0.2.0
 modifyLazy :: forall label s m sig . HasLabelled label (State s) sig m => (s -> s) -> m ()
-modifyLazy f = runUnderLabel @_ @label (S.modifyLazy f)
+modifyLazy f = runUnderLabel @label (S.modifyLazy f)
 {-# INLINEABLE modifyLazy #-}
 
 -- | Compute a new state and a value in a single step.
@@ -90,5 +90,5 @@ modifyLazy f = runUnderLabel @_ @label (S.modifyLazy f)
 --
 -- @since 1.0.2.0
 state :: forall label s m a sig . HasLabelled label (State s) sig m => (s -> (s, a)) -> m a
-state f = runUnderLabel @_ @label (S.state f)
+state f = runUnderLabel @label (S.state f)
 {-# INLINEABLE state #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -7,6 +7,7 @@ module Control.Effect.State.Labelled
   State
 , get
 , gets
+, put
   -- * Re-exports
 , Algebra
 , Effect
@@ -39,3 +40,14 @@ get = runUnderLabel @_ @label S.get
 gets :: forall label s m a sig . HasLabelled label (State s) sig m => (s -> a) -> m a
 gets f = runUnderLabel @_ @label (S.gets f)
 {-# INLINEABLE gets #-}
+
+-- | Replace the state value with a new value.
+--
+-- @
+-- runState a ('runLabelled' @_ @label ('put' @label b) '>>' m) = runState b m
+-- @
+--
+-- @since 1.0.2.0
+put :: forall label s m sig . HasLabelled label (State s) sig m => s -> m ()
+put s = runUnderLabel @_ @label (S.put s)
+{-# INLINEABLE put #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -6,6 +6,7 @@ module Control.Effect.State.Labelled
 ( -- * State effect
   State
 , get
+, gets
   -- * Re-exports
 , Algebra
 , Effect
@@ -27,3 +28,14 @@ import           Control.Effect.State.Internal
 get :: forall label s m sig . HasLabelled label (State s) sig m => m s
 get = runUnderLabel @_ @label S.get
 {-# INLINEABLE get #-}
+
+-- | Project a function out of the current state value.
+--
+-- @
+-- 'gets' f = 'fmap' f 'get'
+-- @
+--
+-- @since 1.0.2.0
+gets :: forall label s m a sig . HasLabelled label (State s) sig m => (s -> a) -> m a
+gets f = runUnderLabel @_ @label (S.gets f)
+{-# INLINEABLE gets #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -8,6 +8,7 @@ module Control.Effect.State.Labelled
 , get
 , gets
 , put
+, modify
   -- * Re-exports
 , Algebra
 , Effect
@@ -51,3 +52,15 @@ gets f = runUnderLabel @_ @label (S.gets f)
 put :: forall label s m sig . HasLabelled label (State s) sig m => s -> m ()
 put s = runUnderLabel @_ @label (S.put s)
 {-# INLINEABLE put #-}
+
+-- | Replace the state value with the result of applying a function to the current state value.
+--   This is strict in the new state.
+--
+-- @
+-- 'modify' f = 'get' '>>=' ('put' . f '$!')
+-- @
+--
+-- @since 1.0.2.0
+modify :: forall label s m sig . HasLabelled label (State s) sig m => (s -> s) -> m ()
+modify f = runUnderLabel @_ @label (S.modify f)
+{-# INLINEABLE modify #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+-- | Labelled 'State' operations.
+--
+-- @since 1.0.2.0
 module Control.Effect.State.Labelled
 ( -- * State effect
   State

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -10,6 +10,7 @@ module Control.Effect.State.Labelled
 , put
 , modify
 , modifyLazy
+, state
   -- * Re-exports
 , Algebra
 , Effect
@@ -77,3 +78,14 @@ modify f = runUnderLabel @_ @label (S.modify f)
 modifyLazy :: forall label s m sig . HasLabelled label (State s) sig m => (s -> s) -> m ()
 modifyLazy f = runUnderLabel @_ @label (S.modifyLazy f)
 {-# INLINEABLE modifyLazy #-}
+
+-- | Compute a new state and a value in a single step.
+--
+-- @
+-- 'state' f = 'gets' f '>>=' \\ (s, a) -> 'put' s '>>' 'pure' a
+-- @
+--
+-- @since 1.0.2.0
+state :: forall label s m a sig . HasLabelled label (State s) sig m => (s -> (s, a)) -> m a
+state f = runUnderLabel @_ @label (S.state f)
+{-# INLINEABLE state #-}

--- a/src/Control/Effect/State/Labelled.hs
+++ b/src/Control/Effect/State/Labelled.hs
@@ -1,0 +1,2 @@
+module Control.Effect.State.Labelled
+() where

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -73,6 +73,7 @@ reassociateSumL = \case
   L l     -> L (L l)
   R (L l) -> L (R l)
   R (R r) -> R r
+{-# INLINE reassociateSumL #-}
 
 
 -- | Decompose sums on the left into multiple 'Member' constraints.

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -49,23 +49,27 @@ class Member (sub :: (* -> *) -> (* -> *)) sup where
 -- | Reflexivity: @t@ is a member of itself.
 instance Member t t where
   inj = id
+  {-# INLINE inj #-}
 
 -- | Left-recursion: if @t@ is a member of @l1 ':+:' l2 ':+:' r@, then we can inject it into @(l1 ':+:' l2) ':+:' r@ by injection into a right-recursive signature, followed by left-association.
 instance {-# OVERLAPPABLE #-}
          Member t (l1 :+: l2 :+: r)
       => Member t ((l1 :+: l2) :+: r) where
   inj = reassociateSumL . inj
+  {-# INLINE inj #-}
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}
          Member l (l :+: r) where
   inj = L
+  {-# INLINE inj #-}
 
 -- | Right-recursion: if @t@ is a member of @r@, we can inject it into @r@ in O(n), followed by lifting that into @l ':+:' r@ in O(1).
 instance {-# OVERLAPPABLE #-}
          Member l r
       => Member l (l' :+: r) where
   inj = R . inj
+  {-# INLINE inj #-}
 
 
 -- | Reassociate a right-chained sum leftwards.

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -53,9 +54,10 @@ instance {-# OVERLAPPABLE #-}
          Member t (l1 :+: l2 :+: r)
       => Member t ((l1 :+: l2) :+: r) where
   inj = reassoc . inj where
-    reassoc (L l)     = L (L l)
-    reassoc (R (L l)) = L (R l)
-    reassoc (R (R r)) = R r
+    reassoc = \case
+      L l     -> L (L l)
+      R (L l) -> L (R l)
+      R (R r) -> R r
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -69,6 +69,8 @@ instance {-# OVERLAPPABLE #-}
 
 
 -- | Reassociate a right-chained sum leftwards.
+--
+-- @since 1.0.2.0
 reassociateSumL :: (l1 :+: l2 :+: r) m a -> ((l1 :+: l2) :+: r) m a
 reassociateSumL = \case
   L l     -> L (L l)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -16,6 +16,7 @@ module Control.Effect.Sum
 , Members
   -- * Sums
 , (:+:)(..)
+, reassociateSumL
 ) where
 
 import Control.Effect.Class
@@ -53,11 +54,7 @@ instance Member t t where
 instance {-# OVERLAPPABLE #-}
          Member t (l1 :+: l2 :+: r)
       => Member t ((l1 :+: l2) :+: r) where
-  inj = reassoc . inj where
-    reassoc = \case
-      L l     -> L (L l)
-      R (L l) -> L (R l)
-      R (R r) -> R r
+  inj = reassociateSumL . inj
 
 -- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
 instance {-# OVERLAPPABLE #-}
@@ -69,6 +66,13 @@ instance {-# OVERLAPPABLE #-}
          Member l r
       => Member l (l' :+: r) where
   inj = R . inj
+
+
+reassociateSumL :: (l1 :+: l2 :+: r) m a -> ((l1 :+: l2) :+: r) m a
+reassociateSumL = \case
+  L l     -> L (L l)
+  R (L l) -> L (R l)
+  R (R r) -> R r
 
 
 -- | Decompose sums on the left into multiple 'Member' constraints.

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -68,6 +68,7 @@ instance {-# OVERLAPPABLE #-}
   inj = R . inj
 
 
+-- | Reassociate a right-chained sum leftwards.
 reassociateSumL :: (l1 :+: l2 :+: r) m a -> ((l1 :+: l2) :+: r) m a
 reassociateSumL = \case
   L l     -> L (L l)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -72,7 +72,7 @@ instance {-# OVERLAPPABLE #-}
   {-# INLINE inj #-}
 
 
--- | Reassociate a right-chained sum leftwards.
+-- | Reassociate a right-nested sum leftwards.
 --
 -- @since 1.0.2.0
 reassociateSumL :: (l1 :+: l2 :+: r) m a -> ((l1 :+: l2) :+: r) m a


### PR DESCRIPTION
This PR defines a module for labelled effects, allowing some pretty powerful patterns applying injectivity/type dependencies to effects. For example:

1. Stock effects such as `Reader` and `State` can be distinguished by means of arbitrary labels, which can be much more convenient than `ScopedTypeVariables` in many cases.

2. Type inference can be improved by the same means for many parametric effects if and as desired.

3. Effect parameters can be made dependent on the carrier without concretely mentioning it; this amounts to the ability to associate arbitrary types with effects via a label.

4. Equivalently, ambiguities can be resolved for effect parameters via a label.

Labels offer a super flexible means of applying injectivity to uniquely determine some effect from an arbitrary label, without having to define new classes anywhere; indeed, existing effects, operations, and carriers can be lifted into their labelled counterparts _as-is_.

This is in quite good shape for use, but there’s still some work to do before we merge this:

- [x] API documentation.
- [x] Document the sorts of patterns this enables; e.g. how to solve interesting inference or ambiguity problems.
- [x] Maybe bake in labelled `Reader`/`State` operations?
- [x] Changelog entry.
- [x] Tests.
- [x] ~~Laws? What would they even look like…?~~ This isn’t really meaningful beyond the labelled `Reader`/`State` operations.
- [x] Changelog entries for `Control.Effect.Reader.Labelled` and `Control.Effect.State.Labelled`.
- [x] ~~Hackage release.~~ Going to do this in a separate PR after #347 is in.
