### PR TITLE
Fix `Accum` carriers (`Strict` and `Church`) to not duplicate state

### DIFF
--- a/src/Control/Carrier/Accum/Church.hs
+++ b/src/Control/Carrier/Accum/Church.hs
@@ -129,5 +129,5 @@ instance (Algebra sig m, Monoid w) => Algebra (Accum w :+: sig) (AccumC w m) whe
     L accum -> case accum of
       Add w' -> k w' ctx
       Look   -> k mempty $ w <$ ctx
-    R other  -> thread (uncurry (runAccum (curry pure)) ~<~ hdl) other (w, ctx) >>= uncurry k
+    R other  -> thread (uncurry (runAccum (curry pure)) ~<~ hdl) other (mempty, ctx) >>= uncurry k
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Accum/Strict.hs
+++ b/src/Control/Carrier/Accum/Strict.hs
@@ -132,5 +132,5 @@ instance (Algebra sig m, Monoid w) => Algebra (Accum w :+: sig) (AccumC w m) whe
     L accum -> case accum of
       Add w' -> pure (w', ctx)
       Look   -> pure (mempty, w <$ ctx)
-    R other  -> thread (uncurry runAccum ~<~ hdl) other (w, ctx)
+    R other  -> thread (uncurry runAccum ~<~ hdl) other (mempty, ctx)
   {-# INLINE alg #-}


### PR DESCRIPTION
Fixes #449.  Previously, the `Algebra` instances erroneously returned a copy of the input state when processing other effects.  Since these carriers assume that the returned state represents any *additional* output produced, this resulted in the state being duplicated.  Instead, when processing other effects (which necessarily have no `Accum` effects) we should return `mempty`.

Sorry it's taken me a while to get around to this.  I had grand plans at first of looking into writing some additional tests, as discussed in #449 , but I'm not sure whether I'll ever get around to that, and I figure it's better to have a fix with no tests than nothing at all.