### PR TITLE
[WIP] Use Close type family to avoid ambiguity

### DIFF
--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -99,6 +99,7 @@ library
     Control.Effect.State.Internal
     Control.Effect.Throw.Internal
     Control.Effect.Writer.Internal
+    Control.Effect.Close
   build-depends:
     , base          >= 4.9 && < 4.14
     , transformers  >= 0.4 && < 0.6

--- a/src/Control/Effect/Close.hs
+++ b/src/Control/Effect/Close.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE InstanceSigs #-}
+
+-- JZ:TODO: I would recommand put sum in Data.Functor.Internal.Sum, and then export from Control.Effect
+module Control.Effect.Close 
+  where
+
+
+import Data.Kind (Type)
+import Data.Proxy
+
+-- | Higher-order sums are used to combine multiple effects into a signature, typically by chaining okn the right.
+data (f :+: g) (m :: Type -> Type) k
+  = L (f m k)
+  | R (g m k)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+infixr 4 :+:
+
+data Pos = Here|Le Pos|Ri Pos
+data Res = Found Pos | NotFound | Ambiguous
+
+type Nat = (Type -> Type) -> Type -> Type
+type family Elem (e :: Nat) (p :: Nat) :: Res where
+  Elem a a = 'Found 'Here
+  Elem e (l :+: r) = Choose (Elem e l) (Elem e r)
+  -- UndecidableInstances is caused by here.
+  -- Perhaps we can find a way to remove it with decorate a Nil on the end
+  -- But then we need to change the definition of f + g
+  Elem _ _ = 'NotFound
+
+type family Choose (l :: Res) (r :: Res) :: Res where
+  Choose ('Found _) ('Found _) = 'Ambiguous
+  Choose 'Ambiguous _ = 'Ambiguous
+  Choose _ 'Ambiguous = 'Ambiguous
+  Choose ('Found x) 'NotFound = 'Found ('Le x)
+  Choose 'NotFound ('Found x) = 'Found ('Ri x)
+  Choose 'NotFound 'NotFound = 'NotFound
+
+
+class Subsume (pos :: Res) a b where
+  iinj :: (Proxy pos) -> a m x -> b m x
+
+instance Subsume ('Found 'Here) a a where
+  iinj _ = id
+  {-# INLINE iinj #-}
+
+instance Subsume ('Found p) a b => Subsume ('Found ('Le p)) a (b :+: c) where
+  iinj _ = L . iinj (Proxy :: Proxy ('Found p))
+  {-# INLINE iinj #-}
+
+instance Subsume ('Found p) a b => Subsume ('Found ('Ri p)) a (c :+: b) where
+  iinj _ = R . iinj (Proxy :: Proxy ('Found p))
+  {-# INLINE iinj #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -15,18 +17,12 @@ module Control.Effect.Sum
 , Members
   -- * Sums
 , (:+:)(..)
-, reassociateSumL
+, reassociateSumL 
 ) where
 
 import Data.Kind (Constraint, Type)
-
--- | Higher-order sums are used to combine multiple effects into a signature, typically by chaining on the right.
-data (f :+: g) (m :: Type -> Type) k
-  = L (f m k)
-  | R (g m k)
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-infixr 4 :+:
+import Control.Effect.Close
+import Data.Proxy
 
 
 -- | The class of types present in a signature.
@@ -40,31 +36,9 @@ class Member (sub :: (Type -> Type) -> (Type -> Type)) sup where
   -- | Inject a member of a signature into the signature.
   inj :: sub m a -> sup m a
 
--- | Reflexivity: @t@ is a member of itself.
-instance Member t t where
-  inj = id
+instance Subsume (Elem sub sup) sub sup => Member sub sup where
+  inj = iinj (Proxy @(Elem sub sup))
   {-# INLINE inj #-}
-
--- | Left-recursion: if @t@ is a member of @l1 ':+:' l2 ':+:' r@, then we can inject it into @(l1 ':+:' l2) ':+:' r@ by injection into a right-recursive signature, followed by left-association.
-instance {-# OVERLAPPABLE #-}
-         Member t (l1 :+: l2 :+: r)
-      => Member t ((l1 :+: l2) :+: r) where
-  inj = reassociateSumL . inj
-  {-# INLINE inj #-}
-
--- | Left-occurrence: if @t@ is at the head of a signature, we can inject it in O(1).
-instance {-# OVERLAPPABLE #-}
-         Member l (l :+: r) where
-  inj = L
-  {-# INLINE inj #-}
-
--- | Right-recursion: if @t@ is a member of @r@, we can inject it into @r@ in O(n), followed by lifting that into @l ':+:' r@ in O(1).
-instance {-# OVERLAPPABLE #-}
-         Member l r
-      => Member l (l' :+: r) where
-  inj = R . inj
-  {-# INLINE inj #-}
-
 
 -- | Reassociate a right-nested sum leftwards.
 --
@@ -75,7 +49,6 @@ reassociateSumL = \case
   R (L l) -> L (R l)
   R (R r) -> R r
 {-# INLINE reassociateSumL #-}
-
 
 -- | Decompose sums on the left into multiple 'Member' constraints.
 --


### PR DESCRIPTION
This PR try to introduce http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.643.3533&rep=rep1&type=pdf to eliminate ambiguity by abitary `:+:`.

The paper has an implementation by its author as in https://github.com/pa-ba/compdata

Currently, this PR is work in process to fix about Label.