### PR TITLE
Add MonadUnliftIO instances for eligible carrier types.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# v1.1.2.0
+
+- Adds `MonadUnliftIO` instances for `ReaderC`, `LiftC`, and `InterpretC`.
+
 # v1.1.1.2
 
 - Adds support for `ghc` 9.2.1 and `base` 4.16.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # v1.1.2.0
 
-- Adds `MonadUnliftIO` instances for `ReaderC`, `LiftC`, and `InterpretC`.
+- Adds `MonadUnliftIO` instances for `ReaderC`, `LiftC`, and `InterpretC`. ([#420](https://github.com/fused-effects/fused-effects/pull/420))
 
 # v1.1.1.2
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,3 @@
-# v1.1.2.0
-
 - Adds `MonadUnliftIO` instances for `ReaderC`, `LiftC`, and `InterpretC`. ([#420](https://github.com/fused-effects/fused-effects/pull/420))
 
 # v1.1.1.2

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -112,6 +112,7 @@ library
   build-depends:
       base          >= 4.9 && < 4.17
     , transformers  >= 0.4 && < 0.6
+    , unliftio-core >= 0.2 && < 0.3
 
 
 test-suite examples

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -33,6 +33,7 @@ import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Functor.Const (Const(..))
 import Data.Kind (Type)
 import Unsafe.Coerce (unsafeCoerce)
@@ -87,7 +88,7 @@ runInterpretState handler state m
 
 -- | @since 1.0.0.0
 newtype InterpretC s (sig :: (Type -> Type) -> (Type -> Type)) m a = InterpretC { runInterpretC :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadUnliftIO)
 
 instance MonadTrans (InterpretC s sig) where
   lift = InterpretC

--- a/src/Control/Carrier/Lift.hs
+++ b/src/Control/Carrier/Lift.hs
@@ -20,6 +20,7 @@ import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 
 -- | Extract a 'Lift'ed 'Monad'ic action from an effectful computation.
 --
@@ -30,7 +31,7 @@ runM (LiftC m) = m
 
 -- | @since 1.0.0.0
 newtype LiftC m a = LiftC (m a)
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadUnliftIO)
 
 instance MonadTrans LiftC where
   lift = LiftC

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -101,8 +101,5 @@ instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
   {-# INLINE alg #-}
 
 instance MonadUnliftIO m => MonadUnliftIO (ReaderC r m) where
+  withRunInIO inner = ReaderC $ \ r -> withRunInIO $ \ run -> inner (run . runReader r)
   {-# INLINE withRunInIO #-}
-  withRunInIO inner =
-    ReaderC $ \r ->
-    withRunInIO $ \run ->
-    inner (run . runReader r)

--- a/src/Control/Carrier/Reader.hs
+++ b/src/Control/Carrier/Reader.hs
@@ -24,6 +24,7 @@ import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
+import Control.Monad.IO.Unlift
 
 -- | Run a 'Reader' effect with the passed environment value.
 --
@@ -98,3 +99,10 @@ instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
     L (Local f m) -> runReader (f r) (hdl (m <$ ctx))
     R other       -> alg (runReader r . hdl) other ctx
   {-# INLINE alg #-}
+
+instance MonadUnliftIO m => MonadUnliftIO (ReaderC r m) where
+  {-# INLINE withRunInIO #-}
+  withRunInIO inner =
+    ReaderC $ \r ->
+    withRunInIO $ \run ->
+    inner (run . runReader r)


### PR DESCRIPTION
As per @shinzui and @ocharles's request, and given that `unliftio-core` has a
very small dependency footprint, we've decided to add `MonadUnliftIO` instances.

/hattip @ocharles for demonstrating that `InterpretC` supports this in #406.