### PR TITLE
Fix broken haddock links

### DIFF
--- a/src/Control/Carrier/Trace/Ignoring.hs
+++ b/src/Control/Carrier/Trace/Ignoring.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- | A carrier for the 'Control.Effect.Trace' effect that ignores all traced results. Useful when you wish to disable tracing without removing all trace statements.
+-- | A carrier for the 'Trace' effect that ignores all traced results. Useful when you wish to disable tracing without removing all trace statements.
 --
 -- @since 1.0.0.0
 module Control.Carrier.Trace.Ignoring

--- a/src/Control/Carrier/Trace/Printing.hs
+++ b/src/Control/Carrier/Trace/Printing.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- | A carrier for the 'Control.Effect.Trace' effect that prints all traced results to stderr.
+-- | A carrier for the 'Trace' effect that prints all traced results to stderr.
 --
 -- @since 1.0.0.0
 module Control.Carrier.Trace.Printing

--- a/src/Control/Carrier/Trace/Returning.hs
+++ b/src/Control/Carrier/Trace/Returning.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- | A carrier for the 'Control.Effect.Trace' effect that aggregates and returns all traced values.
+-- | A carrier for the 'Trace' effect that aggregates and returns all traced values.
 --
 -- @since 1.0.0.0
 module Control.Carrier.Trace.Returning


### PR DESCRIPTION
Haddock interpreted this as Trace in a module called Control.Effect
instead of Control.Effect.Trace.