### PR TITLE
Add MonadMask, MonadCatch, MonadThrow, and MonadUnliftIO instances

### DIFF
--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -106,7 +106,9 @@ library
     Control.Effect.Writer.Internal
   build-depends:
       base          >= 4.9 && < 4.15
+    , exceptions    >= 0.10 && < 0.11
     , transformers  >= 0.4 && < 0.6
+    , unliftio-core >= 0.2 && < 0.3
 
 
 test-suite examples

--- a/src/Control/Carrier/Empty/Maybe.hs
+++ b/src/Control/Carrier/Empty/Maybe.hs
@@ -23,6 +23,7 @@ module Control.Carrier.Empty.Maybe
 
 import Control.Algebra
 import Control.Effect.Empty
+import Control.Monad.Catch
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -79,7 +80,7 @@ execEmpty = fmap isJust . runEmpty
 
 -- | @since 1.0.0.0
 newtype EmptyC m a = EmptyC (MaybeT m a)
-  deriving (Algebra (Empty :+: sig), Applicative, Functor, Monad, MonadFix, MonadIO, MonadTrans)
+  deriving (Algebra (Empty :+: sig), Applicative, Functor, Monad, MonadFix, MonadIO, MonadTrans, MonadThrow, MonadMask, MonadCatch)
 
 -- | 'EmptyC' passes 'Fail.MonadFail' operations along to the underlying monad @m@, rather than interpreting it as a synonym for 'empty' à la 'MaybeT'.
 instance Fail.MonadFail m => Fail.MonadFail (EmptyC m) where

--- a/src/Control/Carrier/Error/Either.hs
+++ b/src/Control/Carrier/Error/Either.hs
@@ -19,6 +19,7 @@ import Control.Algebra
 import Control.Applicative (Alternative(..))
 import Control.Effect.Error
 import Control.Monad (MonadPlus)
+import Control.Monad.Catch
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -44,7 +45,7 @@ runError (ErrorC m) = runExceptT m
 
 -- | @since 0.1.0.0
 newtype ErrorC e m a = ErrorC (ExceptT e m a)
-  deriving (Algebra (Error e :+: sig), Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans)
+  deriving (Algebra (Error e :+: sig), Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadTrans, MonadCatch, MonadMask, MonadThrow)
 
 -- | 'ErrorC' passes 'Alternative' operations along to the underlying monad @m@, rather than combining errors à la 'ExceptT'.
 instance (Alternative m, Monad m) => Alternative (ErrorC e m) where

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -29,6 +29,8 @@ import Control.Algebra
 import Control.Applicative (Alternative)
 import Control.Carrier.State.Strict
 import Control.Monad (MonadPlus)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -87,7 +89,7 @@ runInterpretState handler state m
 
 -- | @since 1.0.0.0
 newtype InterpretC s (sig :: (Type -> Type) -> (Type -> Type)) m a = InterpretC { runInterpretC :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadCatch, MonadMask, MonadThrow, MonadUnliftIO)
 
 instance MonadTrans (InterpretC s sig) where
   lift = InterpretC

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -16,9 +16,11 @@ import Control.Algebra
 import Control.Applicative (Alternative)
 import Control.Effect.Lift
 import Control.Monad (MonadPlus)
+import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 
 -- | Extract a 'Lift'ed 'Monad'ic action from an effectful computation.
@@ -30,7 +32,7 @@ runM (LiftC m) = m
 
 -- | @since 1.0.0.0
 newtype LiftC m a = LiftC (m a)
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadUnliftIO, MonadThrow, MonadCatch, MonadMask)
 
 instance MonadTrans LiftC where
   lift = LiftC

--- a/src/Control/Carrier/State/Strict.hs
+++ b/src/Control/Carrier/State/Strict.hs
@@ -26,10 +26,13 @@ import Control.Algebra
 import Control.Applicative (Alternative(..))
 import Control.Effect.State
 import Control.Monad (MonadPlus)
+import Control.Monad.Catch
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.State.Strict (StateT(..))
+import Data.Tuple (swap)
 
 -- | Run a 'State' effect starting from the passed value.
 --
@@ -47,6 +50,12 @@ import Control.Monad.Trans.Class
 runState :: s -> StateC s m a -> m (s, a)
 runState s (StateC runStateC) = runStateC s
 {-# INLINE[3] runState #-}
+
+toStateT :: Monad m => StateC s m a -> StateT s m a
+toStateT (StateC m) = StateT (fmap (fmap swap) m)
+
+fromStateT :: Monad m => StateT s m a -> StateC s m a
+fromStateT (StateT m) = StateC (fmap (fmap swap) m)
 
 -- | Run a 'State' effect, yielding the result value and discarding the final state.
 --
@@ -125,3 +134,25 @@ instance Algebra sig m => Algebra (State s :+: sig) (StateC s m) where
     L (Put s) -> pure (s, ctx)
     R other   -> thread (uncurry runState ~<~ hdl) other (s, ctx)
   {-# INLINE alg #-}
+
+instance MonadThrow m => MonadThrow (StateC s m) where
+  throwM = fromStateT . throwM
+  {-# INLINE throwM #-}
+
+instance MonadCatch m => MonadCatch (StateC s m) where
+  catch m f = fromStateT (catch (toStateT m) (toStateT . f))
+  {-# INLINE catch #-}
+
+instance MonadMask m => MonadMask (StateC s m) where
+  mask f = fromStateT (mask (\restore -> toStateT (f (fromStateT . restore . toStateT))))
+  {-# INLINE mask #-}
+
+  uninterruptibleMask f = fromStateT (uninterruptibleMask (\restore -> toStateT (f (fromStateT . restore . toStateT))))
+  {-# INLINE uninterruptibleMask #-}
+
+  generalBracket acquire release inner = fromStateT (generalBracket acquire' release' inner')
+    where
+      acquire' = toStateT acquire
+      release' = fmap (fmap toStateT) release
+      inner' = fmap toStateT inner
+  {-# INLINE generalBracket #-}

--- a/src/Control/Carrier/Throw/Either.hs
+++ b/src/Control/Carrier/Throw/Either.hs
@@ -20,6 +20,7 @@ import Control.Applicative (Alternative)
 import Control.Carrier.Error.Either
 import Control.Effect.Throw
 import Control.Monad (MonadPlus)
+import Control.Monad.Catch
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -32,7 +33,7 @@ runThrow (ThrowC m) = runError m
 
 -- | @since 1.0.0.0
 newtype ThrowC e m a = ThrowC { runThrowC :: ErrorC e m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans, MonadCatch, MonadMask, MonadThrow)
 
 instance Algebra sig m => Algebra (Throw e :+: sig) (ThrowC e m) where
   alg hdl sig ctx = case sig of

--- a/src/Control/Carrier/Writer/Strict.hs
+++ b/src/Control/Carrier/Writer/Strict.hs
@@ -27,6 +27,7 @@ import Control.Applicative (Alternative)
 import Control.Carrier.State.Strict
 import Control.Effect.Writer
 import Control.Monad (MonadPlus)
+import Control.Monad.Catch
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
@@ -58,7 +59,7 @@ execWriter = fmap fst . runWriter
 --
 -- @since 1.0.0.0
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans, MonadCatch, MonadThrow, MonadMask)
 
 instance (Monoid w, Algebra sig m) => Algebra (Writer w :+: sig) (WriterC w m) where
   alg hdl sig ctx = WriterC $ case sig of


### PR DESCRIPTION
An implementation of the suggestion in https://github.com/fused-effects/fused-effects/issues/404. I also added MonadUnliftIO as the same argument applies, and it has an even lighter dependency footprint.