### PR TITLE
Church-encoded Writer carrier

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,8 @@
 
 - Redefines all effects as GADTs. Since we no longer require `Functor`, `HFunctor`, or `Effect` instances, we no longer need to use continuations to allow distinct result types per constructor. `Algebra` instances for these effects can be ported forwards by removing the continuations. User-defined effects are not impacted, but we recommend migrating to GADT definitions of them for convenience and ease of comprehension going forwards. ([#365](https://github.com/fused-effects/fused-effects/pull/365))
 
+- Removes `Control.Carrier.State.Lazy.runStateC`, which was supposed to have been removed in 1.0.
+
 
 # v1.0.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 - Adds a church-encoded `Empty` carrier in `Control.Carrier.Empty.Church`. ([#203](https://github.com/fused-effects/fused-effects/pull/203))
 
+- Adds a church-encoded `Writer` carrier in `Control.Carrier.Writer.Church`. ([#369](https://github.com/fused-effects/fused-effects/pull/369))
+
 - Defines `Algebra` instances for `Control.Monad.Trans.Maybe.MaybeT`, `Control.Monad.Trans.RWS.CPS`, and `Control.Monad.Trans.Writer.CPS`. ([#366](https://github.com/fused-effects/fused-effects/pull/366))
 
 

--- a/benchmark/Bench/Writer.hs
+++ b/benchmark/Bench/Writer.hs
@@ -5,6 +5,7 @@ module Bench.Writer
 ( benchmark
 ) where
 
+import Control.Carrier.Writer.Church as C.Church
 import Control.Carrier.Writer.Strict as C.Strict
 import Control.Monad (replicateM_)
 #if MIN_VERSION_transformers(0,5,6)
@@ -19,7 +20,8 @@ benchmark :: Gauge.Benchmark
 benchmark = bgroup "Writer"
   [ bench "(,) w" $ whnf (fst . (tellLoop :: Int -> (Sum Int, ()))) n
   , bgroup "Identity"
-    [ bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
+    [ bench "Church.WriterC" $ whnf (run . C.Church.execWriter @(Sum Int) . tellLoop) n
+    , bench "Strict.WriterC" $ whnf (run . C.Strict.execWriter @(Sum Int) . tellLoop) n
 #if MIN_VERSION_transformers(0,5,6)
     , bench "CPS.WriterT"    $ whnf (run . T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
 #endif
@@ -27,7 +29,8 @@ benchmark = bgroup "Writer"
     , bench "Strict.WriterT" $ whnf (run . T.Strict.execWriterT @_ @(Sum Int) . tellLoop) n
     ]
   , bgroup "IO"
-    [ bench "Strict.WriterC" $ whnfAppIO (C.Strict.execWriter @(Sum Int) . tellLoop) n
+    [ bench "Church.WriterC" $ whnfAppIO (C.Church.execWriter @(Sum Int) . tellLoop) n
+    , bench "Strict.WriterC" $ whnfAppIO (C.Strict.execWriter @(Sum Int) . tellLoop) n
 #if MIN_VERSION_transformers(0,5,6)
     , bench "CPS.WriterT"    $ whnfAppIO (T.CPS.execWriterT @_ @(Sum Int) . tellLoop) n
 #endif

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -67,6 +67,7 @@ library
     Control.Carrier.Trace.Ignoring
     Control.Carrier.Trace.Printing
     Control.Carrier.Trace.Returning
+    Control.Carrier.Writer.Church
     Control.Carrier.Writer.Strict
     -- Effects
     Control.Effect.Catch

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -99,9 +99,9 @@ instance Monad m => Applicative (StateC s m) where
   {-# INLINE (<*) #-}
 
 instance Monad m => Monad (StateC s m) where
-  m >>= k = StateC $ \ s -> do
-    ~(s', a) <- runState s m
-    runState s' (k a)
+  StateC a >>= k = StateC $ \ s -> do
+    ~(s', a') <- a s
+    runState s' (k a')
   {-# INLINE (>>=) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -23,7 +23,7 @@ module Control.Carrier.State.Lazy
 ) where
 
 import Control.Algebra
-import Control.Applicative (Alternative(..), liftA2)
+import Control.Applicative (Alternative(..))
 import Control.Effect.State
 import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
@@ -86,12 +86,6 @@ instance Monad m => Applicative (StateC s m) where
     ~(s'', a') <- a s'
     pure (s'', f' a')
   {-# INLINE (<*>) #-}
-
-  liftA2 f (StateC a) (StateC b) = StateC $ \ s -> do
-    ~(s', a') <- a s
-    ~(s'', b') <- b s'
-    pure (s'', f a' b')
-  {-# INLINE liftA2 #-}
 
   StateC a *> StateC b = StateC $ \ s -> do
     ~(s', _) <- a s

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -87,7 +87,9 @@ instance Monad m => Applicative (StateC s m) where
     pure (s'', f x)
   {-# INLINE (<*>) #-}
 
-  m *> k = m >>= const k
+  StateC a *> StateC b = StateC $ \ s -> do
+    ~(s', _) <- a s
+    b s'
   {-# INLINE (*>) #-}
 
   StateC a <* StateC b = StateC $ \ s -> do

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -81,10 +81,10 @@ instance Monad m => Applicative (StateC s m) where
   pure a = StateC $ \ s -> pure (s, a)
   {-# INLINE pure #-}
 
-  StateC f <*> StateC a = StateC $ \ s -> do
-    ~(s',  f') <- f s
-    ~(s'', a') <- a s'
-    pure (s'', f' a')
+  StateC mf <*> StateC mx = StateC $ \ s -> do
+    ~(s',  f) <- mf s
+    ~(s'', x) <- mx s'
+    pure (s'', f x)
   {-# INLINE (<*>) #-}
 
   StateC a *> StateC b = StateC $ \ s -> do

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -23,7 +23,7 @@ module Control.Carrier.State.Lazy
 ) where
 
 import Control.Algebra
-import Control.Applicative (Alternative(..))
+import Control.Applicative (Alternative(..), liftA2)
 import Control.Effect.State
 import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
@@ -86,6 +86,12 @@ instance Monad m => Applicative (StateC s m) where
     ~(s'', a') <- a s'
     pure (s'', f' a')
   {-# INLINE (<*>) #-}
+
+  liftA2 f (StateC a) (StateC b) = StateC $ \ s -> do
+    ~(s', a') <- a s
+    ~(s'', b') <- b s'
+    pure (s'', f a' b')
+  {-# INLINE liftA2 #-}
 
   StateC a *> StateC b = StateC $ \ s -> do
     ~(s', _) <- a s

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -87,9 +87,7 @@ instance Monad m => Applicative (StateC s m) where
     pure (s'', f x)
   {-# INLINE (<*>) #-}
 
-  StateC a *> StateC b = StateC $ \ s -> do
-    ~(s', _) <- a s
-    b s'
+  m *> k = m >>= const k
   {-# INLINE (*>) #-}
 
   StateC a <* StateC b = StateC $ \ s -> do

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -104,9 +104,6 @@ instance Monad m => Monad (StateC s m) where
     runState s' (k a')
   {-# INLINE (>>=) #-}
 
-  (>>) = (*>)
-  {-# INLINE (>>) #-}
-
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
   empty = lift empty
   {-# INLINE empty #-}

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -99,9 +99,9 @@ instance Monad m => Applicative (StateC s m) where
   {-# INLINE (<*) #-}
 
 instance Monad m => Monad (StateC s m) where
-  StateC a >>= k = StateC $ \ s -> do
-    ~(s', a') <- a s
-    runState s' (k a')
+  m >>= k = StateC $ \ s -> do
+    ~(s', a) <- runState s m
+    runState s' (k a)
   {-# INLINE (>>=) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -97,14 +97,14 @@ instance Monad m => Monad (StateC s m) where
   {-# INLINE (>>=) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
-  empty = StateC (const empty)
+  empty = lift empty
   {-# INLINE empty #-}
 
   StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
   {-# INLINE (<|>) #-}
 
 instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
-  fail s = StateC (const (Fail.fail s))
+  fail = lift . Fail.fail
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (StateC s m) where
@@ -112,7 +112,7 @@ instance MonadFix m => MonadFix (StateC s m) where
   {-# INLINE mfix #-}
 
 instance MonadIO m => MonadIO (StateC s m) where
-  liftIO io = StateC (\ s -> (,) s <$> liftIO io)
+  liftIO = lift . liftIO
   {-# INLINE liftIO #-}
 
 instance (Alternative m, Monad m) => MonadPlus (StateC s m)

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -90,6 +90,12 @@ instance Monad m => Applicative (StateC s m) where
   m *> k = m >>= const k
   {-# INLINE (*>) #-}
 
+  StateC a <* StateC b = StateC $ \ s -> do
+    ~(s', a') <- a s
+    ~(s'', _) <- b s'
+    pure (s'', a')
+  {-# INLINE (<*) #-}
+
 instance Monad m => Monad (StateC s m) where
   m >>= k = StateC $ \ s -> do
     ~(s', a) <- runState s m

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -81,10 +81,10 @@ instance Monad m => Applicative (StateC s m) where
   pure a = StateC $ \ s -> pure (s, a)
   {-# INLINE pure #-}
 
-  StateC mf <*> StateC mx = StateC $ \ s -> do
-    ~(s',  f) <- mf s
-    ~(s'', x) <- mx s'
-    pure (s'', f x)
+  StateC f <*> StateC a = StateC $ \ s -> do
+    ~(s',  f') <- f s
+    ~(s'', a') <- a s'
+    pure (s'', f' a')
   {-# INLINE (<*>) #-}
 
   StateC a *> StateC b = StateC $ \ s -> do

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -71,7 +71,7 @@ execState s = fmap fst . runState s
 {-# INLINE[3] execState #-}
 
 -- | @since 1.0.0.0
-newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
+newtype StateC s m a = StateC (s -> m (s, a))
 
 instance Functor m => Functor (StateC s m) where
   fmap f m = StateC $ \ s -> (\ ~(s', a) -> (s', f a)) <$> runState s m

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -97,14 +97,14 @@ instance Monad m => Monad (StateC s m) where
   {-# INLINE (>>=) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
-  empty = lift empty
+  empty = StateC (const empty)
   {-# INLINE empty #-}
 
   StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
   {-# INLINE (<|>) #-}
 
 instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
-  fail = lift . Fail.fail
+  fail s = StateC (const (Fail.fail s))
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (StateC s m) where
@@ -112,7 +112,7 @@ instance MonadFix m => MonadFix (StateC s m) where
   {-# INLINE mfix #-}
 
 instance MonadIO m => MonadIO (StateC s m) where
-  liftIO = lift . liftIO
+  liftIO io = StateC (\ s -> (,) s <$> liftIO io)
   {-# INLINE liftIO #-}
 
 instance (Alternative m, Monad m) => MonadPlus (StateC s m)

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -90,12 +90,6 @@ instance Monad m => Applicative (StateC s m) where
   m *> k = m >>= const k
   {-# INLINE (*>) #-}
 
-  StateC a <* StateC b = StateC $ \ s -> do
-    ~(s', a') <- a s
-    ~(s'', _) <- b s'
-    pure (s'', a')
-  {-# INLINE (<*) #-}
-
 instance Monad m => Monad (StateC s m) where
   m >>= k = StateC $ \ s -> do
     ~(s', a) <- runState s m

--- a/src/Control/Carrier/State/Lazy.hs
+++ b/src/Control/Carrier/State/Lazy.hs
@@ -104,6 +104,9 @@ instance Monad m => Monad (StateC s m) where
     runState s' (k a')
   {-# INLINE (>>=) #-}
 
+  (>>) = (*>)
+  {-# INLINE (>>) #-}
+
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
   empty = lift empty
   {-# INLINE empty #-}

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -89,7 +89,7 @@ instance Monad m => Applicative (StateC s m) where
   {-# INLINE (*>) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
-  empty = lift empty
+  empty = StateC (const empty)
   {-# INLINE empty #-}
 
   StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
@@ -102,7 +102,7 @@ instance Monad m => Monad (StateC s m) where
   {-# INLINE (>>=) #-}
 
 instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
-  fail = lift . Fail.fail
+  fail s = StateC (const (Fail.fail s))
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (StateC s m) where
@@ -110,7 +110,7 @@ instance MonadFix m => MonadFix (StateC s m) where
   {-# INLINE mfix #-}
 
 instance MonadIO m => MonadIO (StateC s m) where
-  liftIO = lift . liftIO
+  liftIO io = StateC (\ s -> (,) s <$> liftIO io)
   {-# INLINE liftIO #-}
 
 instance (Alternative m, Monad m) => MonadPlus (StateC s m)

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -89,7 +89,7 @@ instance Monad m => Applicative (StateC s m) where
   {-# INLINE (*>) #-}
 
 instance (Alternative m, Monad m) => Alternative (StateC s m) where
-  empty = StateC (const empty)
+  empty = lift empty
   {-# INLINE empty #-}
 
   StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
@@ -102,7 +102,7 @@ instance Monad m => Monad (StateC s m) where
   {-# INLINE (>>=) #-}
 
 instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
-  fail s = StateC (const (Fail.fail s))
+  fail = lift . Fail.fail
   {-# INLINE fail #-}
 
 instance MonadFix m => MonadFix (StateC s m) where
@@ -110,7 +110,7 @@ instance MonadFix m => MonadFix (StateC s m) where
   {-# INLINE mfix #-}
 
 instance MonadIO m => MonadIO (StateC s m) where
-  liftIO io = StateC (\ s -> (,) s <$> liftIO io)
+  liftIO = lift . liftIO
   {-# INLINE liftIO #-}
 
 instance (Alternative m, Monad m) => MonadPlus (StateC s m)

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -7,6 +7,7 @@
 module Control.Carrier.Writer.Church
 ( -- * Writer carrier
   runWriter
+, execWriter
 , WriterC(WriterC)
   -- * Writer effect
 , module Control.Effect.Writer
@@ -25,6 +26,15 @@ import Control.Monad.Trans.Class
 runWriter :: Monoid w => (w -> a -> m b) -> WriterC w m a -> m b
 runWriter k = runState k mempty . runWriterC
 {-# INLINE runWriter #-}
+
+-- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log and discarding the result value.
+--
+-- @
+-- 'execWriter' = 'runWriter' ('const' '.' 'pure')
+-- @
+execWriter :: (Monoid w, Applicative m) => WriterC w m a -> m w
+execWriter = runWriter (const . pure)
+{-# INLINE execWriter #-}
 
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -1,0 +1,2 @@
+module Control.Carrier.Writer.Church
+() where

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -1,2 +1,6 @@
 module Control.Carrier.Writer.Church
-() where
+( -- * Writer effect
+  module Control.Effect.Writer
+) where
+
+import Control.Effect.Writer

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -1,4 +1,9 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Control.Carrier.Writer.Church
 ( -- * Writer carrier
   runWriter
@@ -7,6 +12,7 @@ module Control.Carrier.Writer.Church
 , module Control.Effect.Writer
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative)
 import Control.Carrier.State.Church
 import Control.Effect.Writer
@@ -20,5 +26,14 @@ runWriter :: Monoid w => (w -> a -> m b) -> WriterC w m a -> m b
 runWriter k = runState k mempty . runWriterC
 {-# INLINE runWriter #-}
 
-newtype WriterC w m a = WriterC (StateC w m a)
+newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+
+instance (Algebra sig m, Monoid w) => Algebra (Writer w :+: sig) (WriterC w m) where
+  alg hdl sig ctx = WriterC $ case sig of
+    L writer -> StateC $ \ k w -> case writer of
+      Tell w'    -> (k $! mappend w w') ctx
+      Listen   m -> runWriter (\ w' a -> (k $! mappend w w') ((,) w' <$> a)) (hdl (m <$ ctx))
+      Censor f m -> runWriter (\ w' a -> (k $! mappend w (f $! w')) a) (hdl (m <$ ctx))
+    R other  -> alg (runWriterC . hdl) (R other) ctx
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -8,6 +8,8 @@
 
 {- | A high-performance, strict, church-encoded carrier for 'Writer'.
 
+This carrier issues left-associated 'mappend's, meaning that 'Monoid's such as @[]@ with poor performance for left-associated 'mappend's are ill-suited for use with this carrier. Alternatives such as 'Data.Monoid.Endo', @Seq@, or @DList@ may be preferred.
+
 @since 1.1.0.0
 -}
 module Control.Carrier.Writer.Church

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -64,8 +64,7 @@ instance (Algebra sig m, Monoid w) => Algebra (Writer w :+: sig) (WriterC w m) w
         let !w'' = mappend w w'
         k w'' ((,) w' <$> a)) (hdl (m <$ ctx))
       Censor f m -> runWriter (\ w' a -> do
-        let !fw' = f w'
-            !w'' = mappend w fw'
+        let !w'' = mappend w (f w')
         k w'' a) (hdl (m <$ ctx))
     R other  -> alg (runWriterC . hdl) (R other) ctx
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -1,6 +1,11 @@
 module Control.Carrier.Writer.Church
-( -- * Writer effect
-  module Control.Effect.Writer
+( -- * Writer carrier
+  WriterC(..)
+  -- * Writer effect
+, module Control.Effect.Writer
 ) where
 
+import Control.Carrier.State.Church
 import Control.Effect.Writer
+
+newtype WriterC w m a = WriterC (StateC w m a)

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{- | A church-encoded carrier for 'Writer'.
+{- | A high-performance, strict, church-encoded carrier for 'Writer'.
 
 @since 1.1.0.0
 -}

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -23,6 +23,20 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
+-- | Run a 'Writer' effect with a 'Monoid'al log, applying a continuation to the final log and result.
+--
+-- @
+-- 'runWriter' k ('pure' a) = k 'mempty' a
+-- @
+-- @
+-- 'runWriter' k ('tell' w) = k w ()
+-- @
+-- @
+-- 'runWriter' k ('listen' ('tell' w)) = k w (w, ())
+-- @
+-- @
+-- 'runWriter' k ('censor' f ('tell' w)) = k (f w) ()
+-- @
 runWriter :: Monoid w => (w -> a -> m b) -> WriterC w m a -> m b
 runWriter k = runState k mempty . runWriterC
 {-# INLINE runWriter #-}

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -5,6 +5,9 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+{- | A church-encoded carrier for 'Writer'.
+-}
 module Control.Carrier.Writer.Church
 ( -- * Writer carrier
   runWriter

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Writer.Church
 ( -- * Writer carrier
-  WriterC(..)
+  runWriter
+, WriterC(WriterC)
   -- * Writer effect
 , module Control.Effect.Writer
 ) where
@@ -14,6 +15,10 @@ import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+
+runWriter :: Monoid w => (w -> a -> m b) -> WriterC w m a -> m b
+runWriter k = runState k mempty . runWriterC
+{-# INLINE runWriter #-}
 
 newtype WriterC w m a = WriterC (StateC w m a)
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {- | A church-encoded carrier for 'Writer'.
+
+@since 1.1.0.0
 -}
 module Control.Carrier.Writer.Church
 ( -- * Writer carrier
@@ -41,6 +43,8 @@ import Control.Monad.Trans.Class
 -- @
 -- 'runWriter' k ('censor' f ('tell' w)) = k (f w) ()
 -- @
+--
+-- @since 1.1.0.0
 runWriter :: Monoid w => (w -> a -> m b) -> WriterC w m a -> m b
 runWriter k = runState k mempty . runWriterC
 {-# INLINE runWriter #-}
@@ -50,10 +54,13 @@ runWriter k = runState k mempty . runWriterC
 -- @
 -- 'execWriter' = 'runWriter' ('const' '.' 'pure')
 -- @
+--
+-- @since 1.1.0.0
 execWriter :: (Monoid w, Applicative m) => WriterC w m a -> m w
 execWriter = runWriter (const . pure)
 {-# INLINE execWriter #-}
 
+-- | @since 1.1.0.0
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Writer/Church.hs
+++ b/src/Control/Carrier/Writer/Church.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Writer.Church
 ( -- * Writer carrier
   WriterC(..)
@@ -5,7 +6,14 @@ module Control.Carrier.Writer.Church
 , module Control.Effect.Writer
 ) where
 
+import Control.Applicative (Alternative)
 import Control.Carrier.State.Church
 import Control.Effect.Writer
+import Control.Monad (MonadPlus)
+import Control.Monad.Fail as Fail
+import Control.Monad.Fix
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
 
 newtype WriterC w m a = WriterC (StateC w m a)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -62,7 +62,7 @@ newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
 instance (Monoid w, Algebra sig m) => Algebra (Writer w :+: sig) (WriterC w m) where
   alg hdl sig ctx = WriterC $ case sig of
     L writer -> StateC $ \ w -> case writer of
-      Tell w'    -> let w'' = mappend w w' in w'' `seq` pure (w'', ctx)
+      Tell w'    -> pure $ let w'' = mappend w w' in w'' `seq` (w'', ctx)
       Listen   m -> do
         (w', a) <- runWriter (hdl (m <$ ctx))
         let w'' = mappend w w'

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -5,6 +5,7 @@
 
 Predefined carriers:
 
+* "Control.Carrier.Writer.Church"
 * "Control.Carrier.Writer.Strict". (A lazy carrier is not provided due to the inherent space leaks associated with lazy writer monads.)
 * "Control.Monad.Trans.RWS.CPS"
 * "Control.Monad.Trans.RWS.Lazy"

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -13,18 +13,18 @@ module Writer
 ) where
 
 import           Control.Arrow ((&&&))
-import qualified Control.Carrier.Writer.Strict as WriterC
+import qualified Control.Carrier.Writer.Strict as C.Writer.Strict
 import           Control.Effect.Writer
 #if MIN_VERSION_transformers(0,5,6)
-import qualified Control.Monad.Trans.RWS.CPS as CPSRWST
+import qualified Control.Monad.Trans.RWS.CPS as T.RWS.CPS
 #endif
-import qualified Control.Monad.Trans.RWS.Lazy as LazyRWST
-import qualified Control.Monad.Trans.RWS.Strict as StrictRWST
+import qualified Control.Monad.Trans.RWS.Lazy as T.RWS.Lazy
+import qualified Control.Monad.Trans.RWS.Strict as T.RWS.Strict
 #if MIN_VERSION_transformers(0,5,6)
-import qualified Control.Monad.Trans.Writer.CPS as CPSWriterT
+import qualified Control.Monad.Trans.Writer.CPS as T.Writer.CPS
 #endif
-import qualified Control.Monad.Trans.Writer.Lazy as LazyWriterT
-import qualified Control.Monad.Trans.Writer.Strict as StrictWriterT
+import qualified Control.Monad.Trans.Writer.Lazy as T.Writer.Lazy
+import qualified Control.Monad.Trans.Writer.Strict as T.Writer.Strict
 import           Data.Bifunctor (first)
 import           Data.Tuple (swap)
 import           Gen
@@ -39,18 +39,18 @@ tests = testGroup "Writer"
     [ testMonad
     , testMonadFix
     , testWriter
-    ] >>= ($ runL WriterC.runWriter)
+    ] >>= ($ runL C.Writer.Strict.runWriter)
   , testGroup "(,)"              $ testWriter (runL pure)
 #if MIN_VERSION_transformers(0,5,6)
-  , testGroup "WriterT (CPS)"    $ testWriter (runL (fmap swap . CPSWriterT.runWriterT))
+  , testGroup "WriterT (CPS)"    $ testWriter (runL (fmap swap . T.Writer.CPS.runWriterT))
 #endif
-  , testGroup "WriterT (Lazy)"   $ testWriter (runL (fmap swap . LazyWriterT.runWriterT))
-  , testGroup "WriterT (Strict)" $ testWriter (runL (fmap swap . StrictWriterT.runWriterT))
+  , testGroup "WriterT (Lazy)"   $ testWriter (runL (fmap swap . T.Writer.Lazy.runWriterT))
+  , testGroup "WriterT (Strict)" $ testWriter (runL (fmap swap . T.Writer.Strict.runWriterT))
 #if MIN_VERSION_transformers(0,5,6)
-  , testGroup "RWST (CPS)"       $ testWriter (runL (runRWST CPSRWST.runRWST))
+  , testGroup "RWST (CPS)"       $ testWriter (runL (runRWST T.RWS.CPS.runRWST))
 #endif
-  , testGroup "RWST (Lazy)"      $ testWriter (runL (runRWST LazyRWST.runRWST))
-  , testGroup "RWST (Strict)"    $ testWriter (runL (runRWST StrictRWST.runRWST))
+  , testGroup "RWST (Lazy)"      $ testWriter (runL (runRWST T.RWS.Lazy.runRWST))
+  , testGroup "RWST (Strict)"    $ testWriter (runL (runRWST T.RWS.Strict.runRWST))
   ] where
   testMonad    run = Monad.test    (m (gen0 w) (genN w b)) a b c initial run
   testMonadFix run = MonadFix.test (m (gen0 w) (genN w b)) a b   initial run

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -35,7 +35,7 @@ import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Writer"
-  [ testGroup "WriterC" $
+  [ testGroup "WriterC (Strict)" $
     [ testMonad
     , testMonadFix
     , testWriter

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -13,6 +13,7 @@ module Writer
 ) where
 
 import           Control.Arrow ((&&&))
+import qualified Control.Carrier.Writer.Church as C.Writer.Church
 import qualified Control.Carrier.Writer.Strict as C.Writer.Strict
 import           Control.Effect.Writer
 #if MIN_VERSION_transformers(0,5,6)
@@ -35,7 +36,12 @@ import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Writer"
-  [ testGroup "WriterC (Strict)" $
+  [ testGroup "WriterC (Church)" $
+    [ testMonad
+    , testMonadFix
+    , testWriter
+    ] >>= ($ runL (C.Writer.Church.runWriter (curry pure)))
+  , testGroup "WriterC (Strict)" $
     [ testMonad
     , testMonadFix
     , testWriter


### PR DESCRIPTION
This PR introduces and benchmarks a high-performance Church-encoded `Writer` carrier. In benchmarks where it wraps `IO`, it outperforms every other carrier by quite a decent margin.