### PR TITLE
Derivable Algebra

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,14 @@
+# Backwards-incompatible changes
+
+- Changes `alg`’s signature, giving it a monad homomorphism which must be applied to each computation in the signature. This change allows `Algebra` instances to be derived using `GeneralizedNewtypeDeriving` and `DerivingVia`, while also obviating the need for `hmap` or `handleCoercible`. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
+
+- Removes `Algebra`’s superclass constraint requiring a `HFunctor` instance for the signature. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
+
+- Removes `handleCoercible`. Algebras which formerly used it when handling the tail of the signature may now compose `coerce` onto the homomorphism passed to `alg`. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
+
+- Removes `HFunctor`. Effects are no longer required to have `HFunctor` instances, and so the class is redundant. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
+
+
 # v1.0.2.0
 
 - Adds a `state` operation for the `State` effect. ([#353](https://github.com/fused-effects/fused-effects/pull/353))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 - Changes `alg`’s signature, giving it a monad homomorphism which must be applied to each computation in the signature. This change allows `Algebra` instances to be derived using `GeneralizedNewtypeDeriving` and `DerivingVia`, while also obviating the need for `hmap` or `handleCoercible`. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
 
+- Changes the signatures of `runInterpret` and `runInterpretState` analogously. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
+
 - Removes `Algebra`’s superclass constraint requiring a `HFunctor` instance for the signature. ([#359](https://github.com/fused-effects/fused-effects/pull/359))
 
 - Removes `handleCoercible`. Algebras which formerly used it when handling the tail of the signature may now compose `coerce` onto the homomorphism passed to `alg`. ([#359](https://github.com/fused-effects/fused-effects/pull/359))

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ example4 = runM . runReader "hello" . runState 0 $ do
 
 ### Required compiler extensions
 
-When defining your own effects, you may need `-XKindSignatures` if GHC cannot correctly infer the type of your handler; see the [documentation on common errors][common] for more information about this case. `-XDeriveGeneric` can be used with many first-order effects to derive default implementations of `HFunctor` and `Effect`.
+When defining your own effects, you may need `-XKindSignatures` if GHC cannot correctly infer the type of your handler; see the [documentation on common errors][common] for more information about this case. `-XDeriveGeneric` can be used with many first-order effects to derive default implementation of `Effect`.
 
 When defining carriers, you’ll need `-XTypeOperators` to declare a `Carrier` instance over (`:+:`), `-XFlexibleInstances` to loosen the conditions on the instance, `-XMultiParamTypeClasses` since `Carrier` takes two parameters, and `-XUndecidableInstances` to satisfy the coverage condition for this instance.
 

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -38,14 +38,14 @@ main = defaultMain
   ,
     bgroup "InterpretC vs InterpretStateC vs StateC"
     [ bgroup "InterpretC"
-      [ bench "100"   $ whnf (\n -> run $ evalState @(Sum Int) 0 $ runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) $ modLoop n) 100
-      , bench "1000"  $ whnf (\n -> run $ evalState @(Sum Int) 0 $ runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) $ modLoop n) 1000
-      , bench "10000" $ whnf (\n -> run $ evalState @(Sum Int) 0 $ runInterpret (\case { Get k -> get @(Sum Int) >>= k ; Put s k -> put s >> k }) $ modLoop n) 10000
+      [ bench "100"   $ whnf (\n -> run $ evalState @(Sum Int) 0 $ runInterpret (\ hom -> \case { Get k -> get @(Sum Int) >>= hom . k ; Put s k -> put s >> hom k }) $ modLoop n) 100
+      , bench "1000"  $ whnf (\n -> run $ evalState @(Sum Int) 0 $ runInterpret (\ hom -> \case { Get k -> get @(Sum Int) >>= hom . k ; Put s k -> put s >> hom k }) $ modLoop n) 1000
+      , bench "10000" $ whnf (\n -> run $ evalState @(Sum Int) 0 $ runInterpret (\ hom -> \case { Get k -> get @(Sum Int) >>= hom . k ; Put s k -> put s >> hom k }) $ modLoop n) 10000
       ]
     , bgroup "InterpretStateC"
-      [ bench "100"   $ whnf (\n -> run $ runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 $ modLoop n) 100
-      , bench "1000"  $ whnf (\n -> run $ runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 $ modLoop n) 1000
-      , bench "10000" $ whnf (\n -> run $ runInterpretState (\ s -> \case { Get k -> runState @(Sum Int) s (k s) ; Put s k -> runState s k }) 0 $ modLoop n) 10000
+      [ bench "100"   $ whnf (\n -> run $ runInterpretState (\ hom s -> \case { Get k -> runState @(Sum Int) s (hom (k s)) ; Put s k -> runState s (hom k) }) 0 $ modLoop n) 100
+      , bench "1000"  $ whnf (\n -> run $ runInterpretState (\ hom s -> \case { Get k -> runState @(Sum Int) s (hom (k s)) ; Put s k -> runState s (hom k) }) 0 $ modLoop n) 1000
+      , bench "10000" $ whnf (\n -> run $ runInterpretState (\ hom s -> \case { Get k -> runState @(Sum Int) s (hom (k s)) ; Put s k -> runState s (hom k) }) 0 $ modLoop n) 10000
       ]
     , bgroup "StateC"
       [ bench "100"   $ whnf (run . evalState @(Sum Int) 0 . modLoop) 100

--- a/docs/defining_effects.md
+++ b/docs/defining_effects.md
@@ -25,9 +25,9 @@ The `Read` operation returns a `String`, and hence its continuation is represent
 
 On the other hand, the `Write` operation returns `()`. Since a function `() -> k` is equivalent to a (non-strict) `k`, we can omit the function parameter.
 
-In addition to a `Functor` instance (derived here using `-XDeriveFunctor`), we need two other instances: `HFunctor` and `Effect`. `HFunctor`, named for “higher-order functor,” has one operation, `hmap`, which applies a function to any embedded computations inside an effect. `Effect` is used by `Algebra` instances to service any requests for their effect occurring inside other computations—whether embedded or in the continuations. Since these may require some state to be maintained, `thread` takes an initial state parameter (encoded as some arbitrary functor filled with `()`), and its function is phrased as a _distributive law_, mapping state functors containing unhandled computations to handled computations producing the state functor alongside any results.
+In addition to a `Functor` instance (derived here using `-XDeriveFunctor`), we need one other instance: `Effect`. `Effect` is used by `Algebra` instances to service any requests for their effect occurring inside other computations—whether embedded or in the continuations. Since these may require some state to be maintained, `thread` takes an initial state parameter (encoded as some arbitrary functor filled with `()`), and its function is phrased as a _distributive law_, mapping state functors containing unhandled computations to handled computations producing the state functor alongside any results.
 
-Since `Teletype` is a first-order effect (i.e., its operations don’t have any embedded computations), we can derive instances both of `HFunctor` and `Effect` by first deriving a `Generic1` instance (using `-XDeriveGeneric`):
+Since `Teletype` is a first-order effect (i.e., its operations don’t have any embedded computations), we can derive an instance of `Effect` by first deriving a `Generic1` instance (using `-XDeriveGeneric`):
 
 ```haskell
 import GHC.Generics (Generic1)
@@ -38,11 +38,10 @@ data Teletype m k
   deriving (Functor, Generic1)
 ```
 
-and then defining `HFunctor` & `Effect`, leaving their methods to use the default definitions:
+and then defining `Effect`, leaving it to use the default definition of the `thread` method:
 
 ```haskell
-instance HFunctor Teletype
-instance Effect   Teletype
+instance Effect Teletype
 ```
 
 Now that we have our effect datatype, we can give definitions for `read` and `write`:

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -38,10 +38,7 @@ There are two approaches: the first is to use the monadic types defined by `tran
 
 ```haskell
 newtype Wrapper s m a = Wrapper { runWrapper :: m a }
-  deriving (Applicative, Functor, Monad)
-
-instance Algebra sig m => Algebra sig (Wrapper s m) where
-  alg = Wrapper . alg . handleCoercible
+  deriving (Algebra sig, Applicative, Functor, Monad)
 
 getState :: Has (State s) sig m => Wrapper s m s
 getState = get
@@ -54,4 +51,3 @@ instance Has (State s) sig m => MTL.MonadState s (Wrapper s m) where
   get = Control.Carrier.State.Strict.get
   put = Control.Carrier.State.Strict.put
 ```
-

--- a/docs/reinterpreting_effects.md
+++ b/docs/reinterpreting_effects.md
@@ -139,13 +139,13 @@ instance ( Has Http sig m
          , Algebra sig m
          ) =>
          Algebra (CatFactClient :+: sig) (CatFactsApi m) where
-  alg = \case
+  alg hom = \case
     L (ListFacts numberOfFacts k) -> do
       resp <- sendRequest (catFactsEndpoint { HTTP.queryString = "?amount=" <> B.pack (show numberOfFacts) })
       case lookup hContentType (HTTP.responseHeaders resp) of
         Just "application/json; charset=utf-8" -> decodeOrThrow (HTTP.responseBody resp) >>= k
         other -> throwError (InvalidContentType (show other))
-    R other -> CatFactsApi (handleCoercible other)
+    R other -> CatFactsApi (alg (runCatFactsApi . hom) other)
 ```
 
 We implement a `CatFacts` effect handler that depends on _three_ underlying effects:
@@ -169,9 +169,9 @@ newtype HttpClient m a = HttpClient { runHttp :: m a }
     )
 
 instance (MonadIO m, Algebra sig m) => Algebra (Http :+: sig) (HttpClient m) where
-  alg = \case
+  alg hom = \case
     L (SendRequest req k) -> liftIO (HTTP.getGlobalManager >>= HTTP.httpLbs req) >>= k
-    R other -> HttpClient (handleCoercible other)
+    R other -> HttpClient (alg (runHttp . hom) other)
 ```
 
 Note for the above code snippets how the `CatFactsApi` carrier delegates fetching JSON to any other effect that supports retrieving JSON given an HTTP request specification.
@@ -235,9 +235,9 @@ runMockHttp :: (HTTP.Request -> IO (HTTP.Response L.ByteString)) -> MockHttpC m 
 runMockHttp responder m = runReader responder (runMockHttpClient m)
 
 instance (MonadIO m, Algebra sig m) => Algebra (Http :+: sig) (MockHttpClient m) where
-  alg = \case
+  alg hom = \case
     L (SendRequest req k) -> MockHttpClient ask >>= \responder -> liftIO (responder req) >>= k
-    R other -> MockHttpClient (handleCoercible other)
+    R other -> MockHttpClient (alg (runMockHttpClient . hom) other)
 
 faultyNetwork :: HTTP.Request -> IO (HTTP.Response L.ByteString)
 faultyNetwork req = throwIO (HTTP.HttpExceptionRequest req HTTP.ConnectionTimeout)

--- a/examples/Inference.hs
+++ b/examples/Inference.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Inference
 ( example
 ) where
@@ -46,5 +46,4 @@ newtype HasEnv env m a = HasEnv { runHasEnv :: m a }
   deriving (Applicative, Functor, Monad)
 
 -- | The 'Carrier' instance for 'HasEnv' simply delegates all effects to the underlying carrier.
-instance Algebra sig m => Algebra sig (HasEnv env m) where
-  alg = HasEnv . alg . handleCoercible
+deriving instance Algebra sig m => Algebra sig (HasEnv env m)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -141,13 +141,13 @@ newtype ParseC m a = ParseC { runParseC :: StateC String m a }
   deriving (Alternative, Applicative, Functor, Monad)
 
 instance (Alternative m, Algebra sig m, Effect sig) => Algebra (Symbol :+: sig) (ParseC m) where
-  alg = \case
+  alg hom = \case
     L (Satisfy p k) -> do
       input <- ParseC get
       case input of
-        c:cs | p c -> ParseC (put cs) *> k c
+        c:cs | p c -> ParseC (put cs) *> hom (k c)
         _          -> empty
-    R other         -> ParseC (alg (R (handleCoercible other)))
+    R other         -> ParseC (alg (runParseC . hom) (R other))
   {-# INLINE alg #-}
 
 

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -116,8 +116,7 @@ example = testGroup "parser"
 data Symbol m k = Satisfy (Char -> Bool) (Char -> m k)
   deriving (Functor, Generic1)
 
-instance HFunctor Symbol
-instance Effect   Symbol
+instance Effect Symbol
 
 satisfy :: Has Symbol sig m => (Char -> Bool) -> m Char
 satisfy p = send (Satisfy p pure)

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
 module Parser
 ( example
 ) where
@@ -134,12 +134,13 @@ newtype ParseC m a = ParseC { runParseC :: StateC String m a }
   deriving (Alternative, Applicative, Functor, Monad)
 
 instance (Alternative m, Algebra sig m, Effect sig) => Algebra (Symbol :+: sig) (ParseC m) where
-  alg (L (Satisfy p k)) = do
-    input <- ParseC get
-    case input of
-      c:cs | p c -> ParseC (put cs) *> k c
-      _          -> empty
-  alg (R other)         = ParseC (alg (R (handleCoercible other)))
+  alg = \case
+    L (Satisfy p k) -> do
+      input <- ParseC get
+      case input of
+        c:cs | p c -> ParseC (put cs) *> k c
+        _          -> empty
+    R other         -> ParseC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}
 
 

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -44,15 +44,14 @@ example = testGroup "parser"
     [ testProperty "matches with a predicate" . property $ do
       c <- forAll Gen.alphaNum
       f <- (. ord) <$> Fn.forAllFn predicate
-      run (runNonDetA (parse [c] (satisfy f))) === if f c then [c] else []
+      run (runNonDetA (parse [c] (satisfy f))) === [c | f c]
 
     , testProperty "fails at end of input" . property $ do
       f <- (. ord) <$> Fn.forAllFn predicate
       run (runNonDetA (parse "" (satisfy f))) === []
 
     , testProperty "fails if input remains" . property $ do
-      c1 <- forAll Gen.alphaNum
-      c2 <- forAll Gen.alphaNum
+      (c1, c2) <- forAll ((,) <$> Gen.alphaNum <*> Gen.alphaNum)
       f <- (. ord) <$> Fn.forAllFn predicate
       run (runNonDetA (parse [c1, c2] (satisfy f))) === []
 
@@ -60,7 +59,7 @@ example = testGroup "parser"
       c1 <- forAll Gen.alphaNum
       c2 <- forAll Gen.alphaNum
       f <- (. ord) <$> Fn.forAllFn predicate
-      run (runNonDetA (parse [c1, c2] ((,) <$> satisfy f <*> satisfy f))) === if f c1 && f c2 then [(c1, c2)] else []
+      run (runNonDetA (parse [c1, c2] ((,) <$> satisfy f <*> satisfy f))) === [(c1, c2) | f c1, f c2]
     ]
 
   , testGroup "factor"

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -1,22 +1,30 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, LambdaCase, MultiParamTypeClasses, StandaloneDeriving, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Parser
 ( example
 ) where
 
-import Control.Algebra
-import Control.Carrier.Cut.Church
-import Control.Carrier.NonDet.Church
-import Control.Carrier.State.Strict
-import Control.Monad (replicateM)
-import Data.Char
-import Data.List (intercalate)
-import GHC.Generics (Generic1)
-import Hedgehog
+import           Control.Algebra
+import           Control.Carrier.Cut.Church
+import           Control.Carrier.NonDet.Church
+import           Control.Carrier.State.Strict
+import           Control.Monad (replicateM)
+import           Data.Char
+import           Data.List (intercalate)
+import           GHC.Generics (Generic1)
+import           Hedgehog
 import qualified Hedgehog.Function as Fn
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Test.Tasty
-import Test.Tasty.Hedgehog
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
 
 example :: TestTree
 example = testGroup "parser"
@@ -93,17 +101,17 @@ example = testGroup "parser"
       run (runCutA (parse (intercalate "+" (intercalate "*" . map (show . abs) . (1:) <$> [0]:as)) expr)) === [sum (map (product . map abs) as)]
     ]
   ]
+  where
+  arbNested :: Gen a -> Range.Size -> Gen [[a]]
+  arbNested _ 0 = pure []
+  arbNested g n = do
+    m <- Gen.integral (Range.linear 0 10)
+    let n' = n `div` (m + 1)
+    replicateM (Range.unSize m) (Gen.list (Range.singleton (Range.unSize n')) g)
 
-    where arbNested :: Gen a -> Range.Size -> Gen [[a]]
-          arbNested _ 0 = pure []
-          arbNested g n = do
-            m <- Gen.integral (Range.linear 0 10)
-            let n' = n `div` (m + 1)
-            replicateM (Range.unSize m) (Gen.list (Range.singleton (Range.unSize n')) g)
-
-          predicate = Fn.fn Gen.bool
-          genFactor = Gen.integral (Range.linear 0 100)
-          genFactors = Gen.list (Range.linear 0 10) genFactor
+  predicate = Fn.fn Gen.bool
+  genFactor = Gen.integral (Range.linear 0 100)
+  genFactors = Gen.list (Range.linear 0 10) genFactor
 
 
 data Symbol m k = Satisfy (Char -> Bool) (Char -> m k)

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -106,8 +106,7 @@ data Log (a :: Type) (m :: Type -> Type) (k :: Type)
   = Log a (m k)
   deriving (Functor, Generic1)
 
-instance HFunctor (Log a)
-instance Effect   (Log a)
+instance Effect (Log a)
 
 -- Log an 'a'.
 log :: Has (Log a) sig m

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -42,8 +42,7 @@ data Teletype m k
   | Write String (m k)
   deriving (Functor, Generic1)
 
-instance HFunctor Teletype
-instance Effect   Teletype
+instance Effect Teletype
 
 read :: Has Teletype sig m => m String
 read = send (Read pure)

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleInstances, GeneralizedNewtypeDeriving, LambdaCase, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 module Teletype
 ( example
@@ -59,9 +59,10 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)
 
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
-  alg (L (Read    k)) = liftIO getLine      >>= k
-  alg (L (Write s k)) = liftIO (putStrLn s) >>  k
-  alg (R other)       = TeletypeIOC (alg (handleCoercible other))
+  alg = \case
+    L (Read    k) -> liftIO getLine      >>= k
+    L (Write s k) -> liftIO (putStrLn s) >>  k
+    R other       -> TeletypeIOC (alg (handleCoercible other))
 
 
 runTeletypeRet :: [String] -> TeletypeRetC m a -> m ([String], ([String], a))
@@ -71,10 +72,11 @@ newtype TeletypeRetC m a = TeletypeRetC { runTeletypeRetC :: StateC [String] (Wr
   deriving (Applicative, Functor, Monad)
 
 instance (Algebra sig m, Effect sig) => Algebra (Teletype :+: sig) (TeletypeRetC m) where
-  alg (L (Read    k)) = do
-    i <- TeletypeRetC get
-    case i of
-      []  -> k ""
-      h:t -> TeletypeRetC (put t) *> k h
-  alg (L (Write s k)) = TeletypeRetC (tell [s]) *> k
-  alg (R other)       = TeletypeRetC (alg (R (R (handleCoercible other))))
+  alg = \case
+    L (Read    k) -> do
+      i <- TeletypeRetC get
+      case i of
+        []  -> k ""
+        h:t -> TeletypeRetC (put t) *> k h
+    L (Write s k) -> TeletypeRetC (tell [s]) *> k
+    R other       -> TeletypeRetC (alg (R (R (handleCoercible other))))

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -59,10 +59,10 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)
 
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
-  alg = \case
-    L (Read    k) -> liftIO getLine      >>= k
-    L (Write s k) -> liftIO (putStrLn s) >>  k
-    R other       -> TeletypeIOC (alg (handleCoercible other))
+  alg hom = \case
+    L (Read    k) -> liftIO getLine      >>= hom . k
+    L (Write s k) -> liftIO (putStrLn s) >>  hom k
+    R other       -> TeletypeIOC (alg (runTeletypeIOC . hom) other)
 
 
 runTeletypeRet :: [String] -> TeletypeRetC m a -> m ([String], ([String], a))
@@ -72,11 +72,11 @@ newtype TeletypeRetC m a = TeletypeRetC { runTeletypeRetC :: StateC [String] (Wr
   deriving (Applicative, Functor, Monad)
 
 instance (Algebra sig m, Effect sig) => Algebra (Teletype :+: sig) (TeletypeRetC m) where
-  alg = \case
+  alg hom = \case
     L (Read    k) -> do
       i <- TeletypeRetC get
       case i of
-        []  -> k ""
-        h:t -> TeletypeRetC (put t) *> k h
-    L (Write s k) -> TeletypeRetC (tell [s]) *> k
-    R other       -> TeletypeRetC (alg (R (R (handleCoercible other))))
+        []  -> hom (k "")
+        h:t -> TeletypeRetC (put t) *> hom (k h)
+    L (Write s k) -> TeletypeRetC (tell [s]) *> hom k
+    R other       -> TeletypeRetC (alg (runTeletypeRetC . hom) (R (R other)))

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -164,6 +164,11 @@ instance Algebra sig m => Algebra (Reader r :+: sig) (Reader.ReaderT r m) where
   alg (L (Local f m k)) = Reader.local f m >>= k
   alg (R other)         = Reader.ReaderT $ \ r -> alg (hmap (`Reader.runReaderT` r) other)
 
+instance Algebra' sig m => Algebra' (Reader r :+: sig) (Reader.ReaderT r m) where
+  alg' (L (Ask       k)) = Reader.ask >>= k
+  alg' (L (Local f m k)) = Reader.local f m >>= k
+  alg' (R other)         = Reader.ReaderT $ \ r -> alg' (hmap (`Reader.runReaderT` r) other)
+
 newtype RWSTF w s a = RWSTF { unRWSTF :: (a, s, w) }
   deriving (Functor)
 

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -182,7 +182,7 @@ instance Algebra sig m => Algebra (Reader r :+: sig) (Reader.ReaderT r m) where
 instance Algebra' sig m => Algebra' (Reader r :+: sig) (Reader.ReaderT r m) where
   alg' hom (L (Ask       k)) = Reader.ask >>= hom . k
   alg' hom (L (Local f m k)) = Reader.local f (hom m) >>= hom . k
-  alg' hom (R other)         = Reader.ReaderT $ \ r -> alg' id (hmap ((`Reader.runReaderT` r) . hom) other)
+  alg' hom (R other)         = Reader.ReaderT $ \ r -> alg' ((`Reader.runReaderT` r) . hom) other
 
 newtype RWSTF w s a = RWSTF { unRWSTF :: (a, s, w) }
   deriving (Functor)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -15,6 +15,7 @@ An instance of the 'Algebra' class defines an interpretation of an effect signat
 -}
 module Control.Algebra
 ( Algebra(..)
+, Algebra'(..)
 , run
 , Has
 , send
@@ -58,6 +59,10 @@ import           Data.Tuple (swap)
 class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   alg :: sig m a -> m a
+
+
+class (HFunctor sig, Monad m) => Algebra' sig m | m -> sig where
+  alg' :: sig m a -> m a
 
 
 -- | Run an action exhausted of effects to produce its final result value.

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -62,7 +62,7 @@ class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
 
 
 class (HFunctor sig, Monad m) => Algebra' sig m | m -> sig where
-  alg' :: (forall x . m x -> n x) -> sig m a -> n a
+  alg' :: Monad n => (forall x . m x -> n x) -> sig m a -> n a
 
 
 -- | Run an action exhausted of effects to produce its final result value.

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -163,6 +165,8 @@ instance Algebra sig m => Algebra sig (Ap m) where
 -- @since 1.0.1.0
 instance Algebra sig m => Algebra sig (Alt m) where
   alg = Alt . alg . handleCoercible
+
+deriving instance Algebra' sig m => Algebra' sig (Alt m)
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (Reader.ReaderT r m) where
   alg (L (Ask       k)) = Reader.ask >>= k

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -58,7 +58,7 @@ import           Data.Tuple (swap)
 -- | The class of carriers (results) for algebras (effect handlers) over signatures (effects), whose actions are given by the 'alg' method.
 --
 -- @since 1.0.0.0
-class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
+class Monad m => Algebra sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   alg :: Monad n => (forall x . n x -> m x) -> sig n a -> m a
 

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -62,7 +62,7 @@ class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
 
 
 class (HFunctor sig, Monad m) => Algebra' sig m | m -> sig where
-  alg' :: sig m a -> m a
+  alg' :: (forall x . m x -> n x) -> sig m a -> n a
 
 
 -- | Run an action exhausted of effects to produce its final result value.
@@ -165,9 +165,9 @@ instance Algebra sig m => Algebra (Reader r :+: sig) (Reader.ReaderT r m) where
   alg (R other)         = Reader.ReaderT $ \ r -> alg (hmap (`Reader.runReaderT` r) other)
 
 instance Algebra' sig m => Algebra' (Reader r :+: sig) (Reader.ReaderT r m) where
-  alg' (L (Ask       k)) = Reader.ask >>= k
-  alg' (L (Local f m k)) = Reader.local f m >>= k
-  alg' (R other)         = Reader.ReaderT $ \ r -> alg' (hmap (`Reader.runReaderT` r) other)
+  alg' hom (L (Ask       k)) = hom $ Reader.ask >>= k
+  alg' hom (L (Local f m k)) = hom $ Reader.local f m >>= k
+  alg' hom (R other)         = hom $ Reader.ReaderT $ \ r -> alg' id (hmap (`Reader.runReaderT` r) other)
 
 newtype RWSTF w s a = RWSTF { unRWSTF :: (a, s, w) }
   deriving (Functor)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -21,6 +21,7 @@ module Control.Algebra
 , run
 , Has
 , send
+, send'
   -- * Re-exports
 , (:+:) (..)
 , module Control.Effect.Class
@@ -88,6 +89,11 @@ type Has eff sig m = (Members eff sig, Algebra sig m)
 send :: (Member eff sig, Algebra sig m) => eff m a -> m a
 send = alg . inj
 {-# INLINE send #-}
+
+-- | Construct a request for an effect to be interpreted by some handler later on.
+send' :: (Member eff sig, Algebra' sig m) => eff m a -> m a
+send' = alg' id . inj
+{-# INLINE send' #-}
 
 
 -- base

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -90,15 +90,19 @@ instance MonadTrans ChooseC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Choose :+: sig) (ChooseC m) where
-  alg (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
-  alg (R other)      = ChooseC $ \ fork leaf -> alg (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf) where
+  alg = \case
+    L (Choose k) -> ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
+    R other      -> ChooseC $ \ fork leaf -> alg (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
+    where
     dst :: ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))
   {-# INLINE alg #-}
 
 instance (Algebra' sig m, Effect sig) => Algebra' (Choose :+: sig) (ChooseC m) where
-  alg' hom (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (hom (k True))) (runChoose fork leaf (hom (k False)))
-  alg' (hom :: forall x . n x -> ChooseC m x) (R other)      = ChooseC $ \ fork leaf -> alg' id (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf) where
+  alg' (hom :: forall x . n x -> ChooseC m x) = \case
+    L (Choose k) -> ChooseC $ \ fork leaf -> fork (runChoose fork leaf (hom (k True))) (runChoose fork leaf (hom (k False)))
+    R other      -> ChooseC $ \ fork leaf -> alg' id (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
+    where
     dst :: ChooseC Identity (n a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure) . hom)
   {-# INLINE alg' #-}

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -95,3 +95,10 @@ instance (Algebra sig m, Effect sig) => Algebra (Choose :+: sig) (ChooseC m) whe
     dst :: ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))
   {-# INLINE alg #-}
+
+instance (Algebra' sig m, Effect sig) => Algebra' (Choose :+: sig) (ChooseC m) where
+  alg' hom (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (hom (k True))) (runChoose fork leaf (hom (k False)))
+  alg' (hom :: forall x . n x -> ChooseC m x) (R other)      = ChooseC $ \ fork leaf -> alg' id (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf) where
+    dst :: ChooseC Identity (n a) -> m (ChooseC Identity a)
+    dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure) . hom)
+  {-# INLINE alg' #-}

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -90,19 +90,10 @@ instance MonadTrans ChooseC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Choose :+: sig) (ChooseC m) where
-  alg = \case
-    L (Choose k) -> ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
-    R other      -> ChooseC $ \ fork leaf -> alg (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
-    where
-    dst :: ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
-    dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))
-  {-# INLINE alg #-}
-
-instance (Algebra' sig m, Effect sig) => Algebra' (Choose :+: sig) (ChooseC m) where
-  alg' (hom :: forall x . n x -> ChooseC m x) = \case
+  alg (hom :: forall x . n x -> ChooseC m x) = \case
     L (Choose k) -> ChooseC $ \ fork leaf -> fork (runChoose fork leaf (hom (k True))) (runChoose fork leaf (hom (k False)))
-    R other      -> ChooseC $ \ fork leaf -> alg' id (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
+    R other      -> ChooseC $ \ fork leaf -> alg id (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
     where
     dst :: ChooseC Identity (n a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure) . hom)
-  {-# INLINE alg' #-}
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -91,6 +92,6 @@ instance MonadTrans ChooseC where
 instance (Algebra sig m, Effect sig) => Algebra (Choose :+: sig) (ChooseC m) where
   alg (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChoose fork leaf (k True)) (runChoose fork leaf (k False))
   alg (R other)      = ChooseC $ \ fork leaf -> alg (thread (pure ()) dst other) >>= runIdentity . runChoose (coerce fork) (coerce leaf) where
-    dst :: Applicative m => ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
+    dst :: ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
@@ -74,8 +75,9 @@ instance MonadTrans CullC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Cull :+: NonDet :+: sig) (CullC m) where
-  alg (L (Cull (CullC m) k)) = CullC (local (const True) m) >>= k
-  alg (R (L (L Empty)))      = empty
-  alg (R (L (R (Choose k)))) = k True <|> k False
-  alg (R (R other))          = CullC (alg (R (R (handleCoercible other))))
+  alg = \case
+    L (Cull (CullC m) k) -> CullC (local (const True) m) >>= k
+    R (L (L Empty))      -> empty
+    R (L (R (Choose k))) -> k True <|> k False
+    R (R other)          -> CullC (alg (R (R (handleCoercible other))))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
@@ -95,11 +96,13 @@ instance MonadTrans CutC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
-  alg (L Cutfail)    = CutC $ \ _    _   fail -> fail
-  alg (L (Call m k)) = CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (k a)) nil nil m
-  alg (R (L (L Empty)))      = empty
-  alg (R (L (R (Choose k)))) = k True <|> k False
-  alg (R (R other))          = CutC $ \ cons nil fail -> alg (thread (pure ()) dst other) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail) where
+  alg = \case
+    L Cutfail    -> CutC $ \ _    _   fail -> fail
+    L (Call m k) -> CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (k a)) nil nil m
+    R (L (L Empty))      -> empty
+    R (L (R (Choose k))) -> k True <|> k False
+    R (R other)          -> CutC $ \ cons nil fail -> alg (thread (pure ()) dst other) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail)
+    where
     dst :: Applicative m => CutC Identity (CutC m a) -> m (CutC Identity a)
     dst = runIdentity . runCut (fmap . liftA2 (<|>) . runCut (fmap . (<|>) . pure) (pure empty) (pure cutfail)) (pure (pure empty)) (pure (pure cutfail))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -96,13 +97,13 @@ instance MonadTrans CutC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
-  alg = \case
+  alg (hom :: forall x . n x -> CutC m x) = \case
     L Cutfail    -> CutC $ \ _    _   fail -> fail
-    L (Call m k) -> CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (k a)) nil nil m
+    L (Call m k) -> CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (hom (k a))) nil nil (hom m)
     R (L (L Empty))      -> empty
-    R (L (R (Choose k))) -> k True <|> k False
-    R (R other)          -> CutC $ \ cons nil fail -> alg (thread (pure ()) dst other) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail)
+    R (L (R (Choose k))) -> hom (k True) <|> hom (k False)
+    R (R other)          -> CutC $ \ cons nil fail -> alg id (thread (pure ()) dst other) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail)
     where
-    dst :: Applicative m => CutC Identity (CutC m a) -> m (CutC Identity a)
-    dst = runIdentity . runCut (fmap . liftA2 (<|>) . runCut (fmap . (<|>) . pure) (pure empty) (pure cutfail)) (pure (pure empty)) (pure (pure cutfail))
+    dst :: CutC Identity (n a) -> m (CutC Identity a)
+    dst = runIdentity . runCut (fmap . liftA2 (<|>) . runCut (fmap . (<|>) . pure) (pure empty) (pure cutfail) . hom) (pure (pure empty)) (pure (pure cutfail))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -52,7 +52,7 @@ instance Fail.MonadFail m => Fail.MonadFail (EmptyC m) where
   {-# INLINE fail #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Empty :+: sig) (EmptyC m) where
-  alg = \case
+  alg hom = \case
     L Empty -> EmptyC (MaybeT (pure Nothing))
-    R other -> EmptyC (MaybeT (alg (thread (Just ()) (maybe (pure Nothing) runEmpty) other)))
+    R other -> EmptyC (MaybeT (alg id (thread (Just ()) (maybe (pure Nothing) (runEmpty . hom)) other)))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -51,6 +52,7 @@ instance Fail.MonadFail m => Fail.MonadFail (EmptyC m) where
   {-# INLINE fail #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Empty :+: sig) (EmptyC m) where
-  alg (L Empty) = EmptyC (MaybeT (pure Nothing))
-  alg (R other) = EmptyC (MaybeT (alg (thread (Just ()) (maybe (pure Nothing) runEmpty) other)))
+  alg = \case
+    L Empty -> EmptyC (MaybeT (pure Nothing))
+    R other -> EmptyC (MaybeT (alg (thread (Just ()) (maybe (pure Nothing) runEmpty) other)))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -43,7 +43,7 @@ runError (ErrorC m) = runExceptT m
 
 -- | @since 0.1.0.0
 newtype ErrorC e m a = ErrorC (ExceptT e m a)
-  deriving (Algebra' (Error e :+: sig), Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
+  deriving (Algebra (Error e :+: sig), Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
 
 -- | 'ErrorC' passes 'Alternative' operations along to the underlying monad @m@, rather than combining errors à la 'ExceptT'.
 instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
@@ -54,7 +54,3 @@ instance (Alternative m, Monad m) => Alternative (ErrorC e m) where
 
 -- | 'ErrorC' passes 'MonadPlus' operations along to the underlying monad @m@, rather than combining errors à la 'ExceptT'.
 instance (Alternative m, Monad m) => MonadPlus (ErrorC e m)
-
-instance (Algebra sig m, Effect sig) => Algebra (Error e :+: sig) (ErrorC e m) where
-  alg = ErrorC . alg . handleCoercible
-  {-# INLINE alg #-}

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -43,7 +43,7 @@ runError (ErrorC m) = runExceptT m
 
 -- | @since 0.1.0.0
 newtype ErrorC e m a = ErrorC (ExceptT e m a)
-  deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
+  deriving (Algebra' (Error e :+: sig), Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
 
 -- | 'ErrorC' passes 'Alternative' operations along to the underlying monad @m@, rather than combining errors à la 'ExceptT'.
 instance (Alternative m, Monad m) => Alternative (ErrorC e m) where

--- a/src/Control/Carrier/Fail/Either.hs
+++ b/src/Control/Carrier/Fail/Either.hs
@@ -40,12 +40,8 @@ runFail (FailC m) = runThrow m
 
 -- | @since 1.0.0.0
 newtype FailC m a = FailC (ThrowC String m a)
-  deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Algebra (Fail :+: sig), Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Fail.MonadFail (FailC m) where
   fail = send . Fail
   {-# INLINE fail #-}
-
-instance (Algebra sig m, Effect sig) => Algebra (Fail :+: sig) (FailC m) where
-  alg = FailC . alg . handleCoercible
-  {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -57,6 +58,7 @@ newtype FreshC m a = FreshC (StateC Int m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Fresh :+: sig) (FreshC m) where
-  alg (L (Fresh k)) = FreshC (get <* modify (+ (1 :: Int))) >>= k
-  alg (R other)     = FreshC (alg (R (handleCoercible other)))
+  alg = \case
+    L (Fresh k) -> FreshC (get <* modify (+ (1 :: Int))) >>= k
+    R other     -> FreshC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -12,7 +12,7 @@ module Control.Carrier.Fresh.Strict
 ( -- * Fresh carrier
   runFresh
 , evalFresh
-, FreshC(..)
+, FreshC(FreshC)
   -- * Fresh effect
 , module Control.Effect.Fresh
 ) where
@@ -54,11 +54,11 @@ evalFresh :: Functor m => Int -> FreshC m a -> m a
 evalFresh n (FreshC m) = evalState n m
 
 -- | @since 1.0.0.0
-newtype FreshC m a = FreshC (StateC Int m a)
+newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Fresh :+: sig) (FreshC m) where
-  alg = \case
-    L (Fresh k) -> FreshC (get <* modify (+ (1 :: Int))) >>= k
-    R other     -> FreshC (alg (R (handleCoercible other)))
+  alg hom = \case
+    L (Fresh k) -> FreshC (get <* modify (+ (1 :: Int))) >>= hom . k
+    R other     -> FreshC (alg (runFreshC . hom) (R other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -91,5 +92,6 @@ instance MonadTrans (InterpretC s sig) where
   lift = InterpretC
 
 instance (HFunctor eff, HFunctor sig, Reifies s (Handler eff m), Monad m, Algebra sig m) => Algebra (eff :+: sig) (InterpretC s eff m) where
-  alg (L eff)   = runHandler (getConst (reflect @s)) eff
-  alg (R other) = InterpretC (alg (handleCoercible other))
+  alg = \case
+    L eff   -> runHandler (getConst (reflect @s)) eff
+    R other -> InterpretC (alg (handleCoercible other))

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -89,7 +89,7 @@ newtype InterpretC s (sig :: (* -> *) -> * -> *) m a = InterpretC { runInterpret
 instance MonadTrans (InterpretC s sig) where
   lift = InterpretC
 
-instance (HFunctor eff, Reifies s (Handler eff m), Monad m, Algebra sig m) => Algebra (eff :+: sig) (InterpretC s eff m) where
+instance (Reifies s (Handler eff m), Monad m, Algebra sig m) => Algebra (eff :+: sig) (InterpretC s eff m) where
   alg hom = \case
     L eff   -> runHandler (getConst (reflect @s)) hom eff
     R other -> InterpretC (alg (runInterpretC . hom) other)

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -91,7 +91,7 @@ newtype InterpretC s (sig :: (* -> *) -> * -> *) m a = InterpretC { runInterpret
 instance MonadTrans (InterpretC s sig) where
   lift = InterpretC
 
-instance (HFunctor eff, HFunctor sig, Reifies s (Handler eff m), Monad m, Algebra sig m) => Algebra (eff :+: sig) (InterpretC s eff m) where
+instance (HFunctor eff, Reifies s (Handler eff m), Monad m, Algebra sig m) => Algebra (eff :+: sig) (InterpretC s eff m) where
   alg hom = \case
     L eff   -> runHandler (getConst (reflect @s)) hom eff
     R other -> InterpretC (alg (runInterpretC . hom) other)

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -36,4 +36,4 @@ instance MonadTrans LiftC where
   lift = LiftC
 
 instance Monad m => Algebra (Lift m) (LiftC m) where
-  alg (LiftWith with k) = LiftC (with (Identity ()) (fmap Identity . runM . runIdentity)) >>= k . runIdentity
+  alg hom (LiftWith with k) = LiftC (with (Identity ()) (fmap Identity . runM . hom . runIdentity)) >>= hom . k . runIdentity

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
@@ -113,9 +114,11 @@ instance MonadTrans NonDetC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (NonDet :+: sig) (NonDetC m) where
-  alg (L (L Empty))      = empty
-  alg (L (R (Choose k))) = k True <|> k False
-  alg (R other)          = NonDetC $ \ fork leaf nil -> alg (thread (pure ()) dst other) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil) where
+  alg = \case
+    L (L Empty)      -> empty
+    L (R (Choose k)) -> k True <|> k False
+    R other          -> NonDetC $ \ fork leaf nil -> alg (thread (pure ()) dst other) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil)
+    where
     dst :: Applicative m => NonDetC Identity (NonDetC m a) -> m (NonDetC Identity a)
     dst = runIdentity . runNonDet (liftA2 (liftA2 (<|>))) (Identity . runNonDetA) (pure (pure empty))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -114,11 +115,11 @@ instance MonadTrans NonDetC where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (NonDet :+: sig) (NonDetC m) where
-  alg = \case
+  alg (hom :: forall x . n x -> NonDetC m x) = \case
     L (L Empty)      -> empty
-    L (R (Choose k)) -> k True <|> k False
-    R other          -> NonDetC $ \ fork leaf nil -> alg (thread (pure ()) dst other) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil)
+    L (R (Choose k)) -> hom (k True) <|> hom (k False)
+    R other          -> NonDetC $ \ fork leaf nil -> alg id (thread (pure ()) dst other) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil)
     where
-    dst :: Applicative m => NonDetC Identity (NonDetC m a) -> m (NonDetC Identity a)
-    dst = runIdentity . runNonDet (liftA2 (liftA2 (<|>))) (Identity . runNonDetA) (pure (pure empty))
+    dst :: NonDetC Identity (n a) -> m (NonDetC Identity a)
+    dst = runIdentity . runNonDet (liftA2 (liftA2 (<|>))) (Identity . runNonDetA . hom) (pure (pure empty))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -85,8 +85,8 @@ instance MonadTrans (ReaderC r) where
   {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
-  alg = \case
-    L (Ask       k) -> ReaderC (\ r -> runReader r (k r))
-    L (Local f m k) -> ReaderC (\ r -> runReader (f r) m) >>= k
-    R other         -> ReaderC (\ r -> alg (hmap (runReader r) other))
+  alg hom = \case
+    L (Ask       k) -> ReaderC (\ r -> runReader r (hom (k r)))
+    L (Local f m k) -> ReaderC (\ r -> runReader (f r) (hom m)) >>= hom . k
+    R other         -> ReaderC (\ r -> alg (runReader r . hom) other)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -84,7 +85,8 @@ instance MonadTrans (ReaderC r) where
   {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
-  alg (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))
-  alg (L (Local f m k)) = ReaderC (\ r -> runReader (f r) m) >>= k
-  alg (R other)         = ReaderC (\ r -> alg (hmap (runReader r) other))
+  alg = \case
+    L (Ask       k) -> ReaderC (\ r -> runReader r (k r))
+    L (Local f m k) -> ReaderC (\ r -> runReader (f r) m) >>= k
+    R other         -> ReaderC (\ r -> alg (hmap (runReader r) other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -44,7 +44,7 @@ runReader r (ReaderC runReaderC) = runReaderC r
 
 -- | @since 1.0.0.0
 newtype ReaderC r m a = ReaderC (r -> m a)
-  deriving (Algebra' (Reader r :+: sig), Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
   deriving (MonadTrans) via R.ReaderT r
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -45,7 +45,10 @@ runReader r (ReaderC runReaderC) = runReaderC r
 -- | @since 1.0.0.0
 newtype ReaderC r m a = ReaderC (r -> m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
-  deriving (MonadTrans) via R.ReaderT r
+
+instance MonadTrans (ReaderC r) where
+  lift = ReaderC . const
+  {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
   alg (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -44,7 +44,7 @@ runReader r (ReaderC runReaderC) = runReaderC r
 
 -- | @since 1.0.0.0
 newtype ReaderC r m a = ReaderC (r -> m a)
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
+  deriving (Algebra' (Reader r :+: sig), Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
   deriving (MonadTrans) via R.ReaderT r
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
@@ -16,14 +16,13 @@ module Control.Carrier.Reader
 ) where
 
 import           Control.Algebra
-import           Control.Applicative (Alternative)
+import           Control.Applicative (Alternative(..), liftA2)
 import           Control.Effect.Reader
-import           Control.Monad (MonadPlus)
+import           Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class
-import qualified Control.Monad.Trans.Reader as R
 
 -- | Run a 'Reader' effect with the passed environment value.
 --
@@ -44,7 +43,41 @@ runReader r (ReaderC runReaderC) = runReaderC r
 
 -- | @since 1.0.0.0
 newtype ReaderC r m a = ReaderC (r -> m a)
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
+  deriving (Functor)
+
+instance Applicative m => Applicative (ReaderC r m) where
+  pure = ReaderC . const . pure
+  {-# INLINE pure #-}
+  ReaderC f <*> ReaderC a = ReaderC (liftA2 (<*>) f a)
+  {-# INLINE (<*>) #-}
+  ReaderC u *> ReaderC v = ReaderC $ \ r -> u r *> v r
+  {-# INLINE (*>) #-}
+  ReaderC u <* ReaderC v = ReaderC $ \ r -> u r <* v r
+  {-# INLINE (<*) #-}
+
+instance Alternative m => Alternative (ReaderC r m) where
+  empty = ReaderC (const empty)
+  {-# INLINE empty #-}
+  ReaderC l <|> ReaderC r = ReaderC (liftA2 (<|>) l r)
+  {-# INLINE (<|>) #-}
+
+instance Monad m => Monad (ReaderC r m) where
+  ReaderC a >>= f = ReaderC (\ r -> a r >>= runReader r . f)
+  {-# INLINE (>>=) #-}
+
+instance Fail.MonadFail m => Fail.MonadFail (ReaderC r m) where
+  fail = ReaderC . const . Fail.fail
+  {-# INLINE fail #-}
+
+instance MonadFix m => MonadFix (ReaderC s m) where
+  mfix f = ReaderC (\ r -> mfix (runReader r . f))
+  {-# INLINE mfix #-}
+
+instance MonadIO m => MonadIO (ReaderC r m) where
+  liftIO = ReaderC . const . liftIO
+  {-# INLINE liftIO #-}
+
+instance (Alternative m, Monad m) => MonadPlus (ReaderC r m)
 
 instance MonadTrans (ReaderC r) where
   lift = ReaderC . const

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -45,10 +45,7 @@ runReader r (ReaderC runReaderC) = runReaderC r
 -- | @since 1.0.0.0
 newtype ReaderC r m a = ReaderC (r -> m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus) via R.ReaderT r m
-
-instance MonadTrans (ReaderC r) where
-  lift = ReaderC . const
-  {-# INLINE lift #-}
+  deriving (MonadTrans) via R.ReaderT r
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
   alg (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -118,7 +119,8 @@ instance MonadTrans (StateC s) where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
-  alg (L (Get   k)) = StateC (\ s -> runState s (k s))
-  alg (L (Put s k)) = StateC (\ _ -> runState s k)
-  alg (R other)     = StateC (\ s -> alg (thread (s, ()) (uncurry runState) other))
+  alg = \case
+    L (Get   k) -> StateC (\ s -> runState s (k s))
+    L (Put s k) -> StateC (\ _ -> runState s k)
+    R other     -> StateC (\ s -> alg (thread (s, ()) (uncurry runState) other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -119,8 +119,8 @@ instance MonadTrans (StateC s) where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
-  alg = \case
-    L (Get   k) -> StateC (\ s -> runState s (k s))
-    L (Put s k) -> StateC (\ _ -> runState s k)
-    R other     -> StateC (\ s -> alg (thread (s, ()) (uncurry runState) other))
+  alg hom = \case
+    L (Get   k) -> StateC (\ s -> runState s (hom (k s)))
+    L (Put s k) -> StateC (\ _ -> runState s (hom k))
+    R other     -> StateC (\ s -> alg id (thread (s, ()) (uncurry runState . fmap hom) other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -116,7 +117,8 @@ instance MonadTrans (StateC s) where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
-  alg (L (Get   k)) = StateC (\ s -> runState s (k s))
-  alg (L (Put s k)) = StateC (\ _ -> runState s k)
-  alg (R other)     = StateC (\ s -> alg (thread (s, ()) (uncurry runState) other))
+  alg = \case
+    L (Get   k) -> StateC (\ s -> runState s (k s))
+    L (Put s k) -> StateC (\ _ -> runState s k)
+    R other     -> StateC (\ s -> alg (thread (s, ()) (uncurry runState) other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -117,8 +117,8 @@ instance MonadTrans (StateC s) where
   {-# INLINE lift #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
-  alg = \case
-    L (Get   k) -> StateC (\ s -> runState s (k s))
-    L (Put s k) -> StateC (\ _ -> runState s k)
-    R other     -> StateC (\ s -> alg (thread (s, ()) (uncurry runState) other))
+  alg hom = \case
+    L (Get   k) -> StateC (\ s -> runState s (hom (k s)))
+    L (Put s k) -> StateC (\ _ -> runState s (hom k))
+    R other     -> StateC (\ s -> alg id (thread (s, ()) (uncurry runState . fmap hom) other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -34,5 +35,6 @@ newtype ThrowC e m a = ThrowC (ErrorC e m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Throw e :+: sig) (ThrowC e m) where
-  alg (L (Throw e)) = ThrowC (throwError e)
-  alg (R other)     = ThrowC (alg (R (handleCoercible other)))
+  alg = \case
+    L (Throw e) -> ThrowC (throwError e)
+    R other     -> ThrowC (alg (R (handleCoercible other)))

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -11,7 +11,7 @@
 module Control.Carrier.Throw.Either
 ( -- * Throw carrier
   runThrow
-, ThrowC(..)
+, ThrowC(ThrowC)
   -- * Throw effect
 , module Control.Effect.Throw
 ) where
@@ -31,10 +31,10 @@ runThrow :: ThrowC e m a -> m (Either e a)
 runThrow (ThrowC m) = runError m
 
 -- | @since 1.0.0.0
-newtype ThrowC e m a = ThrowC (ErrorC e m a)
+newtype ThrowC e m a = ThrowC { runThrowC :: ErrorC e m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Throw e :+: sig) (ThrowC e m) where
-  alg = \case
+  alg hom = \case
     L (Throw e) -> ThrowC (throwError e)
-    R other     -> ThrowC (alg (R (handleCoercible other)))
+    R other     -> ThrowC (alg (runThrowC . hom) (R other))

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -46,6 +47,7 @@ instance MonadTrans TraceC where
   {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
-  alg (L trace) = traceCont trace
-  alg (R other) = TraceC (alg (handleCoercible other))
+  alg = \case
+    L trace -> traceCont trace
+    R other -> TraceC (alg (handleCoercible other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -47,7 +47,7 @@ instance MonadTrans TraceC where
   {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
-  alg = \case
-    L trace -> traceCont trace
-    R other -> TraceC (alg (handleCoercible other))
+  alg hom = \case
+    L trace -> hom (traceCont trace)
+    R other -> TraceC (alg (runTrace . hom) other)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -48,7 +48,7 @@ instance MonadTrans TraceC where
   {-# INLINE lift #-}
 
 instance (MonadIO m, Algebra sig m) => Algebra (Trace :+: sig) (TraceC m) where
-  alg = \case
-    L (Trace s k) -> liftIO (hPutStrLn stderr s) *> k
-    R other       -> TraceC (alg (handleCoercible other))
+  alg hom = \case
+    L (Trace s k) -> liftIO (hPutStrLn stderr s) *> hom k
+    R other       -> TraceC (alg (runTrace . hom) other)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -47,6 +48,7 @@ instance MonadTrans TraceC where
   {-# INLINE lift #-}
 
 instance (MonadIO m, Algebra sig m) => Algebra (Trace :+: sig) (TraceC m) where
-  alg (L (Trace s k)) = liftIO (hPutStrLn stderr s) *> k
-  alg (R other)       = TraceC (alg (handleCoercible other))
+  alg = \case
+    L (Trace s k) -> liftIO (hPutStrLn stderr s) *> k
+    R other       -> TraceC (alg (handleCoercible other))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -45,5 +46,6 @@ newtype TraceC m a = TraceC (WriterC (Endo [String]) m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Trace :+: sig) (TraceC m) where
-  alg (L (Trace m k)) = TraceC (tell (Endo (m :))) *> k
-  alg (R other)       = TraceC (alg (R (handleCoercible other)))
+  alg = \case
+    L (Trace m k) -> TraceC (tell (Endo (m :))) *> k
+    R other       -> TraceC (alg (R (handleCoercible other)))

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -11,7 +11,7 @@
 module Control.Carrier.Trace.Returning
 ( -- * Trace carrier
   runTrace
-, TraceC(..)
+, TraceC(TraceC)
   -- * Trace effect
 , module Control.Effect.Trace
 ) where
@@ -42,10 +42,10 @@ runTrace :: Functor m => TraceC m a -> m ([String], a)
 runTrace (TraceC m) = first (($[]) . appEndo) <$> runWriter m
 
 -- | @since 1.0.0.0
-newtype TraceC m a = TraceC (WriterC (Endo [String]) m a)
+newtype TraceC m a = TraceC { runTraceC :: WriterC (Endo [String]) m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Trace :+: sig) (TraceC m) where
-  alg = \case
-    L (Trace m k) -> TraceC (tell (Endo (m :))) *> k
-    R other       -> TraceC (alg (R (handleCoercible other)))
+  alg hom = \case
+    L (Trace m k) -> TraceC (tell (Endo (m :))) *> hom k
+    R other       -> TraceC (alg (runTraceC . hom) (R other))

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -16,7 +16,7 @@ module Control.Carrier.Writer.Strict
 ( -- * Writer carrier
   runWriter
 , execWriter
-, WriterC(..)
+, WriterC(WriterC)
   -- * Writer effect
 , module Control.Effect.Writer
 ) where
@@ -56,21 +56,21 @@ execWriter = fmap fst . runWriter
 -- | A space-efficient carrier for 'Writer' effects, implemented atop "Control.Carrier.State.Strict".
 --
 -- @since 1.0.0.0
-newtype WriterC w m a = WriterC (StateC w m a)
+newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Monoid w, Algebra sig m, Effect sig) => Algebra (Writer w :+: sig) (WriterC w m) where
-  alg = \case
-    L (Tell w     k) -> WriterC (modify (`mappend` w)) >> k
+  alg hom = \case
+    L (Tell w     k) -> WriterC (modify (`mappend` w)) >> hom k
     L (Listen   m k) -> WriterC (StateC (\ w -> do
-      (w', a) <- runWriter m
+      (w', a) <- runWriter (hom m)
       let w'' = mappend w w'
       w'' `seq` pure (w'', (w', a))))
-      >>= uncurry k
+      >>= hom . uncurry k
     L (Censor f m k) -> WriterC (StateC (\ w -> do
-      (w', a) <- runWriter m
+      (w', a) <- runWriter (hom m)
       let w'' = mappend w (f w')
       w'' `seq` pure (w'', a)))
-      >>= k
-    R other          -> WriterC (alg (R (handleCoercible other)))
+      >>= hom . k
+    R other          -> WriterC (alg (runWriterC . hom) (R other))
   {-# INLINE alg #-}

--- a/src/Control/Effect/Catch/Internal.hs
+++ b/src/Control/Effect/Catch/Internal.hs
@@ -15,8 +15,5 @@ data Catch e m k
 
 deriving instance Functor m => Functor (Catch e m)
 
-instance HFunctor (Catch e) where
-  hmap f (Catch m h k) = Catch (f m) (f . h) (f . k)
-
 instance Effect (Catch e) where
   thread ctx handler (Catch m h k) = Catch (handler (m <$ ctx)) (handler . (<$ ctx) . h) (handler . fmap k)

--- a/src/Control/Effect/Choose/Internal.hs
+++ b/src/Control/Effect/Choose/Internal.hs
@@ -12,5 +12,4 @@ newtype Choose m k
   = Choose (Bool -> m k)
   deriving (Functor, Generic1)
 
-instance HFunctor Choose
-instance Effect   Choose
+instance Effect Choose

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -10,24 +10,13 @@
 --
 -- @since 1.0.0.0
 module Control.Effect.Class
-( HFunctor(..)
-, Effect(..)
+( Effect(..)
 -- * Generic deriving of 'Effect' instances.
 , GEffect(..)
 ) where
 
 import Data.Coerce
 import GHC.Generics
-
--- | Higher-order functors of kind @(* -> *) -> (* -> *)@ map functors to functors.
---
--- @since 1.0.0.0
-class HFunctor h where
-  -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
-  --
-  -- A definition for 'hmap' over first-order effects can be derived automatically provided a 'Generic1' instance is available.
-  hmap :: Functor m => (forall x . m x -> n x) -> (h m a -> h n a)
-
 
 -- | The class of effect types, which must:
 --

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -22,8 +22,6 @@ import GHC.Generics
 
 -- | Higher-order functors of kind @(* -> *) -> (* -> *)@ map functors to functors.
 --
---   All effects must be 'HFunctor's.
---
 -- @since 1.0.0.0
 class HFunctor h where
   -- | Higher-order functor map of a natural transformation over higher-order positions within the effect.
@@ -43,7 +41,7 @@ class HFunctor h where
 -- All first-order effects (those without existential occurrences of @m@) admit a default definition of 'thread' provided a 'Generic1' instance is available for the effect.
 --
 -- @since 1.0.0.0
-class HFunctor sig => Effect sig where
+class Effect sig where
   -- | Handle any effects in a signature by threading the algebra’s handler all the way through to the continuation, starting from some initial context.
   --
   -- The handler is expressed as a /distributive law/, and required to adhere to the following laws:

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeOperators #-}
 
--- | Provides the 'HFunctor' and 'Effect' classes that effect types implement.
+-- | Provides the 'Effect' class that many effect types implement.
 --
 -- @since 1.0.0.0
 module Control.Effect.Class

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -12,8 +12,7 @@
 module Control.Effect.Class
 ( HFunctor(..)
 , Effect(..)
--- * Generic deriving of 'HFunctor' & 'Effect' instances.
-, GHFunctor(..)
+-- * Generic deriving of 'Effect' instances.
 , GEffect(..)
 ) where
 
@@ -28,9 +27,6 @@ class HFunctor h where
   --
   -- A definition for 'hmap' over first-order effects can be derived automatically provided a 'Generic1' instance is available.
   hmap :: Functor m => (forall x . m x -> n x) -> (h m a -> h n a)
-  default hmap :: (Functor m, Generic1 (h m), Generic1 (h n), GHFunctor m n (Rep1 (h m)) (Rep1 (h n))) => (forall x . m x -> n x) -> (h m a -> h n a)
-  hmap f = to1 . ghmap f . from1
-  {-# INLINE hmap #-}
 
 
 -- | The class of effect types, which must:
@@ -68,53 +64,6 @@ class Effect sig where
     -> sig n (ctx a)
   thread ctx handler = to1 . gthread ctx handler . from1
   {-# INLINE thread #-}
-
-
--- | Generic implementation of 'HFunctor'.
-class GHFunctor m m' rep rep' where
-  -- | Generic implementation of 'hmap'.
-  ghmap :: Functor m => (forall x . m x -> m' x) -> (rep a -> rep' a)
-
-instance GHFunctor m m' rep rep' => GHFunctor m m' (M1 i c rep) (M1 i c rep') where
-  ghmap f = M1 . ghmap f . unM1
-  {-# INLINE ghmap #-}
-
-instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :+: r) (l' :+: r') where
-  ghmap f (L1 l) = L1 (ghmap f l)
-  ghmap f (R1 r) = R1 (ghmap f r)
-  {-# INLINE ghmap #-}
-
-instance (GHFunctor m m' l l', GHFunctor m m' r r') => GHFunctor m m' (l :*: r) (l' :*: r') where
-  ghmap f (l :*: r) = ghmap f l :*: ghmap f r
-  {-# INLINE ghmap #-}
-
-instance GHFunctor m m' V1 V1 where
-  ghmap _ v = case v of {}
-  {-# INLINE ghmap #-}
-
-instance GHFunctor m m' U1 U1 where
-  ghmap _ = id
-  {-# INLINE ghmap #-}
-
-instance GHFunctor m m' (K1 R c) (K1 R c) where
-  ghmap _ = coerce
-  {-# INLINE ghmap #-}
-
-instance GHFunctor m m' Par1 Par1 where
-  ghmap _ = coerce
-  {-# INLINE ghmap #-}
-
-instance (Functor f, GHFunctor m m' g g') => GHFunctor m m' (f :.: g) (f :.: g') where
-  ghmap f = Comp1 . fmap (ghmap f) . unComp1
-  {-# INLINE ghmap #-}
-
-instance GHFunctor m m' (Rec1 m) (Rec1 m') where
-  ghmap f = Rec1 . f . unRec1
-  {-# INLINE ghmap #-}
-
-instance HFunctor f => GHFunctor m m' (Rec1 (f m)) (Rec1 (f m')) where
-  ghmap f = Rec1 . hmap f . unRec1
-  {-# INLINE ghmap #-}
 
 
 -- | Generic implementation of 'Effect'.

--- a/src/Control/Effect/Class.hs
+++ b/src/Control/Effect/Class.hs
@@ -11,7 +11,6 @@
 -- @since 1.0.0.0
 module Control.Effect.Class
 ( HFunctor(..)
-, handleCoercible
 , Effect(..)
 -- * Generic deriving of 'HFunctor' & 'Effect' instances.
 , GHFunctor(..)
@@ -34,16 +33,6 @@ class HFunctor h where
   default hmap :: (Functor m, Generic1 (h m), Generic1 (h n), GHFunctor m n (Rep1 (h m)) (Rep1 (h n))) => (forall x . m x -> n x) -> (h m a -> h n a)
   hmap f = to1 . ghmap f . from1
   {-# INLINE hmap #-}
-
-
--- | Thread a 'Coercible' carrier through an 'HFunctor'.
---
---   This is applicable whenever @f@ is 'Coercible' to @g@, e.g. simple @newtype@s.
---
--- @since 1.0.0.0
-handleCoercible :: (HFunctor sig, Functor f, Coercible f g) => sig f a -> sig g a
-handleCoercible = hmap coerce
-{-# INLINE handleCoercible #-}
 
 
 -- | The class of effect types, which must:

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -32,10 +32,6 @@ data Cull m k
 
 deriving instance Functor m => Functor (Cull m)
 
-instance HFunctor Cull where
-  hmap f (Cull m k) = Cull (f m) (f . k)
-  {-# INLINE hmap #-}
-
 instance Effect Cull where
   thread ctx handler (Cull m k) = Cull (handler (m <$ ctx)) (handler . fmap k)
   {-# INLINE thread #-}

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -39,11 +39,6 @@ data Cut m k
 
 deriving instance Functor m => Functor (Cut m)
 
-instance HFunctor Cut where
-  hmap _ Cutfail    = Cutfail
-  hmap f (Call m k) = Call (f m) (f . k)
-  {-# INLINE hmap #-}
-
 instance Effect Cut where
   thread _   _       Cutfail    = Cutfail
   thread ctx handler (Call m k) = Call (handler (m <$ ctx)) (handler . fmap k)

--- a/src/Control/Effect/Empty/Internal.hs
+++ b/src/Control/Effect/Empty/Internal.hs
@@ -12,5 +12,4 @@ import GHC.Generics (Generic1)
 data Empty (m :: * -> *) k = Empty
   deriving (Functor, Generic1)
 
-instance HFunctor Empty
-instance Effect   Empty
+instance Effect Empty

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -26,8 +26,7 @@ import GHC.Generics (Generic1)
 newtype Fresh m k = Fresh (Int -> m k)
   deriving (Functor, Generic1)
 
-instance HFunctor Fresh
-instance Effect   Fresh
+instance Effect Fresh
 
 
 -- | Produce a fresh (i.e. unique) 'Int'.

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -38,7 +38,7 @@ import Control.Monad.Trans.Class
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
   deriving (Alternative, Applicative, Effect, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
 
-instance (Algebra (eff :+: sig) (sub m)) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
+instance Algebra (eff :+: sig) (sub m) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
   alg hom = \case
     L eff -> Labelled (alg (runLabelled . hom) (L (runLabelled eff)))
     R sig -> Labelled (alg (runLabelled . hom) (R sig))

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -12,6 +12,14 @@
 {-# LANGUAGE UndecidableInstances #-}
 -- | Labelled effects, allowing flexible disambiguation and dependency of parametric effects.
 --
+-- Among other things, this can be used to:
+--
+-- * Improve inference by relating parametric effect types to some arbitrary label. This can be used to lift existing effect operations, or to define new ones; cf "Control.Effect.Reader.Labelled", "Control.Effect.State.Labelled" for examples of lifting effect operations into labelled effect operations.
+--
+-- * Express stronger relationships between an effect and the context it’s run in, e.g. to give an effect shadowing semantics, allowing only one instance of it to be active at a time in a given context.
+--
+-- * Resolve ambiguous types by relating parameters to a concrete label type.
+--
 -- @since 1.0.2.0
 module Control.Effect.Labelled
 ( runLabelled

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -36,12 +36,12 @@ import Control.Monad.Trans.Class
 --
 -- @since 1.0.2.0
 newtype Labelled (label :: k) (sub :: (* -> *) -> (* -> *)) m a = Labelled { runLabelled :: sub m a }
-  deriving (Alternative, Applicative, Effect, Functor, HFunctor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Effect, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
 
-instance (Algebra (eff :+: sig) (sub m), HFunctor eff, HFunctor sig) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
-  alg = \case
-    L eff -> Labelled (send (handleCoercible (runLabelled eff)))
-    R sig -> Labelled (send (handleCoercible sig))
+instance (Algebra (eff :+: sig) (sub m)) => Algebra (Labelled label eff :+: sig) (Labelled label sub m) where
+  alg hom = \case
+    L eff -> Labelled (alg (runLabelled . hom) (L (runLabelled eff)))
+    R sig -> Labelled (alg (runLabelled . hom) (R sig))
   {-# INLINE alg #-}
 
 
@@ -91,7 +91,7 @@ type HasLabelled label eff sig m = (LabelledMember label eff sig, Algebra sig m)
 --
 -- @since 1.0.2.0
 sendLabelled :: forall label eff sig m a . HasLabelled label eff sig m => eff m a -> m a
-sendLabelled = alg . injLabelled @label . Labelled
+sendLabelled = alg id . injLabelled @label . Labelled
 {-# INLINABLE sendLabelled #-}
 
 
@@ -105,8 +105,8 @@ instance MonadTrans (UnderLabel sub label) where
   lift = UnderLabel
   {-# INLINE lift #-}
 
-instance (LabelledMember label sub sig, HFunctor sub, Algebra sig m) => Algebra (sub :+: sig) (UnderLabel label sub m) where
-  alg = \case
-    L sub -> UnderLabel (sendLabelled @label (handleCoercible sub))
-    R sig -> UnderLabel (send (handleCoercible sig))
+instance (LabelledMember label sub sig, Algebra sig m) => Algebra (sub :+: sig) (UnderLabel label sub m) where
+  alg hom = \case
+    L sub -> UnderLabel (alg (runUnderLabel . hom) (injLabelled @label (Labelled sub)))
+    R sig -> UnderLabel (alg (runUnderLabel . hom) sig)
   {-# INLINE alg #-}

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -16,9 +16,6 @@ data Lift sig m k
 instance Functor m => Functor (Lift sig m) where
   fmap f (LiftWith with k) = LiftWith with (fmap f . k)
 
-instance HFunctor (Lift sig) where
-  hmap f (LiftWith go k) = LiftWith (\c lift -> go c (lift . fmap f)) (f . k)
-
 instance Functor sig => Effect (Lift sig) where
   thread ctx dst (LiftWith with k) = LiftWith
     (\ ctx' dst' -> getCompose <$> with (Compose (ctx <$ ctx')) (fmap Compose . dst' . fmap dst . getCompose))

--- a/src/Control/Effect/Reader/Internal.hs
+++ b/src/Control/Effect/Reader/Internal.hs
@@ -14,10 +14,6 @@ data Reader r m k
 
 deriving instance Functor m => Functor (Reader r m)
 
-instance HFunctor (Reader r) where
-  hmap f (Ask k)       = Ask           (f . k)
-  hmap f (Local g m k) = Local g (f m) (f . k)
-
 instance Effect (Reader r) where
   thread ctx handler (Ask k)       = Ask                          (handler . (<$ ctx) . k)
   thread ctx handler (Local f m k) = Local f (handler (m <$ ctx)) (handler . fmap k)

--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -13,5 +13,4 @@ data State s m k
   | Put s (m k)
   deriving (Functor, Generic1)
 
-instance HFunctor (State s)
-instance Effect   (State s)
+instance Effect (State s)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -29,8 +29,7 @@ data (f :+: g) (m :: * -> *) k
 
 infixr 4 :+:
 
-instance (HFunctor f, HFunctor g) => HFunctor (f :+: g)
-instance (Effect f, Effect g)     => Effect   (f :+: g)
+instance (Effect f, Effect g) => Effect (f :+: g)
 
 
 -- | The class of types present in a signature.

--- a/src/Control/Effect/Throw/Internal.hs
+++ b/src/Control/Effect/Throw/Internal.hs
@@ -12,5 +12,4 @@ import GHC.Generics (Generic1)
 newtype Throw e (m :: * -> *) k = Throw e
   deriving (Functor, Generic1)
 
-instance HFunctor (Throw e)
-instance Effect   (Throw e)
+instance Effect (Throw e)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -33,8 +33,7 @@ data Trace m k = Trace
   }
   deriving (Functor, Generic1)
 
-instance HFunctor Trace
-instance Effect   Trace
+instance Effect Trace
 
 -- | Append a message to the trace log.
 --

--- a/src/Control/Effect/Writer/Internal.hs
+++ b/src/Control/Effect/Writer/Internal.hs
@@ -15,12 +15,6 @@ data Writer w m k
 
 deriving instance Functor m => Functor (Writer w m)
 
-instance HFunctor (Writer w) where
-  hmap f (Tell w     k) = Tell w         (f       k)
-  hmap f (Listen   m k) = Listen   (f m) ((f .) . k)
-  hmap f (Censor g m k) = Censor g (f m) (f     . k)
-  {-# INLINE hmap #-}
-
 instance Effect (Writer w) where
   thread ctx handler (Tell w     k) = Tell w                        (handler (k <$ ctx))
   thread ctx handler (Listen   m k) = Listen   (handler (m <$ ctx)) (fmap handler . fmap . k)


### PR DESCRIPTION
This PR changes `Algebra`’s `alg` method, giving it a parameter for a monad homomorphism which is applied to actions within the signature.

Some neat effects of this:

- We can now derive `Algebra` instances using `GeneralizedNewtypeDeriving` or `DerivingVia`.
- The homomorphism obviates the need for uses of `hmap` in the case of e.g. `ReaderC`.
- The homomorphism obviates the need for uses of `handleCoercible` in the case of non-orthogonal carriers.
- All together now: the homomorphism obviates the need for `HFunctor` altogether.

There’s a bunch of work to do:

- [x] Depends on #354 and a hackage release containing it.
- [x] ~~Document the homomorphism parameter. Why is it a homomorphism? What does that mean? What should callers pass? (Why are you calling `alg` yourself, anyway?) What should instances do with it?~~ Not going to bother with this in this PR since #361 replaces it anyway.
- [x] 🔥 `handleCoercible`.
- [x] 🔥 `HFunctor` and its generic derivation machinery.