### PR TITLE
Derive MonadFix for labelled effects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# v1.1.1
+
+* Defines `MonadFix` instances for `Labelled` and `UnderLabel`. ([#402](https://github.com/fused-effects/fused-effects/pull/402))
+
+
 # v1.1
 
 - Adds a church-encoded `State` carrier in `Control.Carrier.State.Church`. ([#363](https://github.com/fused-effects/fused-effects/pull/363))

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -37,6 +37,7 @@ import Control.Applicative (Alternative)
 import Control.Effect.Sum (reassociateSumL)
 import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
+import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Functor.Identity
@@ -46,7 +47,17 @@ import Data.Kind (Type)
 --
 -- @since 1.0.2.0
 newtype Labelled (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) m a = Labelled (sub m a)
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus, MonadTrans)
+  deriving
+    ( Alternative
+    , Applicative
+    , Functor
+    , Monad
+    , Fail.MonadFail
+    , MonadFix -- ^ @since 1.1.1
+    , MonadIO
+    , MonadPlus
+    , MonadTrans
+    )
 
 -- | @since 1.0.2.0
 runLabelled :: forall label sub m a . Labelled label sub m a -> sub m a
@@ -114,7 +125,16 @@ sendLabelled op = runIdentity <$> alg (fmap Identity . runIdentity) (injLabelled
 --
 -- @since 1.0.2.0
 newtype UnderLabel (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) (m :: Type -> Type) a = UnderLabel (m a)
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadIO, MonadPlus)
+  deriving
+    ( Alternative
+    , Applicative
+    , Functor
+    , Monad
+    , Fail.MonadFail
+    , MonadFix -- ^ @since 1.1.1
+    , MonadIO
+    , MonadPlus
+    )
 
 -- | @since 1.0.2.0
 runUnderLabel :: forall label sub m a . UnderLabel label sub m a -> m a


### PR DESCRIPTION
All other carriers already define a conditional `MonadFix` instance.

These instances should probably get a `@since XX` annotation and maybe an entry in the changelog. What is your process in that regard? I can add those if you can tell me what the next version number will be or alternatively add some kind of placeholder to fill in when the next release is done.