### PR TITLE
Instances for Choosing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+- Defines, `Algebra`, `Alternative`, `Applicative`, `Foldable`, `Functor`, `Monad`, `MonadFail`, `MonadFix`, `MonadIO`, `MonadPlus`, `MonadTrans`, `MonadZip`, and `Traversable` instances for `Control.Effect.Choose.Choosing`. ([#419](https://github.com/fused-effects/fused-effects/pull/419))
+
 # v1.1.1.2
 
 - Adds support for `ghc` 9.2.1 and `base` 4.16.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
   - Defines `Algebra` instances for the two mentioned carriers,
     and for `Control.Monad.Trans.Accum` from `transformers`
 
-- Defines, `Algebra`, `Alternative`, `Applicative`, `Foldable`, `Functor`, `Monad`, `MonadFail`, `MonadFix`, `MonadIO`, `MonadPlus`, `MonadTrans`, `MonadZip`, and `Traversable` instances for `Control.Effect.Choose.Choosing`. ([#419](https://github.com/fused-effects/fused-effects/pull/419))
+- Defines, `Algebra`, `Alternative`, `Applicative`, `Foldable`, `Functor`, `Monad`, `MonadFail`, `MonadFix`, `MonadIO`, `MonadPlus`, `MonadTrans`, `MonadUnliftIO`, `MonadZip`, and `Traversable` instances for `Control.Effect.Choose.Choosing`. ([#419](https://github.com/fused-effects/fused-effects/pull/419))
 
 
 # v1.1.1.2

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -35,6 +35,7 @@ import           Control.Effect.Choose.Internal (Choose(..))
 import           Control.Effect.Empty
 import           Control.Monad (MonadPlus)
 import           Control.Monad.Fail as Fail
+import           Control.Monad.Fix
 import           Data.Bool (bool)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Semigroup as S
@@ -111,7 +112,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail)
+  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail, MonadFix)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -33,6 +33,7 @@ import           Control.Algebra
 import qualified Control.Applicative as A
 import           Control.Effect.Choose.Internal (Choose(..))
 import           Control.Effect.Empty
+import           Control.Monad (MonadPlus)
 import           Data.Bool (bool)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Semigroup as S
@@ -125,3 +126,5 @@ instance (Has Choose sig m, Has Empty sig m) => Monoid (Choosing m a) where
 instance (Has Choose sig m, Has Empty sig m) => A.Alternative (Choosing m) where
   empty = mempty
   (<|>) = mappend
+
+instance (Has Choose sig m, Has Empty sig m) => MonadPlus (Choosing m)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -34,6 +34,7 @@ import qualified Control.Applicative as A
 import           Control.Effect.Choose.Internal (Choose(..))
 import           Control.Effect.Empty
 import           Control.Monad (MonadPlus)
+import           Control.Monad.Fail as Fail
 import           Data.Bool (bool)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Semigroup as S
@@ -110,7 +111,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Algebra sig, Applicative, Functor, Monad)
+  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -139,6 +139,7 @@ instance (Has Choose sig m, Has Empty sig m) => MonadPlus (Choosing m)
 
 instance MonadTrans Choosing where
   lift = Choosing
+  {-# INLINE lift #-}
 
 instance Traversable m => Traversable (Choosing m) where
   sequenceA (Choosing m) = fmap Choosing (sequenceA m)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -30,6 +30,7 @@ module Control.Effect.Choose
 ) where
 
 import           Control.Algebra
+import qualified Control.Applicative as A
 import           Control.Effect.Choose.Internal (Choose(..))
 import           Control.Effect.Empty
 import           Data.Bool (bool)
@@ -120,3 +121,7 @@ instance (Has Choose sig m, Has Empty sig m) => Monoid (Choosing m a) where
 
   mappend = (S.<>)
   {-# INLINE mappend #-}
+
+instance (Has Choose sig m, Has Empty sig m) => A.Alternative (Choosing m) where
+  empty = mempty
+  (<|>) = mappend

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -129,7 +129,10 @@ instance (Has Choose sig m, Has Empty sig m) => Monoid (Choosing m a) where
 
 instance (Has Choose sig m, Has Empty sig m) => A.Alternative (Choosing m) where
   empty = mempty
+  {-# INLINE empty #-}
+
   (<|>) = mappend
+  {-# INLINE (<|>) #-}
 
 instance (Has Choose sig m, Has Empty sig m) => MonadPlus (Choosing m)
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -108,7 +108,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Applicative, Functor, Monad)
+  deriving (Algebra sig, Applicative, Functor, Monad)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- | An effect modelling nondeterminism without failure (one or more successful results).
@@ -107,6 +108,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
+  deriving (Applicative, Functor, Monad)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -37,6 +37,7 @@ import           Control.Monad (MonadPlus)
 import           Control.Monad.Fail as Fail
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class (MonadIO)
+import           Control.Monad.IO.Unlift (MonadUnliftIO)
 import           Control.Monad.Trans.Class (MonadTrans(..))
 import           Control.Monad.Zip
 import           Data.Bool (bool)
@@ -115,7 +116,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Algebra sig, Applicative, Foldable, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadZip)
+  deriving (Algebra sig, Applicative, Foldable, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadUnliftIO, MonadZip)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -38,6 +38,7 @@ import           Control.Monad.Fail as Fail
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Class (MonadTrans(..))
+import           Control.Monad.Zip
 import           Data.Bool (bool)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Semigroup as S
@@ -114,7 +115,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)
+  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadZip)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -139,3 +139,16 @@ instance (Has Choose sig m, Has Empty sig m) => MonadPlus (Choosing m)
 
 instance MonadTrans Choosing where
   lift = Choosing
+
+instance Traversable m => Traversable (Choosing m) where
+  sequenceA (Choosing m) = fmap Choosing (sequenceA m)
+  {-# INLINE sequenceA #-}
+
+  traverse f (Choosing m) = fmap Choosing (traverse f m)
+  {-# INLINE traverse #-}
+
+  sequence (Choosing m) = fmap Choosing (sequence m)
+  {-# INLINE sequence #-}
+
+  mapM f (Choosing m) = fmap Choosing (mapM f m)
+  {-# INLINE mapM #-}

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -36,6 +36,7 @@ import           Control.Effect.Empty
 import           Control.Monad (MonadPlus)
 import           Control.Monad.Fail as Fail
 import           Control.Monad.Fix
+import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Class (MonadTrans(..))
 import           Data.Bool (bool)
 import           Data.List.NonEmpty (NonEmpty(..))
@@ -113,7 +114,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail, MonadFix)
+  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -94,7 +94,7 @@ many a = go where go = (:) <$> a <*> go <|> pure []
 --
 -- @
 -- 'some' m = (:) '<$>' m '<*>' 'many' m
--- @-
+-- @
 --
 -- @since 1.0.0.0
 some :: Has Choose sig m => m a -> m [a]

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -94,7 +94,7 @@ many a = go where go = (:) <$> a <*> go <|> pure []
 --
 -- @
 -- 'some' m = (:) '<$>' m '<*>' 'many' m
--- @
+-- @-
 --
 -- @since 1.0.0.0
 some :: Has Choose sig m => m a -> m [a]
@@ -115,7 +115,7 @@ some1 a = (:|) <$> a <*> many a
 
 -- | @since 1.0.0.0
 newtype Choosing m a = Choosing { getChoosing :: m a }
-  deriving (Algebra sig, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadZip)
+  deriving (Algebra sig, Applicative, Foldable, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadZip)
 
 instance Has Choose sig m => S.Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -36,6 +36,7 @@ import           Control.Effect.Empty
 import           Control.Monad (MonadPlus)
 import           Control.Monad.Fail as Fail
 import           Control.Monad.Fix
+import           Control.Monad.Trans.Class (MonadTrans(..))
 import           Data.Bool (bool)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Semigroup as S
@@ -130,3 +131,6 @@ instance (Has Choose sig m, Has Empty sig m) => A.Alternative (Choosing m) where
   (<|>) = mappend
 
 instance (Has Choose sig m, Has Empty sig m) => MonadPlus (Choosing m)
+
+instance MonadTrans Choosing where
+  lift = Choosing


### PR DESCRIPTION
This PR defines/derives a number of instances for `Control.Effect.Choose.Choosing`.

These instances, much like the similar ones for `Alt` and `Ap`, allow us to build values in `Choosing` using effect operators directly, rather than requiring that the operators be wrapped in `Choosing` constructions manually.