### PR TITLE
Fix possible typo in documentation

### DIFF
--- a/docs/defining_effects.md
+++ b/docs/defining_effects.md
@@ -47,8 +47,8 @@ newtype TeletypeIOC m a = TeletypeIOC { runTeletypeIO :: m a }
 
 instance (MonadIO m, Algebra sig m) => Algebra (Teletype :+: sig) (TeletypeIOC m) where
   alg hdl sig ctx = case sig of
-    L Read      -> (<$ ctx) <$ liftIO getLine
-    L (Write s) -> ctx      <$ liftIO (putStrLn s)
+    L Read      -> (<$ ctx) <$> liftIO getLine
+    L (Write s) -> ctx      <$  liftIO (putStrLn s)
     R other     -> TeletypeIOC (alg (runTeletypeIO . hdl) other ctx)
 ```
 


### PR DESCRIPTION
The docs currently read like you are inserting the partially applied `(<$ ctx)` into the Monad that getLine is being lifted into. But according to the typesignature of `alg` this doesn't make much sense.

`(<$ ctx) :: a -> ctx a`
`(<$ ctx) <$ liftIO getLine :: m (a -> ctx a)`
`(<$ ctx) <$> liftIO getLine :: m (ctx a)` <- and `m (ctx a)` is notably the desired result of `alg`