### PR TITLE
Add support for GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.2", "8.4", "8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6.2"]
+        ghc: ["8.2", "8.4", "8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6.2", "9.8.1"]
 
     steps:
     - uses: actions/checkout@v2

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -57,6 +57,10 @@ common common
   if (impl(ghc >= 9.6))
     ghc-options:
       -Wno-redundant-constraints
+  if (impl(ghc >= 9.8))
+    ghc-options:
+      -Wno-missing-poly-kind-signatures
+      -Wno-missing-role-annotations
 
 library
   import:         common

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -27,6 +27,7 @@ tested-with:
   GHC == 9.2.1
   GHC == 9.4.2
   GHC == 9.6.2
+  GHC == 9.8.1
 
 common common
   default-language: Haskell2010
@@ -125,7 +126,7 @@ library
     Control.Effect.Throw.Internal
     Control.Effect.Writer.Internal
   build-depends:
-      base          >= 4.9 && < 4.19
+      base          >= 4.9 && < 4.20
     , transformers  >= 0.4 && < 0.7
     , unliftio-core >= 0.2 && < 0.3
 
@@ -145,7 +146,7 @@ test-suite examples
   build-depends:
     , base
     , fused-effects
-    , hedgehog           >= 1 && < 1.3
+    , hedgehog           >= 1 && < 1.5
     , hedgehog-fn        ^>= 1
 
 
@@ -178,7 +179,7 @@ test-suite test
     Writer
   build-depends:
     , base
-    , containers          >= 0.5 && < 0.7
+    , containers          >= 0.5 && < 0.8
     , fused-effects
     , hedgehog
     , hedgehog-fn

--- a/src/Control/Carrier/Interpret.hs
+++ b/src/Control/Carrier/Interpret.hs
@@ -69,7 +69,7 @@ runInterpret
   -> (forall s . Reifies s (Interpreter eff m) => InterpretC s eff m a)
   -> m a
 runInterpret f m = reify (Interpreter (\ hdl sig -> InterpretC . f (runInterpretC . hdl) sig)) (go m) where
-  go :: InterpretC s eff m x -> Const (m x) s
+  go :: forall s eff m x. InterpretC s eff m x -> Const (m x) s
   go (InterpretC m) = Const m
 {-# INLINE runInterpret #-}
 

--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -106,10 +106,12 @@ instance Fail.MonadFail m => Fail.MonadFail (NonDetC m) where
 -- | Separate fixpoints are computed for each branch.
 instance MonadFix m => MonadFix (NonDetC m) where
   mfix f = NonDetC $ \ fork leaf nil ->
-    mfix (runNonDetA . f . head)
+    mfix (runNonDetA . f . unsafeHead)
     >>= runNonDet fork leaf nil . foldr
-      (\ a _ -> pure a <|> mfix (liftAll . fmap tail . runNonDetA . f))
+      (\ a _ -> pure a <|> mfix (liftAll . fmap (drop 1) . runNonDetA . f))
       empty where
+    unsafeHead (x:_) = x
+    unsafeHead _ = error "unsafeHead: empty list"
     liftAll m = NonDetC $ \ fork leaf nil -> m >>= foldr (fork . leaf) nil
   {-# INLINE mfix #-}
 

--- a/test/Accum.hs
+++ b/test/Accum.hs
@@ -35,10 +35,10 @@ tests = testGroup "Accum"
   , testGroup "AccumT" $ testAccum (runC (fmap (fmap swap) . flip T.Accum.runAccumT))
 #endif
   ] where
-  testMonad    run = Monad.test    (m (gen0 w) (\_ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m (gen0 w) (\_ _ -> [])) a b   initial run
-  testAccum    run = Accum.test    (m (gen0 w) (\_ _ -> [])) a     w       run
-  initial = pair <*> w <*> unit
+  testMonad    run = Monad.test    (genM (gen0 termW) (\_ _ -> [])) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM (gen0 termW) (\_ _ -> [])) termA termB       initial run
+  testAccum    run = Accum.test    (genM (gen0 termW) (\_ _ -> [])) termA             termW   run
+  initial = pair <*> termW <*> unit
 
 gen0
   :: forall w sig m a

--- a/test/Choose.hs
+++ b/test/Choose.hs
@@ -24,9 +24,9 @@ tests = testGroup "Choose"
     ] >>= ($ runL (ChooseC.runChooseS (pure . pure)))
   , testGroup "NonEmpty" $ testChoose (runL (pure . toList))
   ] where
-  testMonad    run = Monad.test    (m mempty genN) a b c initial run
-  testMonadFix run = MonadFix.test (m mempty genN) a b   initial run
-  testChoose   run = Choose.test   (m mempty genN) a b   initial run
+  testMonad    run = Monad.test    (genM mempty genN) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM mempty genN) termA termB       initial run
+  testChoose   run = Choose.test   (genM mempty genN) termA termB       initial run
   initial = identity <*> unit
 
 

--- a/test/Cull.hs
+++ b/test/Cull.hs
@@ -28,9 +28,9 @@ tests = testGroup "Cull"
     , testCull
     ] >>= ($ runL CullC.runCullA)
   ] where
-  testMonad    run = Monad.test    (m gen0 genN) a b c initial run
-  testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run
-  testCull     run = Cull.test     (m gen0 genN) a b   initial run
+  testMonad    run = Monad.test    (genM gen0 genN) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM gen0 genN) termA termB       initial run
+  testCull     run = Cull.test     (genM gen0 genN) termA termB       initial run
   initial = identity <*> unit
 
 

--- a/test/Cut.hs
+++ b/test/Cut.hs
@@ -31,13 +31,13 @@ tests = testGroup "Cut"
     , testCut
     ] >>= ($ runL CutC.runCutA)
   , testGroup "ReaderC · CutC" $
-    Cut.test (local (id @R)) (m (gen0 S.<> Reader.gen0 r) (\ m -> genN m S.<> Reader.genN r m)) a b (pair <*> r <*> unit) (Run (CutC.runCutA . uncurry runReader))
+    Cut.test (local (id @R)) (genM (gen0 S.<> Reader.gen0 termR) (\ m -> genN m S.<> Reader.genN termR m)) termA termB (pair <*> termR <*> unit) (Run (CutC.runCutA . uncurry runReader))
   , testGroup "CutC · ReaderC" $
-    Cut.test (local (id @R)) (m (gen0 S.<> Reader.gen0 r) (\ m -> genN m S.<> Reader.genN r m)) a b (pair <*> r <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
+    Cut.test (local (id @R)) (genM (gen0 S.<> Reader.gen0 termR) (\ m -> genN m S.<> Reader.genN termR m)) termA termB (pair <*> termR <*> unit) (Run (uncurry ((. CutC.runCutA) . runReader)))
   ] where
-  testMonad    run = Monad.test    (m gen0 genN) a b c initial run
-  testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run
-  testCut      run = Cut.test id   (m gen0 genN) a b   initial run
+  testMonad    run = Monad.test    (genM gen0 genN) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM gen0 genN) termA termB       initial run
+  testCut      run = Cut.test id   (genM gen0 genN) termA termB       initial run
   initial = identity <*> unit
 
 

--- a/test/Empty.hs
+++ b/test/Empty.hs
@@ -34,9 +34,9 @@ tests = testGroup "Empty"
   , testGroup "MaybeT" $ testEmpty (runL (fmap maybeToList . T.Maybe.runMaybeT))
   , testGroup "Maybe"  $ testEmpty (runL (pure . maybeToList))
   ] where
-  testMonad    run = Monad.test    (m gen0 (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m gen0 (\ _ _ -> [])) a b   initial run
-  testEmpty    run = Empty.test    (m gen0 (\ _ _ -> [])) a b   initial run
+  testMonad    run = Monad.test    (genM gen0 (\ _ _ -> [])) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM gen0 (\ _ _ -> [])) termA termB       initial run
+  testEmpty    run = Empty.test    (genM gen0 (\ _ _ -> [])) termA termB       initial run
   initial = identity <*> unit
 
 

--- a/test/Error.hs
+++ b/test/Error.hs
@@ -35,9 +35,9 @@ tests = testGroup "Error"
   , testGroup "Either"  $ testError (runL pure)
   , testGroup "ExceptT" $ testError (runL T.Except.runExceptT)
   ] where
-  testMonad    run = Monad.test    (m (gen0 e) (genN e)) a b c initial run
-  testMonadFix run = MonadFix.test (m (gen0 e) (genN e)) a b   initial run
-  testError    run = Error.test e  (m (gen0 e) (genN e)) a b   initial run
+  testMonad    run = Monad.test       (genM (gen0 termE) (genN termE)) termA termB termC initial run
+  testMonadFix run = MonadFix.test    (genM (gen0 termE) (genN termE)) termA termB       initial run
+  testError    run = Error.test termE (genM (gen0 termE) (genN termE)) termA termB       initial run
   initial = identity <*> unit
 
 gen0 :: Has (Error e) sig m => GenTerm e -> GenTerm a -> [GenTerm (m a)]

--- a/test/Fail.hs
+++ b/test/Fail.hs
@@ -24,9 +24,9 @@ tests = testGroup "Fail"
     , testFail
     ] >>= ($ runL FailC.runFail)
   ] where
-  testMonad    run = Monad.test    (m (gen0 e) (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m (gen0 e) (\ _ _ -> [])) a b   initial run
-  testFail     run = Fail.test e   (m (gen0 e) (\ _ _ -> [])) a b   initial run
+  testMonad    run = Monad.test    (genM (gen0 e) (\ _ _ -> [])) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM (gen0 e) (\ _ _ -> [])) termA termB       initial run
+  testFail     run = Fail.test e   (genM (gen0 e) (\ _ _ -> [])) termA termB       initial run
   initial = identity <*> unit
   e = string (Range.linear 0 50) unicode
 

--- a/test/Fresh.hs
+++ b/test/Fresh.hs
@@ -29,9 +29,9 @@ tests = testGroup "Fresh"
     , testFresh
     ] >>= ($ runC C.Strict.runFresh)
   ] where
-  testMonad    run = Monad.test    (m gen (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m gen (\ _ _ -> [])) a b   initial run
-  testFresh    run = Fresh.test    (m gen (\ _ _ -> [])) a     initial run
+  testMonad    run = Monad.test    (genM gen (\ _ _ -> [])) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM gen (\ _ _ -> [])) termA termB       initial run
+  testFresh    run = Fresh.test    (genM gen (\ _ _ -> [])) termA             initial run
   initial = pair <*> n <*> unit
   n = Gen.integral (R.linear 0 100)
 

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -17,23 +17,23 @@
 module Gen
 ( module Data.Functor.Identity
   -- * Polymorphic generation & instantiation
-, m
+, genM
 , GenM
 , genT
 , T(..)
-, a
+, termA
 , A
-, b
+, termB
 , B
-, c
+, termC
 , C
-, e
+, termE
 , E
-, r
+, termR
 , R
-, s
+, termS
 , S
-, w
+, termW
 , W
 , unit
 , identity
@@ -95,14 +95,14 @@ import qualified Hedgehog.Function as Fn
 import           Hedgehog.Gen as Hedgehog
 import           Hedgehog.Range
 
--- | A generator for computations, given a higher-order generator for effectful operations, & a generator for results.
-m
+-- | A generator for computations, given a higher-order generator for effectful operations, & a generator for results.
+genM
   :: forall m
   .  Monad m
   => (forall a . GenTerm a -> [GenTerm (m a)])
   -> (forall a . GenM m -> GenTerm a -> [GenTerm (m a)]) -- ^ A higher-order computation generator using any effects in @m@.
   -> GenM m                                              -- ^ A computation generator.
-m terminals nonterminals = m where
+genM terminals nonterminals = m where
   m :: GenM m
   m a = Comp1 $ scale (`div` 2) $ recursive Hedgehog.choice
     (unComp1 <$> ((Gen.label "pure" pure <*> a) : terminals a))
@@ -131,38 +131,38 @@ instance Monoid (T a) where
 instance KnownSymbol s => Show (T s) where
   showsPrec d = showsUnaryWith showsPrec (symbolVal (Proxy @s)) d . unT
 
-a :: GenTerm A
-a = genT
+termA :: GenTerm A
+termA = genT
 
 type A = T "A"
 
-b :: GenTerm B
-b = genT
+termB :: GenTerm B
+termB = genT
 
 type B = T "B"
 
-c :: GenTerm C
-c = genT
+termC :: GenTerm C
+termC = genT
 
 type C = T "C"
 
-e :: GenTerm E
-e = genT
+termE :: GenTerm E
+termE = genT
 
 type E = T "E"
 
-r :: GenTerm R
-r = genT
+termR :: GenTerm R
+termR = genT
 
 type R = T "R"
 
-s :: GenTerm S
-s = genT
+termS :: GenTerm S
+termS = genT
 
 type S = T "S"
 
-w :: GenTerm W
-w = genT
+termW :: GenTerm W
+termW = genT
 
 type W = T "W"
 

--- a/test/NonDet.hs
+++ b/test/NonDet.hs
@@ -31,9 +31,9 @@ tests = testGroup "NonDet"
     ] >>= ($ runL Church.NonDetC.runNonDetA)
   , testGroup "[]" $ testNonDet (runL pure)
   ] where
-  testMonad    run = Monad.test    (m gen0 genN) a b c initial run
-  testMonadFix run = MonadFix.test (m gen0 genN) a b   initial run
-  testNonDet   run = NonDet.test   (m gen0 genN) a b   initial run
+  testMonad    run = Monad.test    (genM gen0 genN) termA termB termC initial run
+  testMonadFix run = MonadFix.test (genM gen0 genN) termA termB       initial run
+  testNonDet   run = NonDet.test   (genM gen0 genN) termA termB       initial run
   initial = identity <*> unit
 
 

--- a/test/Reader.hs
+++ b/test/Reader.hs
@@ -35,9 +35,9 @@ tests = testGroup "Reader"
   , testGroup "RWST (Lazy)"   $ testReader (runR (uncurry (runRWST LazyRWST.runRWST)   . lower))
   , testGroup "RWST (Strict)" $ testReader (runR (uncurry (runRWST StrictRWST.runRWST) . lower))
   ] where
-  testMonad    run = Monad.test    (m (gen0 r) (genN r)) a b c (Comp1 <$> (identity <*> (pair <*> r <*> unit))) run
-  testMonadFix run = MonadFix.test (m (gen0 r) (genN r)) a b   (Comp1 <$> (identity <*> (pair <*> r <*> unit))) run
-  testReader   run = Reader.test r (m (gen0 r) (genN r)) a                (identity <*>                 unit)   run
+  testMonad    run = Monad.test        (genM (gen0 termR) (genN termR)) termA termB termC (Comp1 <$> (identity <*> (pair <*> termR <*> unit))) run
+  testMonadFix run = MonadFix.test     (genM (gen0 termR) (genN termR)) termA termB       (Comp1 <$> (identity <*> (pair <*> termR <*> unit))) run
+  testReader   run = Reader.test termR (genM (gen0 termR) (genN termR)) termA                        (identity <*>                     unit)   run
   runRWST f r m = (\ (a, _, ()) -> a) <$> f m r r
   lower = runIdentity . unComp1
 

--- a/test/State.hs
+++ b/test/State.hs
@@ -52,9 +52,9 @@ tests = testGroup "State"
   , testGroup "RWST (Lazy)"     $ testState (runC (runRWST RWST.Lazy.runRWST))
   , testGroup "RWST (Strict)"   $ testState (runC (runRWST RWST.Strict.runRWST))
   ] where
-  testMonad    run = Monad.test    (m (gen0 s) (\ _ _ -> [])) a b c (pair <*> s <*> unit) run
-  testMonadFix run = MonadFix.test (m (gen0 s) (\ _ _ -> [])) a b   (pair <*> s <*> unit) run
-  testState    run = State.test    (m (gen0 s) (\ _ _ -> [])) a               s           run
+  testMonad    run = Monad.test    (genM (gen0 termS) (\ _ _ -> [])) termA termB termC (pair <*> termS <*> unit) run
+  testMonadFix run = MonadFix.test (genM (gen0 termS) (\ _ _ -> [])) termA termB       (pair <*> termS <*> unit) run
+  testState    run = State.test    (genM (gen0 termS) (\ _ _ -> [])) termA             termS                     run
   runRWST f s m = (\ (a, s, ()) -> (s, a)) <$> f m s s
 
 

--- a/test/Throw.hs
+++ b/test/Throw.hs
@@ -24,9 +24,9 @@ tests = testGroup "Throw"
     , testThrow
     ] >>= ($ runL ThrowC.runThrow)
   ] where
-  testMonad    run = Monad.test    (m (gen0 e) (\ _ _ -> [])) a b c initial run
-  testMonadFix run = MonadFix.test (m (gen0 e) (\ _ _ -> [])) a b   initial run
-  testThrow    run = Throw.test e  (m (gen0 e) (\ _ _ -> [])) a b   initial run
+  testMonad    run = Monad.test       (genM (gen0 termE) (\ _ _ -> [])) termA termB termC initial run
+  testMonadFix run = MonadFix.test    (genM (gen0 termE) (\ _ _ -> [])) termA termB       initial run
+  testThrow    run = Throw.test termE (genM (gen0 termE) (\ _ _ -> [])) termA termB       initial run
   initial = identity <*> unit
 
 

--- a/test/Writer.hs
+++ b/test/Writer.hs
@@ -56,9 +56,9 @@ tests = testGroup "Writer"
   , testGroup "RWST (Lazy)"      $ testWriter (runL (runRWST T.RWS.Lazy.runRWST))
   , testGroup "RWST (Strict)"    $ testWriter (runL (runRWST T.RWS.Strict.runRWST))
   ] where
-  testMonad    run = Monad.test    (m (gen0 w) (genN w b)) a b c initial run
-  testMonadFix run = MonadFix.test (m (gen0 w) (genN w b)) a b   initial run
-  testWriter   run = Writer.test w (m (gen0 w) (genN w b)) a     initial run
+  testMonad    run = Monad.test        (genM (gen0 termW) (genN termW termB)) termA termB termC initial run
+  testMonadFix run = MonadFix.test     (genM (gen0 termW) (genN termW termB)) termA termB       initial run
+  testWriter   run = Writer.test termW (genM (gen0 termW) (genN termW termB)) termA             initial run
   initial = identity <*> unit
   runRWST f m = (\ (a, _, w) -> (w, a)) <$> f m () ()
 


### PR DESCRIPTION
In addition to bumping dependency bounds & adding GHC 9.8 to CI, this PR:
- Disables two new warning flags, [`missing-poly-kind-signatures`][poly-sigs] and [`missing-role-annotations`][role-anns]
- Addresses warnings surfaced by [`term-variable-capture`][term-capture] and `x-partial`

[poly-sigs]: https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wmissing-poly-kind-signatures
[role-anns]: https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wmissing-role-annotations
[term-capture]: https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wterm-variable-capture