### PR TITLE
Church-encoded Fresh carrier

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Adds a church-encoded `Writer` carrier in `Control.Carrier.Writer.Church`. ([#369](https://github.com/fused-effects/fused-effects/pull/369))
 
+- Adds a church-encoded `Fresh` carrier in `Control.Carrier.Fresh.Church`. ([#373](https://github.com/fused-effects/fused-effects/pull/373))
+
 - Defines `Algebra` instances for `Control.Monad.Trans.Maybe.MaybeT`, `Control.Monad.Trans.RWS.CPS`, and `Control.Monad.Trans.Writer.CPS`. ([#366](https://github.com/fused-effects/fused-effects/pull/366))
 
 - Adds `evalEmpty` and `execEmpty` handlers for the `Empty` carriers as conveniences for using `empty` to signal early returns. ([#371](https://github.com/fused-effects/fused-effects/pull/371))

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -55,6 +55,7 @@ library
     Control.Carrier.Error.Church
     Control.Carrier.Error.Either
     Control.Carrier.Fail.Either
+    Control.Carrier.Fresh.Church
     Control.Carrier.Fresh.Strict
     Control.Carrier.Interpret
     Control.Carrier.Lift

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -1,0 +1,2 @@
+module Control.Carrier.Fresh.Church
+() where

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -61,6 +61,6 @@ newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
 
 instance Algebra sig m => Algebra (Fresh :+: sig) (FreshC m) where
   alg hdl sig ctx = FreshC $ case sig of
-    L Fresh -> gets (<$ ctx) <* modify (+ (1 :: Int))
+    L Fresh -> state $ \ i -> (i + 1, i <$ ctx)
     R other -> alg (runFreshC . hdl) (R other) ctx
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Carrier.Fresh.Church
 ( -- * Fresh carrier
   FreshC(..)
@@ -5,7 +6,14 @@ module Control.Carrier.Fresh.Church
 , module Control.Effect.Fresh
 ) where
 
+import Control.Applicative (Alternative)
 import Control.Carrier.State.Church
 import Control.Effect.Fresh
+import Control.Monad (MonadPlus)
+import Control.Monad.Fail as Fail
+import Control.Monad.Fix
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class
 
 newtype FreshC m a = FreshC (StateC Int m a)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Control.Carrier.Fresh.Church
 ( -- * Fresh carrier
-  FreshC(FreshC)
+  runFresh
+, FreshC(FreshC)
   -- * Fresh effect
 , module Control.Effect.Fresh
 ) where
@@ -20,6 +21,20 @@ import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+
+-- | Run a 'Fresh' effect counting up from 0.
+--
+-- @
+-- 'runFresh' k n ('pure' a) = k n a
+-- @
+-- @
+-- 'runFresh' k n 'fresh' = k (n '+' 1) n
+-- @
+--
+-- @since 1.1.0.0
+runFresh :: (Int -> a -> m b) -> Int -> FreshC m a -> m b
+runFresh k n = runState k n . runFreshC
+{-# INLINE runFresh #-}
 
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -1,11 +1,17 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Control.Carrier.Fresh.Church
 ( -- * Fresh carrier
-  FreshC(..)
+  FreshC(FreshC)
   -- * Fresh effect
 , module Control.Effect.Fresh
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative)
 import Control.Carrier.State.Church
 import Control.Effect.Fresh
@@ -15,5 +21,11 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
-newtype FreshC m a = FreshC (StateC Int m a)
+newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+
+instance Algebra sig m => Algebra (Fresh :+: sig) (FreshC m) where
+  alg hdl sig ctx = FreshC $ case sig of
+    L Fresh -> gets (<$ ctx) <* modify (+ (1 :: Int))
+    R other -> alg (runFreshC . hdl) (R other) ctx
+  {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -1,6 +1,11 @@
 module Control.Carrier.Fresh.Church
-( -- * Fresh effect
-  module Control.Effect.Fresh
+( -- * Fresh carrier
+  FreshC(..)
+  -- * Fresh effect
+, module Control.Effect.Fresh
 ) where
 
+import Control.Carrier.State.Church
 import Control.Effect.Fresh
+
+newtype FreshC m a = FreshC (StateC Int m a)

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+-- | A church-encoded carrier for a 'Fresh' effect, providing access to a monotonically increasing stream of 'Int' values.
+--
+-- @since 1.1.0.0
 module Control.Carrier.Fresh.Church
 ( -- * Fresh carrier
   runFresh

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -1,2 +1,6 @@
 module Control.Carrier.Fresh.Church
-() where
+( -- * Fresh effect
+  module Control.Effect.Fresh
+) where
+
+import Control.Effect.Fresh

--- a/src/Control/Carrier/Fresh/Church.hs
+++ b/src/Control/Carrier/Fresh/Church.hs
@@ -7,6 +7,7 @@
 module Control.Carrier.Fresh.Church
 ( -- * Fresh carrier
   runFresh
+, evalFresh
 , FreshC(FreshC)
   -- * Fresh effect
 , module Control.Effect.Fresh
@@ -36,6 +37,21 @@ runFresh :: (Int -> a -> m b) -> Int -> FreshC m a -> m b
 runFresh k n = runState k n . runFreshC
 {-# INLINE runFresh #-}
 
+-- | Run a 'Fresh' effect counting up from an initial value, and forgetting the final value.
+--
+-- @
+-- 'evalFresh' n ('pure' a) = 'pure' a
+-- @
+-- @
+-- 'evalFresh' n 'fresh' = 'pure' n
+-- @
+--
+-- @since 1.1.0.0
+evalFresh :: Applicative m => Int -> FreshC m a -> m a
+evalFresh n = evalState n . runFreshC
+{-# INLINE evalFresh #-}
+
+-- | @since 1.1.0.0
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -21,7 +21,7 @@ import Control.Algebra
 import Control.Applicative (Alternative(..))
 import Control.Carrier.State.Strict
 import Control.Effect.Fresh
-import Control.Monad (MonadPlus(..))
+import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -61,6 +61,6 @@ newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
 
 instance Algebra sig m => Algebra (Fresh :+: sig) (FreshC m) where
   alg hdl sig ctx = FreshC $ case sig of
-    L Fresh -> gets (<$ ctx) <* modify (+ (1 :: Int))
+    L Fresh -> state $ \ i -> (i + 1, i <$ ctx)
     R other -> alg (runFreshC . hdl) (R other) ctx
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -60,7 +60,7 @@ newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance Algebra sig m => Algebra (Fresh :+: sig) (FreshC m) where
-  alg hdl sig ctx = case sig of
-    L Fresh -> FreshC (gets (<$ ctx) <* modify (+ (1 :: Int)))
-    R other -> FreshC (alg (runFreshC . hdl) (R other) ctx)
+  alg hdl sig ctx = FreshC $ case sig of
+    L Fresh -> gets (<$ ctx) <* modify (+ (1 :: Int))
+    R other -> alg (runFreshC . hdl) (R other) ctx
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Fresh/Strict.hs
+++ b/src/Control/Carrier/Fresh/Strict.hs
@@ -18,7 +18,7 @@ module Control.Carrier.Fresh.Strict
 ) where
 
 import Control.Algebra
-import Control.Applicative (Alternative(..))
+import Control.Applicative (Alternative)
 import Control.Carrier.State.Strict
 import Control.Effect.Fresh
 import Control.Monad (MonadPlus)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -4,8 +4,8 @@
 
 Predefined carriers:
 
-* "Control.Carrier.Fresh.Strict".
-
+* "Control.Carrier.Fresh.Church"
+* "Control.Carrier.Fresh.Strict"
 -}
 module Control.Effect.Fresh
 ( -- * Fresh effect

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -8,6 +8,7 @@ module Fresh
 , test
 ) where
 
+import qualified Control.Carrier.Fresh.Church as C.Church
 import qualified Control.Carrier.Fresh.Strict as C.Strict
 import           Control.Effect.Fresh
 import           Gen
@@ -19,7 +20,12 @@ import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Fresh"
-  [ testGroup "FreshC" $
+  [ testGroup "FreshC (Church)" $
+    [ testMonad
+    , testMonadFix
+    , testFresh
+    ] >>= ($ runC (C.Church.runFresh (curry pure)))
+  , testGroup "FreshC (Strict)" $
     [ testMonad
     , testMonadFix
     , testFresh

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -8,7 +8,7 @@ module Fresh
 , test
 ) where
 
-import qualified Control.Carrier.Fresh.Strict as FreshC
+import qualified Control.Carrier.Fresh.Strict as C.Strict
 import           Control.Effect.Fresh
 import           Gen
 import qualified Hedgehog.Range as R
@@ -23,7 +23,7 @@ tests = testGroup "Fresh"
     [ testMonad
     , testMonadFix
     , testFresh
-    ] >>= ($ runC FreshC.runFresh)
+    ] >>= ($ runC C.Strict.runFresh)
   ] where
   testMonad    run = Monad.test    (m gen (\ _ _ -> [])) a b c initial run
   testMonadFix run = MonadFix.test (m gen (\ _ _ -> [])) a b   initial run


### PR DESCRIPTION
`Control.Carrier.State.Church` gives us a nice boost over `.Strict`, so here’s a `FreshC` based on it, too.