### PR TITLE
Always run the checkout step in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: haskell/actions/setup@v1
       name: Setup Haskell


### PR DESCRIPTION
This was failing because it was keyed to `master`, not `main`, but I can't think
of a situation where we _wouldn't_ want to check out the repo, so I just nixed
the conditional entirely.