### PR TITLE
Support GHC 9.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.2", "8.4", "8.6", "8.8", "8.10", "9.0", "9.2"]
+        ghc: ["8.2", "8.4", "8.6", "8.8", "8.10", "9.0", "9.2", "9.4"]
 
     steps:
     - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@968e175ff94d685b6ce0bb39b02447cca8b4a6bb
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+- Support GHC 9.4.
+
 # v1.1.2.0
 
 - Adds `MonadUnliftIO` instances for `ReaderC`, `LiftC`, and `InterpretC`. ([#420](https://github.com/fused-effects/fused-effects/pull/420))

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -24,6 +24,7 @@ tested-with:
   GHC == 8.10.4
   GHC == 9.0.1
   GHC == 9.2.1
+  GHC == 9.4.2
 
 common common
   default-language: Haskell2010
@@ -116,7 +117,7 @@ library
     Control.Effect.Throw.Internal
     Control.Effect.Writer.Internal
   build-depends:
-      base          >= 4.9 && < 4.17
+      base          >= 4.9 && < 4.18
     , transformers  >= 0.4 && < 0.6
     , unliftio-core >= 0.2 && < 0.3
 

--- a/test/Accum.hs
+++ b/test/Accum.hs
@@ -60,14 +60,14 @@ test
   -> Run ((,) w) ((,) w) m
   -> [TestTree]
 test m a w (Run runAccum) =
-  [ testProperty "look returns the log variable (simple)" . forall (w :. Nil) $
+  [ testProperty "look returns the log variable (simple)" . forall_ (w :. Nil) $
     \ w -> runAccum (w, look) === Identity (mempty, w)
-  , testProperty "add appends to the log variable (simple)" . forall (w :. w :. Nil) $
+  , testProperty "add appends to the log variable (simple)" . forall_ (w :. w :. Nil) $
     \ w0 w -> runAccum (w0, add w) === Identity (w, ())
-  , testProperty "look returns the log variable (continuation)" . forall (w :. fn (m a) :. Nil) $
+  , testProperty "look returns the log variable (continuation)" . forall_ (w :. fn (m a) :. Nil) $
     \ w0 k -> runAccum (w0, look >>= k) === runAccum (w0, k w0)
-  , testProperty "add appends to the log variable and alters the environment for look" . forall (w :. w :. Nil) $
+  , testProperty "add appends to the log variable and alters the environment for look" . forall_ (w :. w :. Nil) $
     \ w0 w -> runAccum (w0, add w >> look) === runAccum (mappend w0 w, look @w <* add w)
-  , testProperty "add appends to the log variable and alters the environment for continuations" . forall (w :. w :. m a :. Nil) $
+  , testProperty "add appends to the log variable and alters the environment for continuations" . forall_ (w :. w :. m a :. Nil) $
     \ w0 w k -> runAccum (w0, add w >> k) === (first (mappend w) <$> runAccum (mappend w0 w, k))
   ]

--- a/test/Catch.hs
+++ b/test/Catch.hs
@@ -35,6 +35,6 @@ test
   -> Run f (Either e) m
   -> [TestTree]
 test e m a _ i (Run runCatch) =
-  [ testProperty "catchError intercepts throwError" . forall (i :. e :. fn (m a) :. Nil) $
+  [ testProperty "catchError intercepts throwError" . forall_ (i :. e :. fn (m a) :. Nil) $
     \ i e h -> runCatch ((throwError e `catchError` h) <$ i) === runCatch (h e <$ i)
   ]

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -43,8 +43,8 @@ test
   -> Run f [] m
   -> [TestTree]
 test m a b i (Run runChoose) =
-  [ testProperty ">>= distributes over <|>" . forall (i :. m a :. m a :. fn (m b) :. Nil) $
+  [ testProperty ">>= distributes over <|>" . forall_ (i :. m a :. m a :. fn (m b) :. Nil) $
     \ i m n k -> runChoose (((m <|> n) >>= k) <$ i) === runChoose (((m >>= k) <|> (n >>= k)) <$ i)
-  , testProperty "<|> is associative" . forall (i :. m a :. m a :. m a :. Nil) $
+  , testProperty "<|> is associative" . forall_ (i :. m a :. m a :. m a :. Nil) $
     \ i m n o -> runChoose (((m <|> n) <|> o) <$ i) === runChoose ((m <|> (n <|> o)) <$ i)
   ]

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -50,6 +50,6 @@ test
   -> Run f [] m
   -> [TestTree]
 test m a b i (Run runCull)
-  = testProperty "cull returns at most one success" (forall (i :. a :. m a :. m a :. Nil)
+  = testProperty "cull returns at most one success" (forall_ (i :. a :. m a :. m a :. Nil)
     (\ i a m n -> runCull ((cull (pure a <|> m) <|> n) <$ i) === runCull ((pure a <|> n) <$ i)))
   : NonDet.test m a b i (Run runCull)

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -59,11 +59,11 @@ test
   -> Run f [] m
   -> [TestTree]
 test hom m = (\ a _ i (Run runCut) ->
-  [ testProperty "cutfail annihilates >>=" (forall (i :. fn @a (m a) :. Nil)
+  [ testProperty "cutfail annihilates >>=" (forall_ (i :. fn @a (m a) :. Nil)
     (\ i k -> runCut ((hom cutfail >>= k) <$ i) === runCut (hom cutfail <$ i)))
-  , testProperty "cutfail annihilates <|>" (forall (i :. m a :. Nil)
+  , testProperty "cutfail annihilates <|>" (forall_ (i :. m a :. Nil)
     (\ i m -> runCut ((hom cutfail <|> m) <$ i) === runCut (hom cutfail <$ i)))
-  , testProperty "call delimits cutfail" (forall (i :. m a :. Nil)
+  , testProperty "call delimits cutfail" (forall_ (i :. m a :. Nil)
     (\ i m -> runCut ((hom (call (hom cutfail)) <|> m) <$ i) === runCut (m <$ i)))
   ])
   S.<> NonDet.test m

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -54,6 +54,6 @@ test
   -> Run f [] m
   -> [TestTree]
 test m _ b i (Run runEmpty) =
-  [ testProperty "empty annihilates >>=" . forall (i :. fn @a (m b) :. Nil) $
+  [ testProperty "empty annihilates >>=" . forall_ (i :. fn @a (m b) :. Nil) $
     \ i k -> runEmpty ((empty >>= k) <$ i) === runEmpty (empty <$ i)
   ]

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -46,6 +46,6 @@ test
   -> Run f (Either String) m
   -> [TestTree]
 test msg m _ b i (Run runFail) =
-  [ testProperty "fail annihilates >>=" . forall (i :. msg :. fn @a (m b) :. Nil) $
+  [ testProperty "fail annihilates >>=" . forall_ (i :. msg :. fn @a (m b) :. Nil) $
     \ i s k -> runFail ((Fail.fail s >>= k) <$ i) === runFail (Fail.fail s <$ i)
   ]

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -48,6 +48,6 @@ test
   -> Run f ((,) Int) m
   -> [TestTree]
 test m a i (Run runFresh) =
-  [ testProperty "fresh yields unique values" . forall (i :. m a :. Nil) $
+  [ testProperty "fresh yields unique values" . forall_ (i :. m a :. Nil) $
     \ i m -> runFresh ((m >> fresh) <$ i) /== runFresh ((m >> fresh >> fresh) <$ i)
   ]

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -44,7 +44,7 @@ module Gen
 , runC
   -- * Generation
 , Rec(..)
-, forall
+, forall_
   -- * Showing generated values
 , showing
 , GenTerm
@@ -221,8 +221,8 @@ data Rec as where
   Nil :: Rec '[]
   (:.) :: a -> Rec as -> Rec (a ': as)
 
-forall :: (Forall g f, HasCallStack) => g -> f -> Hedgehog.Property
-forall g f = withFrozenCallStack $ Hedgehog.property (forall' g f)
+forall_ :: (Forall g f, HasCallStack) => g -> f -> Hedgehog.Property
+forall_ g f = withFrozenCallStack $ Hedgehog.property (forall' g f)
 
 class Forall g f | g -> f, f -> g where
   forall' :: HasCallStack => g -> f -> PropertyT IO ()

--- a/test/Monad.hs
+++ b/test/Monad.hs
@@ -20,14 +20,14 @@ test
   -> Run f g m
   -> [TestTree]
 test m a b c s (Run run) =
-  [ testProperty "return is the left-identity of >>=" . forall (s :. a :. fn (m b) :. Nil) $
+  [ testProperty "return is the left-identity of >>=" . forall_ (s :. a :. fn (m b) :. Nil) $
     \ s a k -> run ((return a >>= k) <$ s) === run (k a <$ s)
-  , testProperty "return is the right-identity of >>=" . forall (s :. m a :. Nil) $
+  , testProperty "return is the right-identity of >>=" . forall_ (s :. m a :. Nil) $
     \ s m -> run ((m >>= return) <$ s) === run (m <$ s)
-  , testProperty ">>= is associative" . forall (s :. m a :. fn (m b) :. fn (m c) :. Nil) $
+  , testProperty ">>= is associative" . forall_ (s :. m a :. fn (m b) :. fn (m c) :. Nil) $
     \ s m k h -> run ((m >>= (k >=> h)) <$ s) === run (((m >>= k) >>= h) <$ s)
-  , testProperty "return = pure" . forall (s :. a :. Nil) $
+  , testProperty "return = pure" . forall_ (s :. a :. Nil) $
     \ s a -> run (return a <$ s) === run (pure a <$ s)
-  , testProperty "ap = (<*>)" . forall (s :. fn b :. m a :. Nil) $
+  , testProperty "ap = (<*>)" . forall_ (s :. fn b :. m a :. Nil) $
     \ s f m -> run ((pure f `ap` m) <$ s) === run ((pure f <*> m) <$ s)
   ]

--- a/test/MonadFix.hs
+++ b/test/MonadFix.hs
@@ -20,12 +20,12 @@ test
   -> Run f g m
   -> [TestTree]
 test m a b s (Run run) =
-  [ testProperty "purity" . forall (s :. termFn a :. Nil) $
+  [ testProperty "purity" . forall_ (s :. termFn a :. Nil) $
     \ s h -> run (mfix (return . h) <$ s) === run (return (fix h) <$ s)
-  , testProperty "left-shrinking" . forall (s :. m a :. termFn (fn (m b)) :. Nil) $
+  , testProperty "left-shrinking" . forall_ (s :. m a :. termFn (fn (m b)) :. Nil) $
     \ s m f -> run (mfix (\ x -> m >>= \ y -> f x y) <$ s) === run ((m >>= \ y -> mfix (\ x -> f x y)) <$ s)
-  , testProperty "sliding" . forall (s :. fn b :. termFn (m a) :. Nil) $
+  , testProperty "sliding" . forall_ (s :. fn b :. termFn (m a) :. Nil) $
     \ s h f -> run (mfix (liftM h . f) <$ s) === run (liftM h (mfix (f . h)) <$ s)
-  , testProperty "nesting" . forall (s :. termFn (termFn (m a)) :. Nil) $
+  , testProperty "nesting" . forall_ (s :. termFn (termFn (m a)) :. Nil) $
     \ s f -> run (mfix (\ x -> mfix (\ y -> f x y)) <$ s) === run (mfix (\ x -> f x x) <$ s)
   ]

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -54,9 +54,9 @@ test
   -> [TestTree]
 test m
   = (\ a _ i (Run runNonDet) ->
-    [ testProperty "empty is the left identity of <|>"  (forall (i :. m a :. Nil)
+    [ testProperty "empty is the left identity of <|>"  (forall_ (i :. m a :. Nil)
       (\ i m -> runNonDet ((empty <|> m) <$ i) === runNonDet (m <$ i)))
-    ,  testProperty "empty is the right identity of <|>" (forall (i :. m a :. Nil)
+    ,  testProperty "empty is the right identity of <|>" (forall_ (i :. m a :. Nil)
       (\ i m -> runNonDet ((m <|> empty) <$ i) === runNonDet (m <$ i)))
     ])
   S.<> Empty.test  m

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -68,8 +68,8 @@ test
   -> Run (f :.: (,) r) Identity m
   -> [TestTree]
 test r m a i (Run runReader) =
-  [ testProperty "ask returns the environment variable" . forall (i :. r :. fn (m a) :. Nil) $
+  [ testProperty "ask returns the environment variable" . forall_ (i :. r :. fn (m a) :. Nil) $
     \ i r k -> runReader (Comp1 ((r, ask >>= k) <$ i)) === runReader (Comp1 ((r, k r) <$ i))
-  , testProperty "local modifies the environment variable" . forall (i :. r :. fn r :. m a :. Nil) $
+  , testProperty "local modifies the environment variable" . forall_ (i :. r :. fn r :. m a :. Nil) $
     \ i r f m -> runReader (Comp1 ((r, local f m) <$ i)) === runReader (Comp1 ((f r, m) <$ i))
   ]

--- a/test/State.hs
+++ b/test/State.hs
@@ -78,8 +78,8 @@ test
   -> Run ((,) s) ((,) s) m
   -> [TestTree]
 test m a s (Run runState) =
-  [ testProperty "get returns the state variable" . forall (s :. fn (m a) :. Nil) $
+  [ testProperty "get returns the state variable" . forall_ (s :. fn (m a) :. Nil) $
     \ s k -> runState (s, get >>= k) === runState (s, k s)
-  , testProperty "put updates the state variable" . forall (s :. s :. m a :. Nil) $
+  , testProperty "put updates the state variable" . forall_ (s :. s :. m a :. Nil) $
     \ s s' m -> runState (s, put s' >> m) === runState (s', m)
   ]

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -45,6 +45,6 @@ test
   -> Run f (Either e) m
   -> [TestTree]
 test e m _ b i (Run runThrow) =
-  [ testProperty "throwError annihilates >>=" . forall (i :. e :. fn @a (m b) :. Nil) $
+  [ testProperty "throwError annihilates >>=" . forall_ (i :. e :. fn @a (m b) :. Nil) $
     \ i e k -> runThrow ((throwError e >>= k) <$ i) === runThrow (throwError e <$ i)
   ]

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -89,10 +89,10 @@ test
   -> Run f ((,) w) m
   -> [TestTree]
 test w m a i (Run runWriter) =
-  [ testProperty "tell appends a value to the log" . forall (i :. w :. m a :. Nil) $
+  [ testProperty "tell appends a value to the log" . forall_ (i :. w :. m a :. Nil) $
     \ i w m -> runWriter ((tell w >> m) <$ i) === fmap (first (mappend w)) (runWriter (m <$ i))
-  , testProperty "listen eavesdrops on written output" . forall (i :. m a :. Nil) $
+  , testProperty "listen eavesdrops on written output" . forall_ (i :. m a :. Nil) $
     \ i m -> runWriter (listen m <$ i) === fmap (fst &&& id) (runWriter (m <$ i))
-  , testProperty "censor revises written output" . forall (i :. fn w :. m a :. Nil) $
+  , testProperty "censor revises written output" . forall_ (i :. fn w :. m a :. Nil) $
     \ i f m -> runWriter (censor f m <$ i) === fmap (first f) (runWriter (m <$ i))
   ]


### PR DESCRIPTION
Because `forall` is going to become a reserved keyword in the future, we had to rename the `forall` function in `Gen` to `forall_`. `forall'` was taken by `Gen` internals. Life goes on.