### PR TITLE
Effects as GADTs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,8 @@
 
 - Reorders the parameters to the higher-order function passed to `Control.Effect.Lift.liftWith` for consistency with `alg` and to reflect its purpose of lifting Kleisli arrows in some underlying monad into the context modulo the context’s state. ([#361](https://github.com/fused-effects/fused-effects/pull/361))
 
+- Redefines all effects as GADTs. Since we no longer require `Functor`, `HFunctor`, or `Effect` instances, we no longer need to use continuations to allow distinct result types per constructor. `Algebra` instances for these effects can be ported forwards by removing the continuations. User-defined effects are not impacted, but we recommend migrating to GADT definitions of them for convenience and ease of comprehension going forwards. ([#365](https://github.com/fused-effects/fused-effects/pull/365))
+
 
 # v1.0.2.0
 

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -32,8 +32,8 @@ main = defaultMain
     , bench "1000"  $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
     , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
     ]
-  ,
-    bgroup "InterpretC vs InterpretStateC vs StateC"
+
+  , bgroup "InterpretC vs InterpretStateC vs StateC"
     [ bgroup "InterpretC"
       [ bench "100"   $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 100
       , bench "1000"  $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 1000

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -33,12 +33,6 @@ main = defaultMain
     , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
     ]
   ,
-    bgroup "Strict StateC"
-    [ bench "100"   $ whnf (run . execState @Int 0 . modLoop) 100
-    , bench "1000"  $ whnf (run . execState @Int 0 . modLoop) 1000
-    , bench "10000" $ whnf (run . execState @Int 0 . modLoop) 10000
-    ]
-  ,
     bgroup "InterpretC vs InterpretStateC vs StateC"
     [ bgroup "InterpretC"
       [ bench "100"   $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 100

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -41,19 +41,19 @@ main = defaultMain
   ,
     bgroup "InterpretC vs InterpretStateC vs StateC"
     [ bgroup "InterpretC"
-      [ bench "100"   $ whnf (\n -> run $ evalState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 100
-      , bench "1000"  $ whnf (\n -> run $ evalState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 1000
-      , bench "10000" $ whnf (\n -> run $ evalState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 10000
+      [ bench "100"   $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 100
+      , bench "1000"  $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 1000
+      , bench "10000" $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 10000
       ]
     , bgroup "InterpretStateC"
-      [ bench "100"   $ whnf (\n -> run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 100
-      , bench "1000"  $ whnf (\n -> run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 1000
-      , bench "10000" $ whnf (\n -> run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 10000
+      [ bench "100"   $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 100
+      , bench "1000"  $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 1000
+      , bench "10000" $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 10000
       ]
     , bgroup "StateC"
-      [ bench "100"   $ whnf (run . evalState @Int 0 . modLoop) 100
-      , bench "1000"  $ whnf (run . evalState @Int 0 . modLoop) 1000
-      , bench "10000" $ whnf (run . evalState @Int 0 . modLoop) 10000
+      [ bench "100"   $ whnf (run . execState @Int 0 . modLoop) 100
+      , bench "1000"  $ whnf (run . execState @Int 0 . modLoop) 1000
+      , bench "10000" $ whnf (run . execState @Int 0 . modLoop) 10000
       ]
     ]
   ]

--- a/docs/common_errors.md
+++ b/docs/common_errors.md
@@ -6,14 +6,14 @@ is an attempt to enumerate and explicate the things that can go wrong
 when using or extending this library. (It is also very much a work in
 progress.)
 
+
 ## I'm getting kind errors when implementing an `Algebra` instance!
 
 Given an effect datatype that doesn’t use the `m` parameter:
 
 ```haskell
-data Fail m k
-  = Fail String
-  deriving (Functor)
+data Fail m k where
+  Fail :: String -> Fail m a
 
 newtype FailC m a = FailC { runFailC :: m (Either String a) }
 ```
@@ -39,7 +39,6 @@ the definition of `Fail`, so GHC makes an understandable but incorrect inference
 An explicit kind annotation on `m` fixes the problem.
 
 ```haskell
-data Fail (m :: * -> *) k
-  = Fail String
-  deriving (Functor)
+data Fail (m :: * -> *) k where
+  Fail :: String -> Fail m a
 ```

--- a/docs/defining_effects.md
+++ b/docs/defining_effects.md
@@ -5,7 +5,7 @@ Effects are a powerful mechanism for abstraction, and so defining new effects is
 It’s often helpful to start by specifying the types of the desired operations. For our example, we’re going to define a `Teletype` effect, with `read` and `write` operations, which read a string from some input and write a string to some output, respectively:
 
 ```haskell
-data Teletype m k
+data Teletype (m :: Type -> Type) k
 read :: Has Teletype sig m => m String
 write :: Has Teletype sig m => String -> m ()
 ```
@@ -15,54 +15,45 @@ Effect types must have two type parameters: `m`, denoting any computations which
 Next, we can flesh out the definition of the `Teletype` effect by providing constructors for each primitive operation:
 
 ```haskell
-data Teletype m k
-  = Read (String -> m k)
-  | Write String (m k)
-  deriving (Functor)
+data Teletype (m :: Type -> Type) k where
+  Read  ::           Teletype m String
+  Write :: String -> Teletype m ()
 ```
 
-The `Read` operation returns a `String`, and hence its continuation is represented as a function _taking_ a `String`. Thus, to continue the computation, a handler will have to provide a `String`. But since the effect type doesn’t say anything about where that `String` should come from, handlers are free to read from `stdin`, use a constant value, etc.
-
-On the other hand, the `Write` operation returns `()`. Since a function `() -> k` is equivalent to a (non-strict) `k`, we can omit the function parameter.
+The `Read` operation returns a `String`, and hence its result type is `String`. Thus, to interpret this constructor, an algebra will have to produce a `String`. But since the effect type doesn’t say anything about where that `String` should come from, algebras are free to read from `stdin`, use a constant value, etc. By contrast, the `Write` operation takes a `String` and returns `()`.
 
 Now that we have our effect datatype, we can give definitions for `read` and `write`:
 
 ```haskell
 read :: Has Teletype sig m => m String
-read = send (Read pure)
+read = send Read
 
 write :: Has Teletype sig m => String -> m ()
-write s = send (Write s (pure ()))
+write s = send (Write s)
 ```
 
 This gives us enough to write computations using the `Teletype` effect. The next section discusses how to run `Teletype` computations.
 
-## Defining effect handlers
 
-Effects only specify actions, they don’t actually perform them. That task is left up to effect handlers, typically defined as functions calling `interpret` to apply a given `Algebra` instance.
+## Defining algebras
+
+Effects only specify actions, they don’t actually specify how any actions should be performed. That task is left up to algebras, defined as `Algebra` instances.
 
 Following from the above section, we can define a carrier for the `Teletype` effect which runs the calls in an underlying `MonadIO` instance, accessed via our carrier’s own `GenericNewtypeDeriving`-derived instance:
 
 ```haskell
-newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
+newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIO :: m a }
   deriving (Applicative, Functor, Monad, MonadIO)
 
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
   alg hdl sig ctx = case sig of
-    L (Read    k) -> liftIO getLine      >>= hdl . (<$ ctx) . k
-    L (Write s k) -> liftIO (putStrLn s) >>  hdl (k <$ ctx>)
-    R other       -> TeletypeIOC (alg (runTeletypeIOC . hdl) other ctx)
+    L Read      -> (<$ ctx) <$ liftIO getLine
+    L (Write s) -> ctx      <$ liftIO (putStrLn s)
+    R other     -> TeletypeIOC (alg (runTeletypeIO . hdl) other ctx)
 ```
 
-Here, `alg` is responsible for handling effectful computations. Since the `Algebra` instance handles a sum (`:+:`) of `Teletype` and the remaining signature, `alg` has two parts: a handler for `Teletype`, and a handler for teletype effects that might be embedded inside other effects in the signature.
+Here, `alg` is responsible for handling effectful computations. Since the `Algebra` instance handles a sum (`:+:`) of `Teletype` and the remaining signature, `alg` has two parts: a case for the `Teletype` effect (in `L`), and a case for effects in the tail of the signature (in `R`).
 
-In this case, since the `Teletype` carrier is just a thin wrapper around the underlying computation, we pass `alg` a function to unwrap any embedded `TeletypeIOC` values by simply composing `runTeletypeIOC` onto `hom`.
+The `Teletype` effect is handled with a case per constructor. Since we’re assuming the existence of a `MonadIO` instance for the underlying computation, we use `liftIO` to inject the `getLine` and `putStrLn` actions into it, and simply bundle up the initial state `ctx` with the results.
 
-That leaves `Teletype` effects themselves, which are handled with one case per constructor. Since we’re assuming the existence of a `MonadIO` instance for the underlying computation, we can use `liftIO` to inject the `getLine` and `putStrLn` actions into it, and then proceed with the continuations, unwrapping them in the process.
-
-By convention, we also provide a `runTeletypeIO` function. For `TeletypeIOC` this just unwrapps the carrier, but for more involved carriers it might also apply some arguments. (We could also have used this name for the type’s field selector directly, at the cost of some asymmetry in its name.)
-
-```haskell
-runTeletypeIO :: TeletypeIOC m a -> m a
-runTeletypeIO = runTeletypeIOC
-```
+Since the `Teletype` carrier is just a thin wrapper around the underlying computation, we can handle the tail of the signature by passing `alg` a function to unwrap any embedded `TeletypeIOC` values by simply composing `runTeletypeIO` onto `hdl`.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -2,13 +2,23 @@
 
 ## Why is `Algebra` called `Algebra`, and not something more specific to the interpretation of effects?
 
-In previous versions of `fused-effects`, `Algebra` was called Carrier. The authors chose to rename this to keep it in line with the literature (the corresponding typeclass is called `TermAlgebra` in _Fusion for Free_), emphasize the importance of morphisms over objects, and emphasize its similarity to the common Haskell idiom of [F-algebras](https://www.schoolofhaskell.com/user/bartosz/understanding-algebras). The term “algebra” stems from the Arabic جبر, _jabr_, which roughly translates to “reunion” or “restoration”. This propery is visible in the definition of the `Carrier` class’s `eff` method:
+In previous versions of `fused-effects`, `Algebra` was called `Carrier`. The authors chose to rename this to keep it in line with the literature (the corresponding typeclass is called `TermAlgebra` in _Fusion for Free_), emphasize the importance of morphisms over objects, and emphasize its similarity to the common Haskell idiom of [F-algebras](https://www.schoolofhaskell.com/user/bartosz/understanding-algebras). The term “algebra” stems from the Arabic جبر, _jabr_, which roughly translates to “reunion” or “restoration”. This property is most clearly visible in the `alg` method’s original type signature:
 
 ```haskell
-eff :: sig m a -> m a
+alg :: sig m a -> m a
 ```
 
 Like the traditional encoding of F-algebras (`f a -> a`), this describes a function that reunites an effect signature `sig` with its monadic context `m`.
+
+In 1.1.0.0, `alg` was given an extended signature:
+
+```haskell
+alg :: Functor ctx => Handler ctx n m -> sig n a -> ctx () -> m (ctx a)
+```
+
+Ignoring `ctx` for the moment, this corresponds to higher-order _Mendler iteration_: instead of the algebra receiving a signature containing `m`s, it receives an algebra containing some other (universally quantified) type `n`, plus a handler function lowering `n` to `m`, similar to how `foldMap` takes a structure `t a` and reduces the `a`s to some `Monoid` `m` using a function `a -> m`.
+
+The context occurs in both `alg` and the handler in order to correctly lower stateful monad transformers `t m` to `m` while carrying along whatever context they need to resume: for `ExceptT e` this is `Either e`, for `StateT s` it’s `(,) s`, and so on. So all told, `alg` is a state-preserving Mendler-style `sig`-algebra.
 
 
 ## When do I need to use the type application (`@Foo`) syntax?

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -10,6 +10,7 @@ eff :: sig m a -> m a
 
 Like the traditional encoding of F-algebras (`f a -> a`), this describes a function that reunites an effect signature `sig` with its monadic context `m`.
 
+
 ## When do I need to use the type application (`@Foo`) syntax?
 
 Because a given effectful operation can have multiple `State` or `Reader` effects, your code may fail to typecheck if it invokes an ambiguous state or reader effect, such as follows:
@@ -31,6 +32,7 @@ okay = do
 ```
 
 The `@Int` syntax—an _explicit type application_ specifies that the return type of `get` must in this case be an `Int`. For more information about type applications, consult the [GHC manual](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-TypeApplications).
+
 
 ## How can I build effect stacks that interoperate correctly with `mtl`?
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -2,6 +2,7 @@
 
 This file summarizes the changelog and extracts the pieces most relevant to bringing up `fused-effects` applications to use newer versions of the library.
 
+
 ## 0.5 → 1.0
 
 * The library has been divided into two hierarchies: `Control.Effect.*` provides the effect types, and `Control.Carrier.*` provides the carrier monads needed to run said effects. Each carrier exports its relevant effect types, so it suffices to import whichever carrier is needed.
@@ -10,4 +11,3 @@ This file summarizes the changelog and extracts the pieces most relevant to brin
 * The `Resumable` effect has been moved to `fused-effects-resumable`.
 * The `Carrier` class has been renamed to `Algebra` and moved to `Control.Algebra`.
 * In order to save keystrokes in the common case of `(Member eff sig, Algebra sig m)`, there now exists a `Has` constraint that covers this case and which all carrier modules reexport. Using `Has`, the above would be written `Has eff sig m`. Code that uses `Member` and `Algebra` will continue to work.
-

--- a/docs/reinterpreting_effects.md
+++ b/docs/reinterpreting_effects.md
@@ -20,7 +20,7 @@ Let's break down some of the properties of the API client that would be desirabl
 ### Initial setup
 
 ``` haskell
-{-# LANGUAGE ExistentialQuantification, DeriveFunctor, FlexibleInstances, GADTs,
+{-# LANGUAGE ExistentialQuantification, FlexibleInstances, GADTs,
 GeneralizedNewtypeDeriving, KindSignatures, OverloadedStrings, MultiParamTypeClasses,
 RankNTypes, TypeApplications, TypeOperators, UndecidableInstances #-}
 module CatFacts

--- a/docs/reinterpreting_effects.md
+++ b/docs/reinterpreting_effects.md
@@ -20,8 +20,8 @@ Let's break down some of the properties of the API client that would be desirabl
 ### Initial setup
 
 ``` haskell
-{-# LANGUAGE ExistentialQuantification, DeriveFunctor, FlexibleInstances,
-GeneralizedNewtypeDeriving, OverloadedStrings, LambdaCase, MultiParamTypeClasses,
+{-# LANGUAGE ExistentialQuantification, DeriveFunctor, FlexibleInstances, GADTs,
+GeneralizedNewtypeDeriving, KindSignatures, OverloadedStrings, MultiParamTypeClasses,
 RankNTypes, TypeApplications, TypeOperators, UndecidableInstances #-}
 module CatFacts
     ( main
@@ -29,6 +29,7 @@ module CatFacts
 -- from base
 import Control.Applicative
 import Control.Exception (throwIO)
+import Data.Kind (Type)
 -- from fused-effects
 import Control.Algebra
 import Control.Carrier.Reader
@@ -66,26 +67,25 @@ instance FromJSON CatFact where
   parseJSON = withObject "CatFact" (\o -> CatFact <$> o .: "text")
 
 -- | Our high level effect type that will be able to target different data sources.
-data CatFactClient m k
-  = ListFacts Int {- ^ Number of facts to fetch -} ([CatFact] -> m k)
-  deriving (Functor)
+data CatFactClient (m :: Type -> Type) k where
+  ListFacts :: Int {- ^ Number of facts to fetch -} -> CatFactClient m [CatFact]
 
 listFacts :: Has CatFactClient sig m => Int -> m [CatFact]
-listFacts n = send (ListFacts n pure)
+listFacts n = send (ListFacts n)
 ```
 
 Now that we have our very simple DSL in place, let's think about the underlying API: we know that it's an HTTP-based system, so let's introduce the notion of a handler that is provided a request and hands back an HTTP response.
 
 ``` haskell
-data Http m k
-  = SendRequest HTTP.Request (HTTP.Response L.ByteString -> m k)
-  deriving (Functor)
+data Http (m :: Type -> Type) k where
+  SendRequest :: HTTP.Request -> Http m (HTTP.Response L.ByteString)
 
 sendRequest :: Has Http sig m => HTTP.Request -> m (HTTP.Response L.ByteString)
-sendRequest r = send (SendRequest r pure)
+sendRequest r = send (SendRequest r)
 ```
 
 The `listFacts` function provides the ‘what’ of this API, and the `sendRequest` function provides the ‘how’. In decomposing this problem into a set of effects, each responsible for a single layer of the original problem description, we provide ourselves with a flexible, composable vocabulary rather than a single monolithic action.
+
 
 ## "Stacking" effects
 
@@ -133,13 +133,13 @@ instance ( Has Http sig m
          , Algebra sig m
          ) =>
          Algebra (CatFactClient :+: sig) (CatFactsApi m) where
-  alg hom = \case
-    L (ListFacts numberOfFacts k) -> do
+  alg hdl sig ctx = case sig of
+    L (ListFacts numberOfFacts) -> do
       resp <- sendRequest (catFactsEndpoint { HTTP.queryString = "?amount=" <> B.pack (show numberOfFacts) })
       case lookup hContentType (HTTP.responseHeaders resp) of
-        Just "application/json; charset=utf-8" -> decodeOrThrow (HTTP.responseBody resp) >>= k
+        Just "application/json; charset=utf-8" -> (<$ ctx) <$> decodeOrThrow (HTTP.responseBody resp)
         other -> throwError (InvalidContentType (show other))
-    R other -> CatFactsApi (alg (runCatFactsApi . hom) other)
+    R other -> CatFactsApi (alg (runCatFactsApi . hdl) other ctx)
 ```
 
 We implement a `CatFacts` effect handler that depends on _three_ underlying effects:
@@ -163,9 +163,9 @@ newtype HttpClient m a = HttpClient { runHttp :: m a }
     )
 
 instance (MonadIO m, Algebra sig m) => Algebra (Http :+: sig) (HttpClient m) where
-  alg hom = \case
-    L (SendRequest req k) -> liftIO (HTTP.getGlobalManager >>= HTTP.httpLbs req) >>= k
-    R other -> HttpClient (alg (runHttp . hom) other)
+  alg hdl sig ctx = case sig of
+    L (SendRequest req) -> (<$ ctx) <$> liftIO (HTTP.getGlobalManager >>= HTTP.httpLbs req)
+    R other -> HttpClient (alg (runHttp . hdl) other ctx)
 ```
 
 Note for the above code snippets how the `CatFactsApi` carrier delegates fetching JSON to any other effect that supports retrieving JSON given an HTTP request specification.
@@ -209,6 +209,7 @@ Cats have free-floating clavicle bones that attach their shoulders to their fore
 Wikipedia has a recording of a cat meowing, because why not?
 ```
 
+
 ### Testing with alternative effect handlers
 
 Per point 2. of our initial implementation criteria, we want to be able to simulate failure cases for testing purposes. This is a great case for swapping in an alternative effect handler for our HTTP layer.
@@ -229,9 +230,11 @@ runMockHttp :: (HTTP.Request -> IO (HTTP.Response L.ByteString)) -> MockHttpC m 
 runMockHttp responder m = runReader responder (runMockHttpClient m)
 
 instance (MonadIO m, Algebra sig m) => Algebra (Http :+: sig) (MockHttpClient m) where
-  alg hom = \case
-    L (SendRequest req k) -> MockHttpClient ask >>= \responder -> liftIO (responder req) >>= k
-    R other -> MockHttpClient (alg (runMockHttpClient . hom) other)
+  alg hdl sig ctx = case sig of
+    L (SendRequest req) -> do
+      responder <- MockHttpClient ask
+      (<$ ctx) <$> liftIO (responder req)
+    R other -> MockHttpClient (alg (runMockHttpClient . hdl) other ctx)
 
 faultyNetwork :: HTTP.Request -> IO (HTTP.Response L.ByteString)
 faultyNetwork req = throwIO (HTTP.HttpExceptionRequest req HTTP.ConnectionTimeout)
@@ -279,6 +282,7 @@ InvalidContentType "Just \"text/xml\""
 
 With effects, we have fine-grained ways of testing slices of our API. All that's needed to turn an integration test into a unit test or vice versa is a different set of `Algebra`-implementing effect handlers!
 
+
 ## Observing & altering effects
 
 Building new effect handling algebras can be a little bit verbose. In simpler situations, we may want to simply operate
@@ -296,17 +300,17 @@ traceHttp
   :: (Has Http sig m, MonadIO m)
   => (forall s. Reifies s (Handler Http m) => InterpretC s Http m a)
   -> m a
-traceHttp = runInterpret $ \r@(SendRequest req sendResp) -> do
+traceHttp = runInterpret $ \ _ r@(SendRequest req) ctx -> do
   startTime <- liftIO getCurrentTime
   liftIO (putStr (B.unpack (HTTP.path req) ++ " ... "))
   -- Pass the request on to something that actually knows how to respond.
-  send $ SendRequest req $ \resp -> do
-    -- Once the actual response is obtained,
-    -- we can capture the end time and status of the response.
-    endTime <- liftIO getCurrentTime
-    let timeSpent = endTime `diffUTCTime` startTime
-    liftIO $ putStrLn ("[" ++ show (statusCode $ HTTP.responseStatus resp) ++ "] took " ++ show timeSpent ++ "\n\n")
-    sendResp resp
+  resp <- sendRequest req
+  -- Once the actual response is obtained,
+  -- we can capture the end time and status of the response.
+  endTime <- liftIO getCurrentTime
+  let timeSpent = endTime `diffUTCTime` startTime
+  liftIO $ putStrLn ("[" ++ show (statusCode $ HTTP.responseStatus resp) ++ "] took " ++ show timeSpent ++ "\n\n")
+  pure (resp <$ ctx)
 ```
 
 Updating our `main` function once more:
@@ -333,6 +337,7 @@ Cats have free-floating clavicle bones that attach their shoulders to their fore
 Fossil records from two million years ago show evidence of jaguars.
 Since cats are so good at hiding illness, even a single instance of a symptom should be taken very seriously.
 ```
+
 
 ### Conclusion
 

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -10,7 +10,6 @@
 --   structured log messages as strings.
 
 
-{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -73,6 +73,6 @@ instance Algebra sig m => Algebra (Teletype :+: sig) (TeletypeRetC m) where
       i <- TeletypeRetC get
       case i of
         []  -> pure ("" <$ ctx)
-        h:t -> (h <$ ctx) <$ TeletypeRetC (put t)
+        h:t -> h <$ ctx <$ TeletypeRetC (put t)
     L (Write s) -> ctx <$ TeletypeRetC (tell [s])
     R other     -> TeletypeRetC (alg (runTeletypeRetC . hdl) (R (R other)) ctx)

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GADTs, GeneralizedNewtypeDeriving, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 
 module Teletype
 ( example
 , runTeletypeIO
 ) where
 
-import Prelude hiding (read)
-
 import Control.Algebra
 import Control.Carrier.State.Strict
 import Control.Carrier.Writer.Strict
 import Control.Monad.IO.Class
+import Data.Kind (Type)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import Prelude hiding (read)
 import Test.Tasty
 import Test.Tasty.Hedgehog
 
@@ -36,17 +36,16 @@ example = testGroup "teletype"
   ] where
   genLine = Gen.string (Range.linear 0 20) Gen.unicode
 
-data Teletype m k
-  = Read (String -> m k)
-  | Write String (m k)
-  deriving (Functor)
+data Teletype (m :: Type -> Type) k where
+  Read  ::           Teletype m String
+  Write :: String -> Teletype m ()
 
 
 read :: Has Teletype sig m => m String
-read = send (Read pure)
+read = send Read
 
 write :: Has Teletype sig m => String -> m ()
-write s = send (Write s (pure ()))
+write s = send (Write s)
 
 
 runTeletypeIO :: TeletypeIOC m a -> m a
@@ -57,9 +56,9 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIOC :: m a }
 
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
   alg hdl sig ctx = case sig of
-    L (Read    k) -> liftIO getLine      >>= hdl . (<$ ctx) . k
-    L (Write s k) -> liftIO (putStrLn s) >>  hdl (k <$ ctx)
-    R other       -> TeletypeIOC (alg (runTeletypeIOC . hdl) other ctx)
+    L Read      -> (<$ ctx) <$> liftIO getLine
+    L (Write s) -> ctx <$ liftIO (putStrLn s)
+    R other     -> TeletypeIOC (alg (runTeletypeIOC . hdl) other ctx)
 
 
 runTeletypeRet :: [String] -> TeletypeRetC m a -> m ([String], ([String], a))
@@ -70,10 +69,10 @@ newtype TeletypeRetC m a = TeletypeRetC { runTeletypeRetC :: StateC [String] (Wr
 
 instance Algebra sig m => Algebra (Teletype :+: sig) (TeletypeRetC m) where
   alg hdl sig ctx = case sig of
-    L (Read    k) -> do
+    L Read      -> do
       i <- TeletypeRetC get
       case i of
-        []  -> hdl (k "" <$ ctx)
-        h:t -> TeletypeRetC (put t) *> hdl (k h <$ ctx)
-    L (Write s k) -> TeletypeRetC (tell [s]) *> hdl (k <$ ctx)
-    R other       -> TeletypeRetC (alg (runTeletypeRetC . hdl) (R (R other)) ctx)
+        []  -> pure ("" <$ ctx)
+        h:t -> (h <$ ctx) <$ TeletypeRetC (put t)
+    L (Write s) -> ctx <$ TeletypeRetC (tell [s])
+    R other     -> TeletypeRetC (alg (runTeletypeRetC . hdl) (R (R other)) ctx)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -144,8 +144,8 @@ instance Algebra Empty Maybe where
 
 instance Algebra (Error e) (Either e) where
   alg hdl sig ctx = case sig of
-    L (Throw e)     -> Left e
-    R (Catch m h k) -> either (hdl . (<$ ctx) . h) pure (hdl (m <$ ctx)) >>= hdl . fmap k
+    L (Throw e)   -> Left e
+    R (Catch m h) -> either (hdl . (<$ ctx) . h) pure (hdl (m <$ ctx))
 
 instance Algebra (Reader r) ((->) r) where
   alg hdl sig ctx = case sig of
@@ -168,9 +168,9 @@ instance Monoid w => Algebra (Writer w) ((,) w) where
 
 instance Algebra sig m => Algebra (Error e :+: sig) (Except.ExceptT e m) where
   alg hdl sig ctx = case sig of
-    L (L (Throw e))     -> Except.throwE e
-    L (R (Catch m h k)) -> Except.catchE (hdl (m <$ ctx)) (hdl . (<$ ctx) . h) >>= hdl . fmap k
-    R other             -> Except.ExceptT $ thread (either (pure . Left) Except.runExceptT) hdl other (Right ctx)
+    L (L (Throw e))   -> Except.throwE e
+    L (R (Catch m h)) -> Except.catchE (hdl (m <$ ctx)) (hdl . (<$ ctx) . h)
+    R other           -> Except.ExceptT $ thread (either (pure . Left) Except.runExceptT) hdl other (Right ctx)
 
 deriving instance Algebra sig m => Algebra sig (Identity.IdentityT m)
 

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -131,10 +131,10 @@ send sig = runIdentity <$> alg (fmap Identity . runIdentity) (inj sig) (Identity
 -- base
 
 instance Algebra (Lift IO) IO where
-  alg hdl (LiftWith with k) ctx = with hdl ctx >>= hdl . fmap k
+  alg hdl (LiftWith with) = with hdl
 
 instance Algebra (Lift Identity) Identity where
-  alg hdl (LiftWith with k) ctx = with hdl ctx >>= hdl . fmap k
+  alg hdl (LiftWith with) = with hdl
 
 instance Algebra Choose NonEmpty where
   alg _ Choose ctx = (True <$ ctx) :| [ False <$ ctx ]

--- a/src/Control/Carrier/Choose/Church.hs
+++ b/src/Control/Carrier/Choose/Church.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
@@ -91,8 +92,8 @@ instance MonadTrans ChooseC where
 
 instance Algebra sig m => Algebra (Choose :+: sig) (ChooseC m) where
   alg (hdl :: forall x . ctx (n x) -> ChooseC m (ctx x)) sig (ctx :: ctx ()) = case sig of
-    L (Choose k) -> ChooseC $ \ fork leaf -> fork (runChoose fork leaf (hdl (k True <$ ctx))) (runChoose fork leaf (hdl (k False <$ ctx)))
-    R other      -> ChooseC $ \ fork leaf -> thread dst hdl other (pure ctx) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
+    L Choose -> ChooseC $ \ fork leaf -> fork (leaf (True <$ ctx)) (leaf (False <$ ctx))
+    R other  -> ChooseC $ \ fork leaf -> thread dst hdl other (pure ctx) >>= runIdentity . runChoose (coerce fork) (coerce leaf)
     where
     dst :: ChooseC Identity (ChooseC m a) -> m (ChooseC Identity a)
     dst = runIdentity . runChoose (liftA2 (liftA2 (<|>))) (pure . runChoose (liftA2 (<|>)) (pure . pure))

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -76,7 +76,7 @@ instance MonadTrans CullC where
 
 instance Algebra sig m => Algebra (Cull :+: NonDet :+: sig) (CullC m) where
   alg hdl sig ctx = case sig of
-    L (Cull m k)     -> CullC (local (const True) (runCullC (hdl (m <$ ctx)))) >>= hdl . fmap k
+    L (Cull m)       -> CullC (local (const True) (runCullC (hdl (m <$ ctx))))
     R (L (L Empty))  -> empty
     R (L (R Choose)) -> pure (True <$ ctx) <|> pure (False <$ ctx)
     R (R other)      -> CullC (alg (runCullC . hdl) (R (R other)) ctx)

--- a/src/Control/Carrier/Cull/Church.hs
+++ b/src/Control/Carrier/Cull/Church.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -75,8 +76,8 @@ instance MonadTrans CullC where
 
 instance Algebra sig m => Algebra (Cull :+: NonDet :+: sig) (CullC m) where
   alg hdl sig ctx = case sig of
-    L (Cull m k)         -> CullC (local (const True) (runCullC (hdl (m <$ ctx)))) >>= hdl . fmap k
-    R (L (L Empty))      -> empty
-    R (L (R (Choose k))) -> hdl (k True <$ ctx) <|> hdl (k False <$ ctx)
-    R (R other)          -> CullC (alg (runCullC . hdl) (R (R other)) ctx)
+    L (Cull m k)     -> CullC (local (const True) (runCullC (hdl (m <$ ctx)))) >>= hdl . fmap k
+    R (L (L Empty))  -> empty
+    R (L (R Choose)) -> pure (True <$ ctx) <|> pure (False <$ ctx)
+    R (R other)      -> CullC (alg (runCullC . hdl) (R (R other)) ctx)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -99,9 +100,9 @@ instance Algebra sig m => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
   alg (hdl :: forall x . ctx (n x) -> CutC m (ctx x)) sig (ctx :: ctx ()) = case sig of
     L Cutfail    -> CutC $ \ _    _   fail -> fail
     L (Call m k) -> CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (hdl (fmap k a))) nil nil (hdl (m <$ ctx))
-    R (L (L Empty))      -> empty
-    R (L (R (Choose k))) -> hdl (k True <$ ctx) <|> hdl (k False <$ ctx)
-    R (R other)          -> CutC $ \ cons nil fail -> thread dst hdl other (pure ctx) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail)
+    R (L (L Empty))  -> empty
+    R (L (R Choose)) -> pure (True <$ ctx) <|> pure (False <$ ctx)
+    R (R other)      -> CutC $ \ cons nil fail -> thread dst hdl other (pure ctx) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail)
     where
     dst :: CutC Identity (CutC m a) -> m (CutC Identity a)
     dst = runIdentity . runCut (fmap . liftA2 (<|>) . runCut (fmap . (<|>) . pure) (pure empty) (pure cutfail)) (pure (pure empty)) (pure (pure cutfail))

--- a/src/Control/Carrier/Cut/Church.hs
+++ b/src/Control/Carrier/Cut/Church.hs
@@ -98,8 +98,8 @@ instance MonadTrans CutC where
 
 instance Algebra sig m => Algebra (Cut :+: NonDet :+: sig) (CutC m) where
   alg (hdl :: forall x . ctx (n x) -> CutC m (ctx x)) sig (ctx :: ctx ()) = case sig of
-    L Cutfail    -> CutC $ \ _    _   fail -> fail
-    L (Call m k) -> CutC $ \ cons nil fail -> runCut (\ a as -> runCut cons as fail (hdl (fmap k a))) nil nil (hdl (m <$ ctx))
+    L Cutfail  -> CutC $ \ _    _   fail -> fail
+    L (Call m) -> CutC $ \ cons nil _    -> runCut cons nil nil (hdl (m <$ ctx))
     R (L (L Empty))  -> empty
     R (L (R Choose)) -> pure (True <$ ctx) <|> pure (False <$ ctx)
     R (R other)      -> CutC $ \ cons nil fail -> thread dst hdl other (pure ctx) >>= runIdentity . runCut (coerce cons) (coerce nil) (coerce fail)

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
@@ -58,6 +59,6 @@ newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
 
 instance Algebra sig m => Algebra (Fresh :+: sig) (FreshC m) where
   alg hdl sig ctx = case sig of
-    L (Fresh k) -> FreshC (get <* modify (+ (1 :: Int))) >>= hdl . (<$ ctx) . k
-    R other     -> FreshC (alg (runFreshC . hdl) (R other) ctx)
+    L Fresh -> FreshC (gets (<$ ctx) <* modify (+ (1 :: Int)))
+    R other -> FreshC (alg (runFreshC . hdl) (R other) ctx)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -35,4 +35,4 @@ instance MonadTrans LiftC where
   lift = LiftC
 
 instance Monad m => Algebra (Lift m) (LiftC m) where
-  alg hdl (LiftWith with k) ctx = LiftC (with (runM . hdl) ctx) >>= hdl . fmap k
+  alg hdl (LiftWith with) ctx = LiftC (with (runM . hdl) ctx)

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -115,9 +116,9 @@ instance MonadTrans NonDetC where
 
 instance Algebra sig m => Algebra (NonDet :+: sig) (NonDetC m) where
   alg (hdl :: forall x . ctx (n x) -> NonDetC m (ctx x)) sig (ctx :: ctx ()) = case sig of
-    L (L Empty)      -> empty
-    L (R (Choose k)) -> hdl (k True <$ ctx) <|> hdl (k False <$ ctx)
-    R other          -> NonDetC $ \ fork leaf nil -> thread dst hdl other (pure ctx) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil)
+    L (L Empty)  -> empty
+    L (R Choose) -> pure (True <$ ctx) <|> pure (False <$ ctx)
+    R other      -> NonDetC $ \ fork leaf nil -> thread dst hdl other (pure ctx) >>= runIdentity . runNonDet (coerce fork) (coerce leaf) (coerce nil)
     where
     dst :: NonDetC Identity (NonDetC m a) -> m (NonDetC Identity a)
     dst = runIdentity . runNonDet (liftA2 (liftA2 (<|>))) (Identity . runNonDetA) (pure (pure empty))

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -85,7 +86,7 @@ instance MonadTrans (ReaderC r) where
 
 instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
   alg hdl sig ctx = case sig of
-    L (Ask       k) -> ReaderC (\ r -> runReader r (hdl (k r <$ ctx)))
-    L (Local f m k) -> ReaderC (\ r -> runReader (f r) (hdl (m <$ ctx))) >>= hdl . fmap k
-    R other         -> ReaderC (\ r -> alg (runReader r . hdl) other ctx)
+    L Ask         -> ReaderC (pure . (<$ ctx))
+    L (Local f m) -> ReaderC (\ r -> runReader (f r) (hdl (m <$ ctx)))
+    R other       -> ReaderC (\ r -> alg (runReader r . hdl) other ctx)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -119,7 +120,7 @@ instance MonadTrans (StateC s) where
 
 instance Algebra sig m => Algebra (State s :+: sig) (StateC s m) where
   alg hdl sig ctx = case sig of
-    L (Get   k) -> StateC (\ s -> runState s (hdl (k s <$ ctx)))
-    L (Put s k) -> StateC (\ _ -> runState s (hdl (k <$ ctx)))
-    R other     -> StateC (\ s -> thread (uncurry runState) hdl other (s, ctx))
+    L Get     -> StateC (\ s -> pure (s, s <$ ctx))
+    L (Put s) -> StateC (\ _ -> pure (s, ctx))
+    R other   -> StateC (\ s -> thread (uncurry runState) hdl other (s, ctx))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -117,7 +118,7 @@ instance MonadTrans (StateC s) where
 
 instance Algebra sig m => Algebra (State s :+: sig) (StateC s m) where
   alg hdl sig ctx = case sig of
-    L (Get   k) -> StateC (\ s -> runState s (hdl (k s <$ ctx)))
-    L (Put s k) -> StateC (\ _ -> runState s (hdl (k <$ ctx)))
-    R other     -> StateC (\ s -> thread (uncurry runState) hdl other (s, ctx))
+    L Get     -> StateC (\ s -> pure (s, s <$ ctx))
+    L (Put s) -> StateC (\ _ -> pure (s, ctx))
+    R other   -> StateC (\ s -> thread (uncurry runState) hdl other (s, ctx))
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -47,7 +47,7 @@ instance MonadTrans TraceC where
   {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
-  alg hdl sig ctx = case sig of
-    L (Trace _) -> pure ctx
-    R other     -> TraceC (alg (runTrace . hdl) other ctx)
+  alg hdl sig = case sig of
+    L (Trace _) -> pure
+    R other     -> TraceC . alg (runTrace . hdl) other
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -47,7 +48,7 @@ instance MonadTrans TraceC where
   {-# INLINE lift #-}
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
-  alg hdl sig = case sig of
+  alg hdl = \case
     L (Trace _) -> pure
     R other     -> TraceC . alg (runTrace . hdl) other
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
@@ -47,6 +48,6 @@ instance MonadTrans TraceC where
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
   alg hdl sig ctx = case sig of
-    L trace -> hdl (traceCont trace <$ ctx)
-    R other -> TraceC (alg (runTrace . hdl) other ctx)
+    L (Trace _) -> pure ctx
+    R other     -> TraceC (alg (runTrace . hdl) other ctx)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
@@ -48,6 +49,6 @@ instance MonadTrans TraceC where
 
 instance (MonadIO m, Algebra sig m) => Algebra (Trace :+: sig) (TraceC m) where
   alg hdl sig ctx = case sig of
-    L (Trace s k) -> liftIO (hPutStrLn stderr s) *> hdl (k <$ ctx)
-    R other       -> TraceC (alg (runTrace . hdl) other ctx)
+    L (Trace s) -> ctx <$ liftIO (hPutStrLn stderr s)
+    R other     -> TraceC (alg (runTrace . hdl) other ctx)
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
@@ -46,5 +47,5 @@ newtype TraceC m a = TraceC { runTraceC :: WriterC (Endo [String]) m a }
 
 instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
   alg hdl sig ctx = case sig of
-    L (Trace m k) -> TraceC (tell (Endo (m :))) *> hdl (k <$ ctx)
-    R other       -> TraceC (alg (runTraceC . hdl) (R other) ctx)
+    L (Trace m) -> ctx <$ TraceC (tell (Endo (m :)))
+    R other     -> TraceC (alg (runTraceC . hdl) (R other) ctx)

--- a/src/Control/Effect/Catch.hs
+++ b/src/Control/Effect/Catch.hs
@@ -29,4 +29,4 @@ import Control.Effect.Catch.Internal (Catch(..))
 --
 -- @since 0.1.0.0
 catchError :: Has (Catch e) sig m => m a -> (e -> m a) -> m a
-catchError m h = send (Catch m h pure)
+catchError m h = send (Catch m h)

--- a/src/Control/Effect/Catch/Internal.hs
+++ b/src/Control/Effect/Catch/Internal.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE StandaloneDeriving #-}
 module Control.Effect.Catch.Internal
 ( Catch(..)
 ) where
@@ -10,5 +8,3 @@ module Control.Effect.Catch.Internal
 -- @since 1.0.0.0
 data Catch e m k
   = forall b . Catch (m b) (e -> m b) (b -> m k)
-
-deriving instance Functor m => Functor (Catch e m)

--- a/src/Control/Effect/Catch/Internal.hs
+++ b/src/Control/Effect/Catch/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 module Control.Effect.Catch.Internal
 ( Catch(..)
 ) where
@@ -6,5 +6,5 @@ module Control.Effect.Catch.Internal
 -- | 'Catch' effects can be used alongside 'Control.Effect.Throw.Throw' to provide recoverable exceptions.
 --
 -- @since 1.0.0.0
-data Catch e m k
-  = forall b . Catch (m b) (e -> m b) (b -> m k)
+data Catch e m k where
+  Catch :: m a -> (e -> m a) -> Catch e m a

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -52,7 +52,7 @@ import qualified Data.Semigroup as S
 --
 -- @since 1.0.0.0
 (<|>) :: Has Choose sig m => m a -> m a -> m a
-(<|>) a b = send (Choose (bool b a))
+a <|> b = send Choose >>= bool b a
 
 infixl 3 <|>
 

--- a/src/Control/Effect/Choose/Internal.hs
+++ b/src/Control/Effect/Choose/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 module Control.Effect.Choose.Internal
 ( Choose(..)
 ) where
@@ -6,4 +5,3 @@ module Control.Effect.Choose.Internal
 -- | @since 1.0.0.0
 newtype Choose m k
   = Choose (Bool -> m k)
-  deriving (Functor)

--- a/src/Control/Effect/Choose/Internal.hs
+++ b/src/Control/Effect/Choose/Internal.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 module Control.Effect.Choose.Internal
 ( Choose(..)
 ) where
 
+import Data.Kind (Type)
+
 -- | @since 1.0.0.0
-newtype Choose m k
-  = Choose (Bool -> m k)
+data Choose (m :: Type -> Type) k where
+  Choose :: Choose m Bool

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 {- | Provides an effect to cull choices in a given nondeterministic context. This effect is used in concert with 'Control.Effect.NonDet.NonDet'.
 
 Computations run inside a call to 'cull' will return at most one result.
@@ -24,8 +24,8 @@ import Control.Algebra
 -- | 'Cull' effects are used with 'Control.Effect.Choose' to provide control over branching.
 --
 -- @since 0.1.2.0
-data Cull m k
-  = forall a . Cull (m a) (a -> m k)
+data Cull m k where
+  Cull :: m a -> Cull m a
 
 
 -- | Cull nondeterminism in the argument, returning at most one result.
@@ -36,4 +36,4 @@ data Cull m k
 --
 -- @since 0.1.2.0
 cull :: Has Cull sig m => m a -> m a
-cull m = send (Cull m pure)
+cull m = send (Cull m)

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {- | Provides an effect to cull choices in a given nondeterministic context. This effect is used in concert with 'Control.Effect.NonDet.NonDet'.
 
 Computations run inside a call to 'cull' will return at most one result.
@@ -28,8 +26,6 @@ import Control.Algebra
 -- @since 0.1.2.0
 data Cull m k
   = forall a . Cull (m a) (a -> m k)
-
-deriving instance Functor m => Functor (Cull m)
 
 
 -- | Cull nondeterminism in the argument, returning at most one result.

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 
 {- | Provides an effect to delimit backtracking in a given nondeterministic context. This effect is used in concert with 'Control.Effect.NonDet.NonDet'.
 
@@ -29,9 +29,9 @@ import Control.Applicative (Alternative(..))
 -- | 'Cut' effects are used with 'Control.Effect.Choose' to provide control over backtracking.
 --
 -- @since 0.1.2.0
-data Cut m k
-  = Cutfail
-  | forall a . Call (m a) (a -> m k)
+data Cut m k where
+  Cutfail ::        Cut m a
+  Call    :: m a -> Cut m a
 
 
 -- | Fail the current branch, and prevent backtracking within the nearest enclosing 'call' (if any).
@@ -58,7 +58,7 @@ cutfail = send Cutfail
 --
 -- @since 0.1.2.0
 call :: Has Cut sig m => m a -> m a
-call m = send (Call m pure)
+call m = send (Call m)
 {-# INLINE call #-}
 
 -- | Commit to the current branch, preventing backtracking within the nearest enclosing 'call' (if any) on failure.

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {- | Provides an effect to delimit backtracking in a given nondeterministic context. This effect is used in concert with 'Control.Effect.NonDet.NonDet'.
 
@@ -34,8 +32,6 @@ import Control.Applicative (Alternative(..))
 data Cut m k
   = Cutfail
   | forall a . Call (m a) (a -> m k)
-
-deriving instance Functor m => Functor (Cut m)
 
 
 -- | Fail the current branch, and prevent backtracking within the nearest enclosing 'call' (if any).

--- a/src/Control/Effect/Empty/Internal.hs
+++ b/src/Control/Effect/Empty/Internal.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE KindSignatures #-}
 module Control.Effect.Empty.Internal
 ( Empty(..)
 ) where
 
+import Data.Kind (Type)
+
 -- | @since 1.0.0.0
-data Empty (m :: * -> *) k = Empty
+data Empty (m :: Type -> Type) k where
+  Empty :: Empty m a

--- a/src/Control/Effect/Empty/Internal.hs
+++ b/src/Control/Effect/Empty/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE KindSignatures #-}
 module Control.Effect.Empty.Internal
 ( Empty(..)
@@ -6,4 +5,3 @@ module Control.Effect.Empty.Internal
 
 -- | @since 1.0.0.0
 data Empty (m :: * -> *) k = Empty
-  deriving (Functor)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {- | This effect provides source to an infinite source of 'Int' values, suitable for generating "fresh" values to uniquely identify data without needing to invoke random numbers or impure IO.
 
 Predefined carriers:
@@ -16,9 +18,11 @@ module Control.Effect.Fresh
 ) where
 
 import Control.Algebra
+import Data.Kind (Type)
 
 -- | @since 0.1.0.0
-newtype Fresh m k = Fresh (Int -> m k)
+data Fresh (m :: Type -> Type) k where
+  Fresh :: Fresh m Int
 
 
 -- | Produce a fresh (i.e. unique) 'Int'.
@@ -29,4 +33,4 @@ newtype Fresh m k = Fresh (Int -> m k)
 --
 -- @since 0.1.0.0
 fresh :: Has Fresh sig m => m Int
-fresh = send (Fresh pure)
+fresh = send Fresh

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
-
 {- | This effect provides source to an infinite source of 'Int' values, suitable for generating "fresh" values to uniquely identify data without needing to invoke random numbers or impure IO.
 
 Predefined carriers:
@@ -21,7 +19,6 @@ import Control.Algebra
 
 -- | @since 0.1.0.0
 newtype Fresh m k = Fresh (Int -> m k)
-  deriving (Functor)
 
 
 -- | Produce a fresh (i.e. unique) 'Int'.

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -34,7 +34,7 @@ import Control.Effect.Lift.Internal (Lift(..))
 --
 -- @since 1.0.0.0
 sendM :: (Has (Lift n) sig m, Functor n) => n a -> m a
-sendM m = send (LiftWith (\ _ ctx -> (<$ ctx) <$> m) pure)
+sendM m = send (LiftWith (\ _ ctx -> (<$ ctx) <$> m))
 
 -- | A type-restricted variant of 'sendM' for 'IO' actions.
 --
@@ -62,4 +62,4 @@ liftWith
   :: Has (Lift n) sig m
   => (forall ctx . Functor ctx => Handler ctx m n -> ctx () -> n (ctx a))
   -> m a
-liftWith with = send (LiftWith with pure)
+liftWith with = send (LiftWith with)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -34,7 +34,7 @@ import Control.Effect.Lift.Internal (Lift(..))
 --
 -- @since 1.0.0.0
 sendM :: (Has (Lift n) sig m, Functor n) => n a -> m a
-sendM m = send (LiftWith (\ _ ctx -> (<$ ctx) <$> m))
+sendM m = liftWith (\ _ ctx -> (<$ ctx) <$> m)
 
 -- | A type-restricted variant of 'sendM' for 'IO' actions.
 --

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 module Control.Effect.Lift.Internal
 ( Lift(..)
@@ -7,7 +7,5 @@ module Control.Effect.Lift.Internal
 import Control.Algebra.Internal (Handler)
 
 -- | @since 1.0.0.0
-data Lift sig m k
-  = forall a . LiftWith
-    (forall ctx . Functor ctx => Handler ctx m sig -> ctx () -> sig (ctx a))
-    (a -> m k)
+data Lift sig m k where
+  LiftWith :: (forall ctx . Functor ctx => Handler ctx m sig -> ctx () -> sig (ctx a)) -> Lift sig m a

--- a/src/Control/Effect/Lift/Internal.hs
+++ b/src/Control/Effect/Lift/Internal.hs
@@ -11,6 +11,3 @@ data Lift sig m k
   = forall a . LiftWith
     (forall ctx . Functor ctx => Handler ctx m sig -> ctx () -> sig (ctx a))
     (a -> m k)
-
-instance Functor m => Functor (Lift sig m) where
-  fmap f (LiftWith with k) = LiftWith with (fmap f . k)

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,4 +1,4 @@
-{- | An effect access to an immutable (but locally-modifiable) context value.
+{- | An effect providing access to an immutable (but locally-modifiable) context value.
 
 This effect is similar to the traditional @MonadReader@ typeclass, though it allows the presence of multiple @Reader t@ effects.
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,4 +1,4 @@
-{- | An effect providing access to an immutable (but locally-modifiable) context value.
+{- | An effect access to an immutable (but locally-modifiable) context value.
 
 This effect is similar to the traditional @MonadReader@ typeclass, though it allows the presence of multiple @Reader t@ effects.
 
@@ -36,7 +36,7 @@ import Control.Effect.Reader.Internal (Reader(..))
 --
 -- @since 0.1.0.0
 ask :: Has (Reader r) sig m => m r
-ask = send (Ask pure)
+ask = send Ask
 {-# INLINE ask #-}
 
 -- | Project a function out of the current environment value.
@@ -47,7 +47,7 @@ ask = send (Ask pure)
 --
 -- @since 0.1.0.0
 asks :: Has (Reader r) sig m => (r -> a) -> m a
-asks f = send (Ask (pure . f))
+asks = (`fmap` ask)
 {-# INLINE asks #-}
 
 -- | Run a computation with an environment value locally modified by the passed function.
@@ -58,5 +58,5 @@ asks f = send (Ask (pure . f))
 --
 -- @since 0.1.0.0
 local :: Has (Reader r) sig m => (r -> r) -> m a -> m a
-local f m = send (Local f m pure)
+local f m = send (Local f m)
 {-# INLINE local #-}

--- a/src/Control/Effect/Reader/Internal.hs
+++ b/src/Control/Effect/Reader/Internal.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 module Control.Effect.Reader.Internal
 ( Reader(..)
 ) where
 
 -- | @since 0.1.0.0
-data Reader r m k
-  = Ask (r -> m k)
-  | forall b . Local (r -> r) (m b) (b -> m k)
+data Reader r m k where
+  Ask   ::                    Reader r m r
+  Local :: (r -> r) -> m a -> Reader r m a

--- a/src/Control/Effect/Reader/Internal.hs
+++ b/src/Control/Effect/Reader/Internal.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE StandaloneDeriving #-}
 module Control.Effect.Reader.Internal
 ( Reader(..)
 ) where
@@ -9,5 +7,3 @@ module Control.Effect.Reader.Internal
 data Reader r m k
   = Ask (r -> m k)
   | forall b . Local (r -> r) (m b) (b -> m k)
-
-deriving instance Functor m => Functor (Reader r m)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -40,7 +40,7 @@ import Control.Effect.State.Internal (State(..))
 --
 -- @since 0.1.0.0
 get :: Has (State s) sig m => m s
-get = send (Get pure)
+get = send Get
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
@@ -51,7 +51,7 @@ get = send (Get pure)
 --
 -- @since 0.1.0.0
 gets :: Has (State s) sig m => (s -> a) -> m a
-gets f = send (Get (pure . f))
+gets = (`fmap` get)
 {-# INLINEABLE gets #-}
 
 -- | Replace the state value with a new value.
@@ -62,7 +62,7 @@ gets f = send (Get (pure . f))
 --
 -- @since 0.1.0.0
 put :: Has (State s) sig m => s -> m ()
-put s = send (Put s (pure ()))
+put s = send (Put s)
 {-# INLINEABLE put #-}
 
 -- | Replace the state value with the result of applying a function to the current state value.

--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 module Control.Effect.State.Internal
 ( State(..)
 ) where
 
+import Data.Kind (Type)
+
 -- | @since 0.1.0.0
-data State s m k
-  = Get (s -> m k)
-  | Put s (m k)
+data State s (m :: Type -> Type) k where
+  Get ::      State s m s
+  Put :: s -> State s m ()

--- a/src/Control/Effect/State/Internal.hs
+++ b/src/Control/Effect/State/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 module Control.Effect.State.Internal
 ( State(..)
 ) where
@@ -7,4 +6,3 @@ module Control.Effect.State.Internal
 data State s m k
   = Get (s -> m k)
   | Put s (m k)
-  deriving (Functor)

--- a/src/Control/Effect/Throw/Internal.hs
+++ b/src/Control/Effect/Throw/Internal.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE KindSignatures #-}
 module Control.Effect.Throw.Internal
 ( Throw(..)
 ) where
 
+import Data.Kind (Type)
+
 -- | @since 1.0.0.0
-newtype Throw e (m :: * -> *) k = Throw e
+newtype Throw e (m :: Type -> Type) k where
+  Throw :: e -> Throw e m a

--- a/src/Control/Effect/Throw/Internal.hs
+++ b/src/Control/Effect/Throw/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE KindSignatures #-}
 module Control.Effect.Throw.Internal
 ( Throw(..)
@@ -6,4 +5,3 @@ module Control.Effect.Throw.Internal
 
 -- | @since 1.0.0.0
 newtype Throw e (m :: * -> *) k = Throw e
-  deriving (Functor)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {- | An effect that provides a record of 'String' values ("traces") aggregate during the execution of a given computation.
 
 Predefined carriers:
@@ -20,15 +22,14 @@ module Control.Effect.Trace
 ) where
 
 import Control.Algebra
+import Data.Kind (Type)
 
 -- | @since 0.1.0.0
-data Trace m k = Trace
-  { traceMessage :: String
-  , traceCont    :: m k
-  }
+data Trace (m :: Type -> Type) k where
+  Trace :: { traceMessage :: String } -> Trace m ()
 
 -- | Append a message to the trace log.
 --
 -- @since 0.1.0.0
 trace :: Has Trace sig m => String -> m ()
-trace message = send (Trace message (pure ()))
+trace message = send (Trace message)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
-
 {- | An effect that provides a record of 'String' values ("traces") aggregate during the execution of a given computation.
 
 Predefined carriers:
@@ -28,7 +26,6 @@ data Trace m k = Trace
   { traceMessage :: String
   , traceCont    :: m k
   }
-  deriving (Functor)
 
 -- | Append a message to the trace log.
 --

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -30,6 +30,7 @@ module Control.Effect.Writer
 
 import Control.Algebra
 import Control.Effect.Writer.Internal (Writer(..))
+import Data.Bifunctor (first)
 
 -- | Write a value to the log.
 --
@@ -39,7 +40,7 @@ import Control.Effect.Writer.Internal (Writer(..))
 --
 -- @since 0.1.0.0
 tell :: Has (Writer w) sig m => w -> m ()
-tell w = send (Tell w (pure ()))
+tell w = send (Tell w)
 {-# INLINE tell #-}
 
 -- | Run a computation, returning the pair of its output and its result.
@@ -50,18 +51,18 @@ tell w = send (Tell w (pure ()))
 --
 -- @since 0.2.0.0
 listen :: Has (Writer w) sig m => m a -> m (w, a)
-listen m = send (Listen m (curry pure))
+listen m = send (Listen m)
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
 -- @
--- 'listens' f m = 'fmap' ('Data.Bifunctor.first' f) ('listen' m)
+-- 'listens' f m = 'fmap' ('first' f) ('listen' m)
 -- @
 --
 -- @since 0.2.0.0
 listens :: Has (Writer w) sig m => (w -> b) -> m a -> m (b, a)
-listens f m = send (Listen m (curry pure . f))
+listens f = fmap (first f) . listen
 {-# INLINE listens #-}
 
 -- | Run a computation, modifying its output with the passed function.
@@ -72,5 +73,5 @@ listens f m = send (Listen m (curry pure . f))
 --
 -- @since 0.2.0.0
 censor :: Has (Writer w) sig m => (w -> w) -> m a -> m a
-censor f m = send (Censor f m pure)
+censor f m = send (Censor f m)
 {-# INLINE censor #-}

--- a/src/Control/Effect/Writer/Internal.hs
+++ b/src/Control/Effect/Writer/Internal.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE StandaloneDeriving #-}
 module Control.Effect.Writer.Internal
 ( Writer(..)
 ) where
@@ -10,5 +8,3 @@ data Writer w m k
   = Tell w (m k)
   | forall a . Listen (m a) (w -> a -> m k)
   | forall a . Censor (w -> w) (m a) (a -> m k)
-
-deriving instance Functor m => Functor (Writer w m)

--- a/src/Control/Effect/Writer/Internal.hs
+++ b/src/Control/Effect/Writer/Internal.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 module Control.Effect.Writer.Internal
 ( Writer(..)
 ) where
 
 -- | @since 0.1.0.0
-data Writer w m k
-  = Tell w (m k)
-  | forall a . Listen (m a) (w -> a -> m k)
-  | forall a . Censor (w -> w) (m a) (a -> m k)
+data Writer w m k where
+  Tell   :: w               -> Writer w m ()
+  Listen :: m a             -> Writer w m (w, a)
+  Censor :: (w -> w) -> m a -> Writer w m a


### PR DESCRIPTION
This PR redefines all the effects as GADTs, simplifying and tidying the smart constructors and algebras considerably.

- [x] Depends on #361.
- [x] Update the changelog.