### PR TITLE
Use simple cabal cradle

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,8 +1,2 @@
 cradle:
   cabal:
-    - path: "src"
-      component: "lib:fused-effects"
-    - path: "test"
-      component: "test:test"
-    - path: "benchmark"
-      component: "benchmark:benchmark"


### PR DESCRIPTION
With cabal 3.4, this suffices for most (hopefully all) cabal projects.

Allows us to load the examples into the IDE.