### PR TITLE
evalEmpty & execEmpty handlers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 
 - Defines `Algebra` instances for `Control.Monad.Trans.Maybe.MaybeT`, `Control.Monad.Trans.RWS.CPS`, and `Control.Monad.Trans.Writer.CPS`. ([#366](https://github.com/fused-effects/fused-effects/pull/366))
 
+- Adds `evalEmpty` and `execEmpty` handlers for the `Empty` carriers as conveniences for using `empty` to signal early returns. ([#371](https://github.com/fused-effects/fused-effects/pull/371))
+
 
 ## Backwards-incompatible changes
 

--- a/src/Control/Carrier/Empty/Church.hs
+++ b/src/Control/Carrier/Empty/Church.hs
@@ -12,6 +12,7 @@
 module Control.Carrier.Empty.Church
 ( -- * Empty carrier
   runEmpty
+, evalEmpty
 , EmptyC(..)
   -- * Empty effect
 , module Control.Effect.Empty
@@ -40,6 +41,19 @@ import Data.Functor.Identity
 runEmpty :: m b -> (a -> m b) -> EmptyC m a -> m b
 runEmpty nil leaf (EmptyC m) = m nil leaf
 {-# INLINE runEmpty #-}
+
+-- | Run an 'Empty' effect, discarding its result.
+--
+-- This is convenient for using 'empty' to signal early returns without needing to know whether control exited normally or not.
+--
+-- @
+-- 'evalEmpty' = 'runEmpty' ('pure' ()) ('const' ('pure' ()))
+-- @
+--
+-- @since 1.1.0.0
+evalEmpty :: Applicative m => EmptyC m a -> m ()
+evalEmpty = runEmpty (pure ()) (const (pure ()))
+{-# INLINE evalEmpty #-}
 
 -- | @since 1.1.0.0
 newtype EmptyC m a = EmptyC (forall b . m b -> (a -> m b) -> m b)

--- a/src/Control/Carrier/Empty/Church.hs
+++ b/src/Control/Carrier/Empty/Church.hs
@@ -13,6 +13,7 @@ module Control.Carrier.Empty.Church
 ( -- * Empty carrier
   runEmpty
 , evalEmpty
+, execEmpty
 , EmptyC(..)
   -- * Empty effect
 , module Control.Effect.Empty
@@ -54,6 +55,25 @@ runEmpty nil leaf (EmptyC m) = m nil leaf
 evalEmpty :: Applicative m => EmptyC m a -> m ()
 evalEmpty = runEmpty (pure ()) (const (pure ()))
 {-# INLINE evalEmpty #-}
+
+-- | Run an 'Empty' effect, replacing its result with a 'Bool' indicating whether control exited normally.
+--
+-- This is convenient for using 'empty' to signal early returns when all you need to know is whether control exited normally or not, and not what value it exited with.
+--
+-- @
+-- 'execEmpty' = 'runEmpty' ('pure' 'False') ('const' ('pure' 'True'))
+-- @
+-- @
+-- 'execEmpty' ('pure' a) = 'pure' 'True'
+-- @
+-- @
+-- 'execEmpty' 'empty' = 'pure' 'False'
+-- @
+--
+-- @since 1.1.0.0
+execEmpty :: Applicative m => EmptyC m a -> m Bool
+execEmpty = runEmpty (pure False) (const (pure True))
+{-# INLINE execEmpty #-}
 
 -- | @since 1.1.0.0
 newtype EmptyC m a = EmptyC (forall b . m b -> (a -> m b) -> m b)

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -45,6 +45,9 @@ runEmpty :: EmptyC m a -> m (Maybe a)
 runEmpty (EmptyC m) = runMaybeT m
 {-# INLINE runEmpty #-}
 
+-- | Run an 'Empty' effect, discarding its result.
+--
+-- This is convenient for using 'empty' to signal early returns without needing to know whether control exited normally or not.
 evalEmpty :: Functor m => EmptyC m a -> m ()
 evalEmpty = void . runEmpty
 

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -65,6 +65,12 @@ evalEmpty = void . runEmpty
 -- @
 -- 'execEmpty' = 'fmap' 'isJust' '.' 'runEmpty'
 -- @
+-- @
+-- 'execEmpty' ('pure' a) = 'pure' 'True'
+-- @
+-- @
+-- 'execEmpty' 'empty' = 'pure' 'False'
+-- @
 --
 -- @since 1.1.0.0
 execEmpty :: Functor m => EmptyC m a -> m Bool

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -50,12 +50,14 @@ runEmpty (EmptyC m) = runMaybeT m
 -- This is convenient for using 'empty' to signal early returns without needing to know whether control exited normally or not.
 evalEmpty :: Functor m => EmptyC m a -> m ()
 evalEmpty = void . runEmpty
+{-# INLINE evalEmpty #-}
 
 -- | Run an 'Empty' effect, replacing its result with a 'Bool' indicating whether control exited normally.
 --
 -- This is convenient for using 'empty' to signal early returns when all you need to know is whether control exited normally or not, and not what value it exited with.
 execEmpty :: Functor m => EmptyC m a -> m Bool
 execEmpty = fmap isJust . runEmpty
+{-# INLINE execEmpty #-}
 
 -- | @since 1.0.0.0
 newtype EmptyC m a = EmptyC (MaybeT m a)

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -49,6 +49,10 @@ runEmpty (EmptyC m) = runMaybeT m
 --
 -- This is convenient for using 'empty' to signal early returns without needing to know whether control exited normally or not.
 --
+-- @
+-- 'evalEmpty' = 'void' '.' 'runEmpty'
+-- @
+--
 -- @since 1.1.0.0
 evalEmpty :: Functor m => EmptyC m a -> m ()
 evalEmpty = void . runEmpty
@@ -57,6 +61,10 @@ evalEmpty = void . runEmpty
 -- | Run an 'Empty' effect, replacing its result with a 'Bool' indicating whether control exited normally.
 --
 -- This is convenient for using 'empty' to signal early returns when all you need to know is whether control exited normally or not, and not what value it exited with.
+--
+-- @
+-- 'execEmpty' = 'fmap' 'isJust' '.' 'runEmpty'
+-- @
 --
 -- @since 1.1.0.0
 execEmpty :: Functor m => EmptyC m a -> m Bool

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -51,6 +51,9 @@ runEmpty (EmptyC m) = runMaybeT m
 evalEmpty :: Functor m => EmptyC m a -> m ()
 evalEmpty = void . runEmpty
 
+-- | Run an 'Empty' effect, replacing its result with a 'Bool' indicating whether control exited normally.
+--
+-- This is convenient for using 'empty' to signal early returns when all you need to know is whether control exited normally or not, and not what value it exited with.
 execEmpty :: Functor m => EmptyC m a -> m Bool
 execEmpty = fmap isJust . runEmpty
 

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -48,6 +48,8 @@ runEmpty (EmptyC m) = runMaybeT m
 -- | Run an 'Empty' effect, discarding its result.
 --
 -- This is convenient for using 'empty' to signal early returns without needing to know whether control exited normally or not.
+--
+-- @since 1.1.0.0
 evalEmpty :: Functor m => EmptyC m a -> m ()
 evalEmpty = void . runEmpty
 {-# INLINE evalEmpty #-}
@@ -55,6 +57,8 @@ evalEmpty = void . runEmpty
 -- | Run an 'Empty' effect, replacing its result with a 'Bool' indicating whether control exited normally.
 --
 -- This is convenient for using 'empty' to signal early returns when all you need to know is whether control exited normally or not, and not what value it exited with.
+--
+-- @since 1.1.0.0
 execEmpty :: Functor m => EmptyC m a -> m Bool
 execEmpty = fmap isJust . runEmpty
 {-# INLINE execEmpty #-}

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -15,6 +15,7 @@ module Control.Carrier.Empty.Maybe
 ( -- * Empty carrier
   runEmpty
 , evalEmpty
+, execEmpty
 , EmptyC(..)
   -- * Empty effect
 , module Control.Effect.Empty
@@ -28,6 +29,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
 import Data.Functor (void)
+import Data.Maybe (isJust)
 
 -- | Run an 'Empty' effect, returning 'Nothing' for empty computations, or 'Just' the result otherwise.
 --
@@ -45,6 +47,9 @@ runEmpty (EmptyC m) = runMaybeT m
 
 evalEmpty :: Functor m => EmptyC m a -> m ()
 evalEmpty = void . runEmpty
+
+execEmpty :: Functor m => EmptyC m a -> m Bool
+execEmpty = fmap isJust . runEmpty
 
 -- | @since 1.0.0.0
 newtype EmptyC m a = EmptyC (MaybeT m a)

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -14,6 +14,7 @@ Note that 'Empty' effects can, when they are the last effect in a stack, be inte
 module Control.Carrier.Empty.Maybe
 ( -- * Empty carrier
   runEmpty
+, evalEmpty
 , EmptyC(..)
   -- * Empty effect
 , module Control.Effect.Empty
@@ -26,6 +27,7 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe
+import Data.Functor (void)
 
 -- | Run an 'Empty' effect, returning 'Nothing' for empty computations, or 'Just' the result otherwise.
 --
@@ -40,6 +42,9 @@ import Control.Monad.Trans.Maybe
 runEmpty :: EmptyC m a -> m (Maybe a)
 runEmpty (EmptyC m) = runMaybeT m
 {-# INLINE runEmpty #-}
+
+evalEmpty :: Functor m => EmptyC m a -> m ()
+evalEmpty = void . runEmpty
 
 -- | @since 1.0.0.0
 newtype EmptyC m a = EmptyC (MaybeT m a)


### PR DESCRIPTION
This PR adds `evalEmpty` & `execEmpty` handlers for the `Empty` carriers, respectively discarding the result & returning a `Bool` indicating whether control exited normally.