### PR TITLE
Streamline the tests’ & examples’ dependencies

### DIFF
--- a/examples/Inference.hs
+++ b/examples/Inference.hs
@@ -14,8 +14,7 @@ import           Control.Carrier.Reader
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import           Utils
 
 example :: TestTree
 example = testGroup "inference"

--- a/examples/Labelled.hs
+++ b/examples/Labelled.hs
@@ -12,8 +12,7 @@ import           Control.Effect.Labelled
 import qualified Control.Effect.Reader.Labelled as L
 import qualified Control.Effect.State.Labelled as L
 import           Hedgehog
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import           Utils
 
 sample :: ( HasLabelled "fore" (Reader Int) sig m
           , HasLabelled "aft" (Reader Int) sig m

--- a/examples/Labelled.hs
+++ b/examples/Labelled.hs
@@ -11,8 +11,9 @@ import           Control.Carrier.State.Strict
 import           Control.Effect.Labelled
 import qualified Control.Effect.Reader.Labelled as L
 import qualified Control.Effect.State.Labelled as L
+import           Hedgehog
 import           Test.Tasty
-import           Test.Tasty.HUnit
+import           Test.Tasty.Hedgehog
 
 sample :: ( HasLabelled "fore" (Reader Int) sig m
           , HasLabelled "aft" (Reader Int) sig m
@@ -34,9 +35,12 @@ numerically = liftA2 (+) (L.ask @1) (L.ask @2)
 
 readerExamples :: TestTree
 readerExamples = testGroup "Reader"
-  [ testCase "runUnderLabel"           (run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" sample)))) @=? 15)
-  , testCase "Reader.Labelled helpers" (run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" withHelpers)))) @=? 15)
-  , testCase "Nat labels"              (run (runReader (5 :: Int) (runLabelled @1 (runReader (10 :: Int) (runLabelled @2 numerically)))) @=? 15)
+  [ testProperty "runUnderLabel" . property $
+    run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" sample)))) === 15
+  , testProperty "Reader.Labelled helpers" . property $
+    run (runReader (5 :: Int) (runLabelled @"fore" (runReader (10 :: Int) (runLabelled @"aft" withHelpers)))) === 15
+  , testProperty "Nat labels" . property $
+    run (runReader (5 :: Int) (runLabelled @1 (runReader (10 :: Int) (runLabelled @2 numerically)))) === 15
   ]
 
 sampleS :: ( HasLabelled "fore" (State Int) sig m
@@ -59,9 +63,12 @@ boolean = liftA2 (+) (L.get @'True) (L.get @'False)
 
 stateExamples :: TestTree
 stateExamples = testGroup "State"
-  [ testCase "runUnderLabel"          (run (evalState (5 :: Int) (runLabelled @"fore" (evalState (10 :: Int) (runLabelled @"aft" sampleS)))) @=? 15)
-  , testCase "State.Labelled helpers" (run (evalState (5 :: Int) (runLabelled @"fore" (evalState (10 :: Int) (runLabelled @"aft" helpersS)))) @=? 15)
-  , testCase "Boolean labels"         (run (evalState (5 :: Int) (runLabelled @'True (evalState (10 :: Int) (runLabelled @'False boolean)))) @=? 15)
+  [ testProperty "runUnderLabel" . property $
+    run (evalState (5 :: Int) (runLabelled @"fore" (evalState (10 :: Int) (runLabelled @"aft" sampleS)))) === 15
+  , testProperty "State.Labelled helpers" . property $
+    run (evalState (5 :: Int) (runLabelled @"fore" (evalState (10 :: Int) (runLabelled @"aft" helpersS)))) === 15
+  , testProperty "Boolean labels" . property $
+    run (evalState (5 :: Int) (runLabelled @'True (evalState (10 :: Int) (runLabelled @'False boolean)))) === 15
   ]
 
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -2,15 +2,16 @@ module Main
 ( main
 ) where
 
+import           Hedgehog.Main
 import qualified Inference
 import qualified Labelled
 import qualified Parser
 import qualified ReinterpretLog
 import qualified Teletype
-import Test.Tasty
+import           Utils
 
 main :: IO ()
-main = defaultMain $ testGroup "examples"
+main = defaultMain $ map checkTestTree
   [ Inference.example
   , Parser.example
   , ReinterpretLog.example

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -23,8 +23,7 @@ import           Hedgehog
 import qualified Hedgehog.Function as Fn
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import           Utils
 
 example :: TestTree
 example = testGroup "parser"

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -33,9 +33,10 @@ import Control.Carrier.Reader
 import Control.Carrier.Writer.Strict
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Kind (Type)
+import Hedgehog
 import Prelude hiding (log)
 import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty.Hedgehog
 
 --------------------------------------------------------------------------------
 -- The application
@@ -157,9 +158,9 @@ collectLogMessages = execWriter . runCollectLogMessagesC
 -- Test spec.
 example :: TestTree
 example = testGroup "reinterpret log"
-  [ testCase "reinterprets logs" $ do
-      a <- collectLogMessages . reinterpretLog renderLogMessage $ do
+  [ testProperty "reinterprets logs" . property $ do
+      a <- liftIO . collectLogMessages . reinterpretLog renderLogMessage $ do
         log (Debug "foo")
         log (Info "bar")
-      a @?= ["[debug] foo", "[info] bar"]
+      a === ["[debug] foo", "[info] bar"]
   ]

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -35,8 +35,7 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Data.Kind (Type)
 import Hedgehog
 import Prelude hiding (log)
-import Test.Tasty
-import Test.Tasty.Hedgehog
+import Utils
 
 --------------------------------------------------------------------------------
 -- The application

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -19,8 +19,7 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import           Prelude hiding (read)
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import           Utils
 
 example :: TestTree
 example = testGroup "teletype"

--- a/examples/Utils.hs
+++ b/examples/Utils.hs
@@ -1,0 +1,20 @@
+module Utils
+( module Utils
+) where
+
+import Hedgehog
+
+data TestTree
+  = Leaf String Property
+  | Branch String [TestTree]
+
+checkTestTree :: TestTree -> IO Bool
+checkTestTree t = case t of
+  Leaf   n p  ->        putStrLn n  *> check p                   <* putStrLn ""
+  Branch n ts -> and <$ putStrLn n <*> traverse checkTestTree ts <* putStrLn ""
+
+testGroup :: String -> [TestTree] -> TestTree
+testGroup = Branch
+
+testProperty :: String -> Property -> TestTree
+testProperty = Leaf

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -162,8 +162,6 @@ test-suite test
     , hedgehog           ^>= 1
     , hedgehog-fn        ^>= 1
     , inspection-testing ^>= 0.4
-    , tasty              ^>= 1.2
-    , tasty-hedgehog     ^>= 1
     , transformers
 
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -165,7 +165,6 @@ test-suite test
     , inspection-testing ^>= 0.4
     , tasty              ^>= 1.2
     , tasty-hedgehog     ^>= 1
-    , tasty-hunit        ^>= 0.10
     , transformers
 
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -127,7 +127,6 @@ test-suite examples
     , hedgehog-fn        ^>= 1
     , tasty              ^>= 1.2
     , tasty-hedgehog     ^>= 1
-    , tasty-hunit        ^>= 0.10
 
 
 test-suite test

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -120,13 +120,12 @@ test-suite examples
     Parser
     ReinterpretLog
     Teletype
+    Utils
   build-depends:
     , base
     , fused-effects
     , hedgehog           ^>= 1
     , hedgehog-fn        ^>= 1
-    , tasty              ^>= 1.2
-    , tasty-hedgehog     ^>= 1
 
 
 test-suite test

--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -9,8 +9,6 @@ module Catch
 
 import Control.Effect.Error
 import Gen
-import Test.Tasty
-import Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Catch"

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -14,8 +14,6 @@ import           Data.List.NonEmpty
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Choose"

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -19,8 +19,6 @@ import           Gen
 import qualified Monad
 import qualified MonadFix
 import qualified NonDet
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Cull"

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -22,8 +22,6 @@ import qualified Monad
 import qualified MonadFix
 import qualified NonDet
 import qualified Reader
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Cut"

--- a/test/Cut/Church.hs
+++ b/test/Cut/Church.hs
@@ -6,8 +6,7 @@ module Cut.Church
 import Control.Carrier.Cut.Church
 import Control.Effect.Reader
 import Hedgehog
-import Test.Tasty
-import Test.Tasty.Hedgehog
+import Gen
 
 tests :: TestTree
 tests = testGroup "Cut.Church"

--- a/test/Cut/Church.hs
+++ b/test/Cut/Church.hs
@@ -5,13 +5,14 @@ module Cut.Church
 
 import Control.Carrier.Cut.Church
 import Control.Effect.Reader
+import Hedgehog
 import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Cut.Church"
-  [ testCase "cutfail operates through higher-order effects" $
+  [ testProperty "cutfail operates through higher-order effects" . property $
     runCutA @[] (local (id @()) cutfail <|> pure 'a') ()
-    @?=
+    ===
     runCutA @[] (cutfail <|> pure 'a') ()
   ]

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -18,8 +18,6 @@ import           Data.Maybe (maybeToList)
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Empty"

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -18,7 +18,6 @@ import           Data.Semigroup as S ((<>))
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
 import qualified Throw
 
 tests :: TestTree

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -15,8 +15,6 @@ import           Gen
 import           Hedgehog.Range as Range
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Fail"

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -15,8 +15,6 @@ import           Gen
 import qualified Hedgehog.Range as R
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Fresh"

--- a/test/Fusion.hs
+++ b/test/Fusion.hs
@@ -9,10 +9,9 @@ module Fusion
 import Control.Algebra
 import Control.Carrier.Error.Either
 import Control.Carrier.State.Strict
+import Gen
 import Hedgehog
 import Test.Inspection as Inspection hiding (property, (===))
-import Test.Tasty
-import Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "fusion"

--- a/test/Fusion.hs
+++ b/test/Fusion.hs
@@ -9,24 +9,25 @@ module Fusion
 import Control.Algebra
 import Control.Carrier.Error.Either
 import Control.Carrier.State.Strict
-import Test.Inspection as Inspection
+import Hedgehog
+import Test.Inspection as Inspection hiding (property, (===))
 import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "fusion"
-  [ testCase "eliminates StateCs" $
+  [ testProperty "eliminates StateCs" . property $
     failureOf $(inspectTest $ 'countDown `doesNotUse` ''StateC)
-    @?= Nothing
-  , testCase "eliminates nested StateCs" $
+    === Nothing
+  , testProperty "eliminates nested StateCs" . property $
     failureOf $(inspectTest $ 'countBoth `doesNotUse` ''StateC)
-    @?= Nothing
-  , testCase "eliminates catch and throw" $
+    === Nothing
+  , testProperty "eliminates catch and throw" . property $
     failureOf $(inspectTest $ 'throwing `doesNotUse` ''ErrorC)
-    @?= Nothing
-  , testCase "eliminates calls to alg" $
+    === Nothing
+  , testProperty "eliminates calls to alg" . property $
     failureOf $(inspectTest $ 'countDown `doesNotUse` 'alg)
-    @?= Nothing
+    === Nothing
   ]
 
 

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -316,8 +316,8 @@ data TestTree
 
 checkTestTree :: TestTree -> IO Bool
 checkTestTree = \case
-  Leaf   n p  -> putStrLn n >> check p
-  Branch n ts -> putStrLn n >> and <$> traverse checkTestTree ts
+  Leaf   n p  ->        putStrLn n  *> check p                   <* putStrLn ""
+  Branch n ts -> and <$ putStrLn n <*> traverse checkTestTree ts <* putStrLn ""
 
 testGroup :: String -> [TestTree] -> TestTree
 testGroup = Branch

--- a/test/Lift.hs
+++ b/test/Lift.hs
@@ -6,9 +6,8 @@ import           Control.Carrier.State.Strict
 import           Control.Effect.Lift
 import qualified Control.Exception as E
 import           Control.Monad.IO.Class
+import           Gen
 import           Hedgehog
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Lift"

--- a/test/Lift.hs
+++ b/test/Lift.hs
@@ -6,16 +6,17 @@ import           Control.Carrier.State.Strict
 import           Control.Effect.Lift
 import qualified Control.Exception as E
 import           Control.Monad.IO.Class
+import           Hedgehog
 import           Test.Tasty
-import           Test.Tasty.HUnit
+import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Lift"
-  [ testCase "liftWith" $ do
+  [ testProperty "liftWith" . property $ do
     r <- liftIO . runState "yep" $ handle (put . getMsg) $ do
       modify ("heck " ++)
       liftIO (E.throwIO (E.AssertionFailed "nope"))
-    r @?= ("nope", ())
+    r === ("nope", ())
   ] where
   getMsg (E.AssertionFailed msg) = msg
 

--- a/test/Monad.hs
+++ b/test/Monad.hs
@@ -9,8 +9,6 @@ module Monad
 
 import Control.Monad (ap, (>=>))
 import Gen
-import Test.Tasty
-import Test.Tasty.Hedgehog
 
 test
   :: (Monad m, Arg a, Arg b, Eq (g a), Eq (g b), Eq (g c), Show a, Show b, Show (g a), Show (g b), Show (g c), Vary a, Vary b, Functor f)

--- a/test/MonadFix.hs
+++ b/test/MonadFix.hs
@@ -10,8 +10,6 @@ module MonadFix
 import Control.Monad (liftM)
 import Control.Monad.Fix
 import Gen
-import Test.Tasty
-import Test.Tasty.Hedgehog
 
 test
   :: (MonadFix m, Arg a, Eq (g a), Eq (g b), Functor f, Show a, Show (g a), Show (g b), Vary a)

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -21,8 +21,6 @@ import qualified Empty
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "NonDet"

--- a/test/NonDet/Church.hs
+++ b/test/NonDet/Church.hs
@@ -5,24 +5,25 @@ module NonDet.Church
 import Control.Carrier.Error.Either
 import Control.Carrier.NonDet.Church
 import Control.Carrier.State.Strict hiding (state)
+import Hedgehog
 import Prelude hiding (error)
 import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "NonDet.Church"
-  [ testCase "collects results of effects run inside it" $
+  [ testProperty "collects results of effects run inside it" . property $
     run (runNonDetA (runState 'a' state))
-    @?= [('a', 'z'), ('b', 'b'), ('a', 'a')]
-  , testCase "collapses results of effects run outside it" $
+    === [('a', 'z'), ('b', 'b'), ('a', 'a')]
+  , testProperty "collapses results of effects run outside it" . property $
     run (runState 'a' (runNonDetA state))
-    @?= ('b', "zbb")
-  , testCase "collects results from higher-order effects run inside it" $
+    === ('b', "zbb")
+  , testProperty "collects results from higher-order effects run inside it" . property $
     run (runNonDetA (runError error))
-    @?= [Right 'z', Right 'a' :: Either Char Char]
-  , testCase "collapses results of higher-order effects run outside it" $
+    === [Right 'z', Right 'a' :: Either Char Char]
+  , testProperty "collapses results of higher-order effects run outside it" . property $
     run (runError (runNonDetA error))
-    @?= (Right "a" :: Either Char String)
+    === (Right "a" :: Either Char String)
   ]
 
 state :: (Alternative m, Has (State Char) sig m) => m Char

--- a/test/NonDet/Church.hs
+++ b/test/NonDet/Church.hs
@@ -5,10 +5,9 @@ module NonDet.Church
 import Control.Carrier.Error.Either
 import Control.Carrier.NonDet.Church
 import Control.Carrier.State.Strict hiding (state)
+import Gen
 import Hedgehog
 import Prelude hiding (error)
-import Test.Tasty
-import Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "NonDet.Church"

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -22,8 +22,6 @@ import           Gen
 import           GHC.Generics ((:.:)(..))
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Reader"

--- a/test/State.hs
+++ b/test/State.hs
@@ -26,8 +26,6 @@ import           Data.Tuple (swap)
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "State"

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -12,17 +12,18 @@ import qualified Error
 import qualified Fail
 import qualified Fresh
 import qualified Fusion
+import           Hedgehog (checkParallel)
+import           Hedgehog.Main
 import qualified Lift
 import qualified NonDet
 import qualified NonDet.Church
 import qualified Reader
 import qualified State
-import           Test.Tasty
 import qualified Throw
 import qualified Writer
 
 main :: IO ()
-main = defaultMain $ testGroup "unit tests"
+main = defaultMain $ map checkParallel
   [ Catch.tests
   , Choose.tests
   , Cull.tests

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -12,7 +12,7 @@ import qualified Error
 import qualified Fail
 import qualified Fresh
 import qualified Fusion
-import           Hedgehog (checkParallel)
+import           Gen
 import           Hedgehog.Main
 import qualified Lift
 import qualified NonDet
@@ -23,7 +23,7 @@ import qualified Throw
 import qualified Writer
 
 main :: IO ()
-main = defaultMain $ map checkParallel
+main = defaultMain $ map checkTestTree
   [ Catch.tests
   , Choose.tests
   , Cull.tests

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -15,8 +15,6 @@ import           Control.Effect.Throw
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Throw"

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -31,8 +31,6 @@ import           Data.Tuple (swap)
 import           Gen
 import qualified Monad
 import qualified MonadFix
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
 
 tests :: TestTree
 tests = testGroup "Writer"


### PR DESCRIPTION
This PR streamlines the dependencies of the tests & examples by moving us off of `tasty`, `tasty-hedgehog`, & `tasty-hunit` and just using `hedgehog` for test running/organization.

Reducing our dependency footprint should make maintenance a bit simpler as major compiler versions are released (cf #409).