### PR TITLE
Define a type-restricted sendM variant for IO.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 - Adds a `state` operation for the `State` effect.
 
+- Adds a `sendIO` operation for the `Lift IO` effect ([#360](https://github.com/fused-effects/fused-effects/pull/360)).
+
 # v1.0.0.1
 
 - Adds passthrough `Algebra` instances for `Ap` and `Alt`, allowing the invocation of effects inside these structures without extraneous constructor applications.

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -51,7 +51,7 @@ sendIO = sendM
 -- This can be used to provide interoperation with @base@ functionality like @"Control.Exception".'Control.Exception.catch'@:
 --
 -- @
--- 'liftWith' $ \ ctx hdl -> 'Control.Exception.catch' (hdl (m <$ ctx)) (hdl . (<$ ctx) . h)
+-- 'liftWith' $ \\ ctx hdl -> 'Control.Exception.catch' (hdl (m <$ ctx)) (hdl . (<$ ctx) . h)
 -- @
 --
 -- The higher-order function takes both an initial context, and a handler phrased as the same sort of distributive law as described in the documentation for 'thread'. This handler takes actions lifted into a context functor, which can be either the initial context, or the derived context produced by handling a previous action.

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -43,7 +43,7 @@ sendM m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
 --
 -- @since 1.0.2.0
 sendIO :: Has (Lift IO) sig m => IO a -> m a
-sendIO m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
+sendIO = sendM
 
 
 -- | Run actions in an outer context.

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -39,6 +39,8 @@ sendM m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
 
 -- | A type-restricted variant of 'sendM' for 'IO' actions.
 --
+-- This is particularly useful when you have a @'Has' ('Lift' 'IO') sig m@ constraint for the use of 'liftWith', and want to run an action abstracted over 'Control.Monad.IO.Class.MonadIO'. 'IO' has a 'Control.Monad.IO.Class.MonadIO' instance, and 'sendIO'’s type restricts the action’s type to 'IO' without further type annotations.
+--
 -- @since 1.0.2.0
 sendIO :: Has (Lift IO) sig m => IO a -> m a
 sendIO m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -17,6 +17,7 @@ module Control.Effect.Lift
 ( -- * Lift effect
   Lift(..)
 , sendM
+, sendIO
 , liftWith
   -- * Re-exports
 , Algebra
@@ -35,6 +36,12 @@ import Control.Effect.Lift.Internal (Lift(..))
 -- @since 1.0.0.0
 sendM :: (Has (Lift n) sig m, Functor n) => n a -> m a
 sendM m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
+
+-- | A type-restricted variant of 'sendM' for 'IO' actions.
+--
+-- @since 1.0.2.0
+sendIO :: Has (Lift IO) sig m => IO a -> m a
+sendIO m = send (LiftWith (\ ctx _ -> (<$ ctx) <$> m) pure)
 
 
 -- | Run actions in an outer context.


### PR DESCRIPTION
- [x] Fixes #334.
- [x] Changelog.
- [x] Illustrate why it’s useful.