### PR TITLE
Use Data.Kind.Type instead of * in kind signatures

### DIFF
--- a/.ghci.repl
+++ b/.ghci.repl
@@ -23,7 +23,6 @@
 :seti -Wno-name-shadowing
 :seti -Wno-safe
 :seti -Wno-unsafe
-:seti -Wno-star-is-type
 :seti -Wno-missing-deriving-strategies
 
 -- We have this one on in the project but not in the REPL to reduce noise

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -35,8 +35,6 @@ common common
     -Wno-name-shadowing
     -Wno-safe
     -Wno-unsafe
-  if (impl(ghc >= 8.6))
-    ghc-options: -Wno-star-is-type
   if (impl(ghc >= 8.8))
     ghc-options: -Wno-missing-deriving-strategies
 

--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -59,7 +59,6 @@ function flags {
   echo "-Wno-name-shadowing"
   echo "-Wno-safe"
   echo "-Wno-unsafe"
-  [[ "$ghc_version" = 8.6.* ]] || [[ "$ghc_version" = 8.8.* ]] && echo "-Wno-star-is-type" || true
   [[ "$ghc_version" = 8.8.* ]] && echo "-Wno-missing-deriving-strategies" || true
 }
 

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -85,7 +85,7 @@ runInterpretState handler state m
 {-# INLINE runInterpretState #-}
 
 -- | @since 1.0.0.0
-newtype InterpretC s (sig :: (* -> *) -> * -> *) m a = InterpretC { runInterpretC :: m a }
+newtype InterpretC s (sig :: (* -> *) -> (* -> *)) m a = InterpretC { runInterpretC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans (InterpretC s sig) where

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -34,6 +34,7 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Functor.Const (Const(..))
+import Data.Kind (Type)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | An @Interpreter@ is a function that interprets effects described by @sig@ into the carrier monad @m@.
@@ -85,7 +86,7 @@ runInterpretState handler state m
 {-# INLINE runInterpretState #-}
 
 -- | @since 1.0.0.0
-newtype InterpretC s (sig :: (* -> *) -> (* -> *)) m a = InterpretC { runInterpretC :: m a }
+newtype InterpretC s (sig :: (Type -> Type) -> (Type -> Type)) m a = InterpretC { runInterpretC :: m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
 
 instance MonadTrans (InterpretC s sig) where

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -18,10 +18,10 @@ module Control.Effect.Sum
 , reassociateSumL
 ) where
 
-import Data.Kind (Constraint)
+import Data.Kind (Constraint, Type)
 
 -- | Higher-order sums are used to combine multiple effects into a signature, typically by chaining on the right.
-data (f :+: g) (m :: * -> *) k
+data (f :+: g) (m :: Type -> Type) k
   = L (f m k)
   | R (g m k)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
@@ -36,7 +36,7 @@ infixr 4 :+:
 --   It should not generally be necessary for you to define new 'Member' instances, but these are not specifically prohibited if you wish to get creative.
 --
 -- @since 0.1.0.0
-class Member (sub :: (* -> *) -> (* -> *)) sup where
+class Member (sub :: (Type -> Type) -> (Type -> Type)) sup where
   -- | Inject a member of a signature into the signature.
   inj :: sub m a -> sup m a
 


### PR DESCRIPTION
This PR re-enables `-Wstar-is-type` in `ghc`s which support it, and replaces `*` with `Data.Kind.Type` in the few remaining kind signatures we hadn’t got to yet.

@patrickt has asked me about this now and then, and since `*` is apparently going to be deprecated at some point (since it makes parsing harder), I figured let’s get out in front of that.