### PR TITLE
Rename github actions file and use newer setup-haskell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1
+    - uses: actions/setup-haskell@v1.1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Testing out the latest release of https://github.com/actions/setup-haskell.