### PR TITLE
Benchmark reorganization

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -2,13 +2,12 @@ module Main
 ( main
 ) where
 
-import           Gauge
-
 import qualified Bench.Error as Error
 import qualified Bench.Interpret as Interpret
 import qualified Bench.NonDet as NonDet
 import qualified Bench.Reader as Reader
 import qualified Bench.Writer as Writer
+import           Gauge
 
 main :: IO ()
 main = defaultMain

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,18 +1,14 @@
-{-# LANGUAGE TypeApplications #-}
 module Main
 ( main
 ) where
 
-import           Control.Algebra
-import           Control.Carrier.Writer.Strict
-import           Control.Monad (replicateM_)
-import           Data.Monoid (Sum(..))
 import           Gauge
 
 import qualified Bench.Error as Error
 import qualified Bench.Interpret as Interpret
 import qualified Bench.NonDet as NonDet
 import qualified Bench.Reader as Reader
+import qualified Bench.Writer as Writer
 
 main :: IO ()
 main = defaultMain
@@ -20,13 +16,5 @@ main = defaultMain
   , Interpret.benchmark
   , NonDet.benchmark
   , Reader.benchmark
-
-  , bgroup "WriterC"
-    [ bench "100"   $ whnf (run . execWriter @(Sum Int) . tellLoop) 100
-    , bench "1000"  $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
-    , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
-    ]
+  , Writer.benchmark
   ]
-
-tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
-tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,32 +1,23 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-{-# HLINT ignore "Avoid lambda" #-}
 module Main
 ( main
 ) where
 
 import           Control.Algebra
-import           Control.Carrier.Interpret
-import           Control.Carrier.State.Strict
 import           Control.Carrier.Writer.Strict
 import           Control.Monad (replicateM_)
 import           Data.Monoid (Sum(..))
 import           Gauge
 
 import qualified Bench.Error as Error
+import qualified Bench.Interpret as Interpret
 import qualified Bench.NonDet as NonDet
 import qualified Bench.Reader as Reader
 
 main :: IO ()
 main = defaultMain
   [ Error.benchmark
+  , Interpret.benchmark
   , NonDet.benchmark
   , Reader.benchmark
 
@@ -35,28 +26,7 @@ main = defaultMain
     , bench "1000"  $ whnf (run . execWriter @(Sum Int) . tellLoop) 1000
     , bench "10000" $ whnf (run . execWriter @(Sum Int) . tellLoop) 10000
     ]
-
-  , bgroup "InterpretC vs InterpretStateC vs StateC"
-    [ bgroup "InterpretC"
-      [ bench "100"   $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 100
-      , bench "1000"  $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 1000
-      , bench "10000" $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) 10000
-      ]
-    , bgroup "InterpretStateC"
-      [ bench "100"   $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 100
-      , bench "1000"  $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 1000
-      , bench "10000" $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) 10000
-      ]
-    , bgroup "StateC"
-      [ bench "100"   $ whnf (run . execState @Int 0 . modLoop) 100
-      , bench "1000"  $ whnf (run . execState @Int 0 . modLoop) 1000
-      , bench "10000" $ whnf (run . execState @Int 0 . modLoop) 10000
-      ]
-    ]
   ]
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
-
-modLoop :: Has (State Int) sig m => Int -> m ()
-modLoop i = replicateM_ i (modify (+ (1 :: Int)))

--- a/benchmark/Bench/Error.hs
+++ b/benchmark/Bench/Error.hs
@@ -18,9 +18,9 @@ benchmark = bgroup "Error"
     , bench "ExceptT"       $ whnf (run . Except.runExceptT @Int . errorLoop) n
     ]
   , bgroup "IO"
-    [ bench "Church.ErrorC IO" $ whnfAppIO (Church.runError @Int (pure . Left) (pure . Right) . errorLoop) n
-    , bench "Either.ErrorC IO" $ whnfAppIO (Either.runError @Int . errorLoop) n
-    , bench "ExceptT IO"       $ whnfAppIO (Except.runExceptT @Int . errorLoop) n
+    [ bench "Church.ErrorC" $ whnfAppIO (Church.runError @Int (pure . Left) (pure . Right) . errorLoop) n
+    , bench "Either.ErrorC" $ whnfAppIO (Either.runError @Int . errorLoop) n
+    , bench "ExceptT"       $ whnfAppIO (Except.runExceptT @Int . errorLoop) n
     ]
   ]
   where

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -9,7 +9,7 @@ module Bench.Interpret
 
 import Control.Carrier.Interpret
 import Control.Carrier.State.Strict
-import Control.Monad (replicateM_)
+import Data.Foldable (for_)
 import Gauge hiding (benchmark)
 
 benchmark :: Gauge.Benchmark
@@ -43,5 +43,5 @@ benchmark = bgroup "Interpret"
   n = 100000
 
 modLoop :: Has (State Int) sig m => Int -> m ()
-modLoop i = replicateM_ i (modify (+ (1 :: Int)))
+modLoop i = for_ [1..i] (modify . (+))
 {-# INLINE modLoop #-}

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -1,2 +1,25 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Avoid lambda" #-}
 module Bench.Interpret
-() where
+( benchmark
+) where
+
+import Control.Carrier.Interpret
+import Control.Carrier.State.Strict
+import Control.Monad (replicateM_)
+import Gauge hiding (benchmark)
+
+benchmark :: Gauge.Benchmark
+benchmark = bgroup "Interpret"
+  [ bench "InterpretC" $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) n
+  , bench "InterpretStateC" $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) n
+  , bench "StateC" $ whnf (run . execState @Int 0 . modLoop) n
+  ]
+  where
+  n = 100000
+
+modLoop :: Has (State Int) sig m => Int -> m ()
+modLoop i = replicateM_ i (modify (+ (1 :: Int)))

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -14,16 +14,18 @@ import Gauge hiding (benchmark)
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Interpret"
-  [ bench "InterpretC" $
-    whnf (\ n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of
-      Get   -> gets @Int (<$ ctx)
-      Put s -> ctx <$ put s) $ modLoop n) n
-  , bench "InterpretStateC" $
-    whnf (\ n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of
-      Get   -> pure (s, s <$ ctx)
-      Put s -> pure (s, ctx)) 0 $ modLoop n) n
-  , bench "StateC" $
-    whnf (run . execState @Int 0 . modLoop) n
+  [ bgroup "Identity"
+    [ bench "InterpretC" $
+      whnf (\ n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of
+        Get   -> gets @Int (<$ ctx)
+        Put s -> ctx <$ put s) $ modLoop n) n
+    , bench "InterpretStateC" $
+      whnf (\ n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of
+        Get   -> pure (s, s <$ ctx)
+        Put s -> pure (s, ctx)) 0 $ modLoop n) n
+    , bench "StateC" $
+      whnf (run . execState @Int 0 . modLoop) n
+    ]
   ]
   where
   n = 100000

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -44,3 +44,4 @@ benchmark = bgroup "Interpret"
 
 modLoop :: Has (State Int) sig m => Int -> m ()
 modLoop i = replicateM_ i (modify (+ (1 :: Int)))
+{-# INLINE modLoop #-}

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -15,9 +15,13 @@ import Gauge hiding (benchmark)
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Interpret"
   [ bench "InterpretC" $
-    whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) n
+    whnf (\ n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of
+      Get   -> gets @Int (<$ ctx)
+      Put s -> ctx <$ put s) $ modLoop n) n
   , bench "InterpretStateC" $
-    whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) n
+    whnf (\ n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of
+      Get   -> pure (s, s <$ ctx)
+      Put s -> pure (s, ctx)) 0 $ modLoop n) n
   , bench "StateC" $
     whnf (run . execState @Int 0 . modLoop) n
   ]

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -14,9 +14,12 @@ import Gauge hiding (benchmark)
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Interpret"
-  [ bench "InterpretC" $ whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) n
-  , bench "InterpretStateC" $ whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) n
-  , bench "StateC" $ whnf (run . execState @Int 0 . modLoop) n
+  [ bench "InterpretC" $
+    whnf (\n -> run $ execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of { Get -> gets @Int (<$ ctx) ; Put s -> ctx <$ put s }) $ modLoop n) n
+  , bench "InterpretStateC" $
+    whnf (\n -> fst . run $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of { Get -> pure (s, s <$ ctx) ; Put s -> pure (s, ctx) }) 0 $ modLoop n) n
+  , bench "StateC" $
+    whnf (run . execState @Int 0 . modLoop) n
   ]
   where
   n = 100000

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -1,0 +1,2 @@
+module Bench.Interpret
+() where

--- a/benchmark/Bench/Interpret.hs
+++ b/benchmark/Bench/Interpret.hs
@@ -26,6 +26,18 @@ benchmark = bgroup "Interpret"
     , bench "StateC" $
       whnf (run . execState @Int 0 . modLoop) n
     ]
+  , bgroup "IO"
+    [ bench "InterpretC" $
+      whnfAppIO (\ n -> execState @Int 0 $ runInterpret (\ _ (sig :: State Int m k) ctx -> case sig of
+        Get   -> gets @Int (<$ ctx)
+        Put s -> ctx <$ put s) $ modLoop n) n
+    , bench "InterpretStateC" $
+      whnfAppIO (\ n -> fmap fst $ runInterpretState (\ _ (sig :: State Int m k) (s :: Int) ctx -> case sig of
+        Get   -> pure (s, s <$ ctx)
+        Put s -> pure (s, ctx)) 0 $ modLoop n) n
+    , bench "StateC" $
+      whnfAppIO (execState @Int 0 . modLoop) n
+    ]
   ]
   where
   n = 100000

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -17,7 +17,8 @@ import Gauge hiding (benchmark)
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Writer"
-  [ bgroup "Identity"
+  [ bench "(,) w" $ whnf (fst . (tellLoop :: Int -> (Sum Int, ()))) n
+  , bgroup "Identity"
     [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
   #if MIN_VERSION_transformers(0,5,6)
     , bench "CPS.WriterT" $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -20,9 +20,9 @@ benchmark = bgroup "Writer"
   [ bench "(,) w" $ whnf (fst . (tellLoop :: Int -> (Sum Int, ()))) n
   , bgroup "Identity"
     [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
-  #if MIN_VERSION_transformers(0,5,6)
+#if MIN_VERSION_transformers(0,5,6)
     , bench "CPS.WriterT" $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
-  #endif
+#endif
     , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
     , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
     ]

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 module Bench.Writer
 ( benchmark
@@ -24,7 +25,7 @@ benchmark = bgroup "Writer"
   , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
   ]
   where
-  n = 100000
+  n = 100_000
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -25,7 +25,7 @@ benchmark = bgroup "Writer"
   , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
   ]
   where
-  n = 100_000
+  n = 1_000_000
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -17,12 +17,14 @@ import Gauge hiding (benchmark)
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Writer"
-  [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
-#if MIN_VERSION_transformers(0,5,6)
-  , bench "CPS.WriterT" $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
-#endif
-  , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
-  , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
+  [ bgroup "Identity"
+    [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
+  #if MIN_VERSION_transformers(0,5,6)
+    , bench "CPS.WriterT" $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
+  #endif
+    , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
+    , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
+    ]
   ]
   where
   n = 1_000_000

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -21,17 +21,17 @@ benchmark = bgroup "Writer"
   , bgroup "Identity"
     [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
 #if MIN_VERSION_transformers(0,5,6)
-    , bench "CPS.WriterT" $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
+    , bench "CPS.WriterT"    $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
 #endif
-    , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
+    , bench "Lazy.WriterT"   $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
     , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
     ]
   , bgroup "IO"
     [ bench "Strict.WriterC" $ whnfAppIO (C.Strict.execWriter @(Sum Int) . tellLoop) n
 #if MIN_VERSION_transformers(0,5,6)
-    , bench "CPS.WriterT" $ whnfAppIO (T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
+    , bench "CPS.WriterT"    $ whnfAppIO (T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
 #endif
-    , bench "Lazy.WriterT" $ whnfAppIO (T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
+    , bench "Lazy.WriterT"   $ whnfAppIO (T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
     , bench "Strict.WriterT" $ whnfAppIO (T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
     ]
   ]

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -4,7 +4,7 @@ module Bench.Writer
 ) where
 
 import Control.Carrier.Writer.Strict as C.Strict
-import Control.Monad (replicateM_)
+import Data.Foldable (for_)
 import Data.Monoid (Sum(..))
 import Gauge hiding (benchmark)
 
@@ -16,4 +16,4 @@ benchmark = bgroup "Writer"
   n = 100000
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
-tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
+tellLoop i = for_ [1..i] (tell . Sum)

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -17,3 +17,4 @@ benchmark = bgroup "Writer"
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
 tellLoop i = for_ [1..i] (tell . Sum)
+{-# INLINE tellLoop #-}

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -1,0 +1,2 @@
+module Bench.Writer
+() where

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 module Bench.Writer
 ( benchmark
@@ -36,7 +35,7 @@ benchmark = bgroup "Writer"
     ]
   ]
   where
-  n = 1_000_000
+  n = 1000000
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -4,13 +4,17 @@ module Bench.Writer
 ) where
 
 import Control.Carrier.Writer.Strict as C.Strict
+import Control.Monad.Trans.Writer.Lazy as T.Lazy (execWriterT)
+import Control.Monad.Trans.Writer.Strict as T.Strict (execWriterT)
 import Data.Foldable (for_)
 import Data.Monoid (Sum(..))
 import Gauge hiding (benchmark)
 
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Writer"
-  [ bench "Strict.WriterC" $ whnf (run . execWriter @(Sum Int) . tellLoop) n
+  [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
+  , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
+  , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
   ]
   where
   n = 100000

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -5,12 +5,12 @@ module Bench.Writer
 ) where
 
 import Control.Carrier.Writer.Strict as C.Strict
+import Control.Monad (replicateM_)
 #if MIN_VERSION_transformers(0,5,6)
 import Control.Monad.Trans.Writer.CPS as T.CPS (execWriterT)
 #endif
 import Control.Monad.Trans.Writer.Lazy as T.Lazy (execWriterT)
 import Control.Monad.Trans.Writer.Strict as T.Strict (execWriterT)
-import Data.Foldable (for_)
 import Data.Monoid (Sum(..))
 import Gauge hiding (benchmark)
 
@@ -27,5 +27,5 @@ benchmark = bgroup "Writer"
   n = 100000
 
 tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
-tellLoop i = for_ [1..i] (tell . Sum)
+tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
 {-# INLINE tellLoop #-}

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -26,6 +26,14 @@ benchmark = bgroup "Writer"
     , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
     , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
     ]
+  , bgroup "IO"
+    [ bench "Strict.WriterC" $ whnfAppIO (C.Strict.execWriter @(Sum Int) . tellLoop) n
+#if MIN_VERSION_transformers(0,5,6)
+    , bench "CPS.WriterT" $ whnfAppIO (T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
+#endif
+    , bench "Lazy.WriterT" $ whnfAppIO (T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
+    , bench "Strict.WriterT" $ whnfAppIO (T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
+    ]
   ]
   where
   n = 1_000_000

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -1,2 +1,19 @@
+{-# LANGUAGE TypeApplications #-}
 module Bench.Writer
-() where
+( benchmark
+) where
+
+import Control.Carrier.Writer.Strict as C.Strict
+import Control.Monad (replicateM_)
+import Data.Monoid (Sum(..))
+import Gauge hiding (benchmark)
+
+benchmark :: Gauge.Benchmark
+benchmark = bgroup "Writer"
+  [ bench "Strict.WriterC" $ whnf (run . execWriter @(Sum Int) . tellLoop) n
+  ]
+  where
+  n = 100000
+
+tellLoop :: Has (Writer (Sum Int)) sig m => Int -> m ()
+tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeApplications #-}
 module Bench.Writer
 ( benchmark
 ) where
 
 import Control.Carrier.Writer.Strict as C.Strict
+#if MIN_VERSION_transformers(0,5,6)
+import Control.Monad.Trans.Writer.CPS as T.CPS (execWriterT)
+#endif
 import Control.Monad.Trans.Writer.Lazy as T.Lazy (execWriterT)
 import Control.Monad.Trans.Writer.Strict as T.Strict (execWriterT)
 import Data.Foldable (for_)
@@ -13,6 +17,9 @@ import Gauge hiding (benchmark)
 benchmark :: Gauge.Benchmark
 benchmark = bgroup "Writer"
   [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
+#if MIN_VERSION_transformers(0,5,6)
+  , bench "CPS.WriterT" $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
+#endif
   , bench "Lazy.WriterT" $ whnf (run . T.Lazy.execWriterT @_ @(Sum Int) . tellLoop) n
   , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
   ]

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -185,6 +185,7 @@ benchmark benchmark
   main-is:        Bench.hs
   other-modules:
     Bench.Error
+    Bench.Interpret
     Bench.Reader
     Bench.NonDet
     Bench.NonDet.NQueens

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -186,9 +186,9 @@ benchmark benchmark
   other-modules:
     Bench.Error
     Bench.Interpret
-    Bench.Reader
     Bench.NonDet
     Bench.NonDet.NQueens
+    Bench.Reader
     Bench.Writer
   build-depends:
     , base

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -189,6 +189,7 @@ benchmark benchmark
     Bench.Reader
     Bench.NonDet
     Bench.NonDet.NQueens
+    Bench.Writer
   build-depends:
     , base
     , fused-effects


### PR DESCRIPTION
This PR moves the benchmarks around a little and simplifies them to not benchmark 100/1000/10000 iterations separately, but just run a large number of iterations once.