### PR TITLE
Add eff HasLabelledLift

### DIFF
--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -107,11 +107,7 @@ instance Monad n => Algebra (Labelled Lift (Lift n)) (LabelledLift Lift n) where
 -- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
 -- similar to @lift@ from the @MonadTrans@ typeclass.
 -- @since 1.1.2.2
-sendM
-    :: forall a n m sig
-     . Functor n => HasLabelledLift n sig m
-    => n a
-    -> m a
+sendM :: forall a n m sig. (Functor n, HasLabelledLift n sig m) => n a -> m a
 sendM n = runUnderLabel @Lift (Lift.sendM @n n)
 {-# INLINE sendM #-}
 

--- a/src/Control/Effect/Labelled.hs
+++ b/src/Control/Effect/Labelled.hs
@@ -33,7 +33,7 @@ module Control.Effect.Labelled
 , HasLabelledLift
 , runLabelledLift
 , LabelledLift
-, sendM
+, lift
 
 , module Control.Algebra
 ) where
@@ -45,7 +45,7 @@ import Control.Monad (MonadPlus)
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Class
+import qualified Control.Monad.Trans.Class as T
 import Data.Functor.Identity
 import Data.Kind (Type)
 import Control.Effect.Lift (Lift)
@@ -65,7 +65,7 @@ newtype Labelled (label :: k) (sub :: (Type -> Type) -> (Type -> Type)) m a = La
     , MonadFix -- ^ @since 1.1.1
     , MonadIO
     , MonadPlus
-    , MonadTrans
+    , T.MonadTrans
     )
 
 -- | @since 1.0.2.0
@@ -103,13 +103,13 @@ instance Monad n => Algebra (Labelled Lift (Lift n)) (LabelledLift Lift n) where
     alg hdl (Labelled sub) = LabelledLift . alg (LiftC . runLabelledLift . hdl) sub
     {-# INLINE alg #-}
 
--- | Given a @HasLabelledLift n sig m@ constraint in a signature carried by @m@, 'sendM'
+-- | Given a @HasLabelledLift n sig m@ constraint in a signature carried by @m@, 'lift'
 -- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
 -- similar to @lift@ from the @MonadTrans@ typeclass.
 -- @since 1.1.2.2
-sendM :: forall a n m sig. (Functor n, HasLabelledLift n sig m) => n a -> m a
-sendM n = runUnderLabel @Lift (Lift.sendM @n n)
-{-# INLINE sendM #-}
+lift :: forall a n m sig. (Functor n, HasLabelledLift n sig m) => n a -> m a
+lift n = runUnderLabel @Lift (Lift.sendM @n n)
+{-# INLINE lift #-}
 
 -- | @m@ is a carrier for @sig@ containing @Lift n@ associated with label @Lift@.
 --
@@ -188,7 +188,7 @@ runUnderLabel :: forall label sub m a . UnderLabel label sub m a -> m a
 runUnderLabel (UnderLabel l) = l
 {-# INLINE runUnderLabel #-}
 
-instance MonadTrans (UnderLabel sub label) where
+instance T.MonadTrans (UnderLabel sub label) where
   lift = UnderLabel
   {-# INLINE lift #-}
 


### PR DESCRIPTION
Added the `HasLabelledLift` effect, which is the `Labelled` version of `Lift`.

For the effect `Has (Lift n) sig m` , we can add a `constraint` on `n` and then use `sendM @n someFunction` to lift `someFunction`. Here we need to provide an explicit `@n` signature.

```haskell
foo ::
  forall n sig m.
  ( Has (Reader Int) sig m,
    Has (Lift n) sig m,
    MonadTime n,
    MonadSay n
  ) =>
  m ()
foo = do
  ct <- sendM @n getCurrentTime
  i <- ask @Int
  sendM @n $ say $ show (ct, i)
```

For the effect `HasLabelledLift n sig m`, lift the function directly using `lift`, no redundant signature is required.
```haskell
newFoo ::
  ( Has (Reader Int) sig m,
    HasLabelledLift n sig m,
    MonadTime n,
    MonadSay n
  ) =>
  m ()
newFoo = do
  ct <- lift getCurrentTime
  i <- ask @Int
  lift $ say $ show (ct, i)
```

--------------------

below is the complete example

```haskell
import Control.Algebra
import Control.Carrier.Lift
import Control.Carrier.Reader
import Control.Effect.Labelled
import Control.Monad.Class.MonadSay
import Control.Monad.Class.MonadTime
import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsSay)

foo ::
  forall n sig m.
  ( Has (Reader Int) sig m,
    Has (Lift n) sig m,
    MonadTime n,
    MonadSay n
  ) =>
  m ()
foo = do
  ct <- sendM @n getCurrentTime
  i <- ask @Int
  sendM @n $ say $ show (ct, i)

runFoo :: forall s. IOSim s ()
runFoo = runM $ runReader @Int 0 (foo @(IOSim s))

-- >>> runFoo'
-- ["(1970-01-01 00:00:00 UTC,0)"]
runFoo' :: [String]
runFoo' = selectTraceEventsSay $ runSimTrace runFoo

newFoo ::
  ( Has (Reader Int) sig m,
    HasLabelledLift n sig m,
    MonadTime n,
    MonadSay n
  ) =>
  m ()
newFoo = do
  ct <- lift getCurrentTime
  i <- ask @Int
  lift $ say $ show (ct, i)

-- >>> runNewFoo
-- ["(1970-01-01 00:00:00 UTC,0)"]
runNewFoo :: [String]
runNewFoo =
  selectTraceEventsSay
    $ runSimTrace
    $ runLabelledLift
    $ runReader @Int 0
    $ newFoo

```
-------------------

More usage examples: https://github.com/EMQ-YangM/hraft/blob/c83dfadf01e91d3858c680ee6a44eb4d58b03ad4/src/Raft/Handler.hs#L64

@patrickt 

---------
More interesting example


Put more Monads on top of each other

```haskell

f1
  :: forall sig0 n sig1 m
   . ( HasLabelledLift IO sig0 n
     , Has (State Int :+: Error ()) sig0 n
     , HasLabelledLift n sig1 m
     , Has (State (Map Int (n ()))) sig1 m
     )
  => m ()
f1 = do
  lift $ do
    i <- get @Int
    lift $ print i
  v <- get @(Map Int (n ()))
  case Map.lookup 1 v of
    Nothing -> pure ()
    Just k -> lift k


runF1 =
  runLabelledLift
    . runError @()
    . runState @Int 0
    . runLabelledLift
    . runState @(Map Int (StateC Int (ErrorC () (LabelledLift Lift IO)) ())) Map.empty
    $ f1

```
