### PR TITLE
Fix `Accum` carriers (`Strict` and `Church`) to not duplicate state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,17 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache ~/.cabal/packages
       with:
         path: ~/.cabal/packages
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache dist-newstyle
       with:
         path: dist-newstyle

--- a/src/Control/Carrier/Accum/Church.hs
+++ b/src/Control/Carrier/Accum/Church.hs
@@ -129,5 +129,5 @@ instance (Algebra sig m, Monoid w) => Algebra (Accum w :+: sig) (AccumC w m) whe
     L accum -> case accum of
       Add w' -> k w' ctx
       Look   -> k mempty $ w <$ ctx
-    R other  -> thread (uncurry (runAccum (curry pure)) ~<~ hdl) other (w, ctx) >>= uncurry k
+    R other  -> thread (uncurry (runAccum (curry pure)) ~<~ hdl) other (mempty, ctx) >>= uncurry k
   {-# INLINE alg #-}

--- a/src/Control/Carrier/Accum/Strict.hs
+++ b/src/Control/Carrier/Accum/Strict.hs
@@ -132,5 +132,5 @@ instance (Algebra sig m, Monoid w) => Algebra (Accum w :+: sig) (AccumC w m) whe
     L accum -> case accum of
       Add w' -> pure (w', ctx)
       Look   -> pure (mempty, w <$ ctx)
-    R other  -> thread (uncurry runAccum ~<~ hdl) other (w, ctx)
+    R other  -> thread (uncurry runAccum ~<~ hdl) other (mempty, ctx)
   {-# INLINE alg #-}


### PR DESCRIPTION
Fixes #449.  Previously, the `Algebra` instances erroneously returned a copy of the input state when processing other effects.  Since these carriers assume that the returned state represents any *additional* output produced, this resulted in the state being duplicated.  Instead, when processing other effects (which necessarily have no `Accum` effects) we should return `mempty`.