### PR TITLE
1.1.2.7

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at robrix@github.com. All
+reported by contacting the project team at rob.rix@me.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# v1.1.2.7
+
+- Supports `base` 4.22.
+
 # v1.1.2.6
 
 - Make strict Accum carrier's `<*>` and `>>=` strict in the accumulated value ([#468](https://github.com/fused-effects/fused-effects/pull/468)) (by @byorgey)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2021, Nicolas Wu, Tom Schrijvers, Rob Rix, and Patrick Thomson
+Copyright (c) 2018-2026, Nicolas Wu, Tom Schrijvers, Rob Rix, and Patrick Thomson
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -1,35 +1,35 @@
-cabal-version:       2.2
-
-name:                fused-effects
-version:             1.1.2.6
-synopsis:            A fast, flexible, fused effect system.
-description:         A fast, flexible, fused effect system, à la Effect Handlers in Scope, Monad Transformers and Modular Algebraic Effects: What Binds Them Together, and Fusion for Free—Efficient Algebraic Effect Handlers.
-homepage:            https://github.com/fused-effects/fused-effects
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
-maintainer:          robrix@github.com
-copyright:           2018-2025 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
-category:            Control
-build-type:          Simple
+cabal-version: 2.2
+name: fused-effects
+version: 1.1.2.7
+synopsis: A fast, flexible, fused effect system.
+description: A fast, flexible, fused effect system, à la Effect Handlers in Scope, Monad Transformers and Modular Algebraic Effects: What Binds Them Together, and Fusion for Free—Efficient Algebraic Effect Handlers.
+homepage: https://github.com/fused-effects/fused-effects
+license: BSD-3-Clause
+license-file: LICENSE
+author: Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
+maintainer: robrix@github.com
+copyright: 2018-2025 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
+category: Control
+build-type: Simple
 extra-source-files:
   README.md
+
 extra-doc-files:
   ChangeLog.md
 
 tested-with:
-  GHC == 8.2.2
-  GHC == 8.4.4
-  GHC == 8.6.5
-  GHC == 8.8.4
-  GHC == 8.10.4
-  GHC == 9.0.1
-  GHC == 9.2.1
-  GHC == 9.4.2
-  GHC == 9.6.2
-  GHC == 9.8.2
-  GHC == 9.10.1
-  GHC == 9.12.1
+  ghc ==8.2.2
+  ghc ==8.4.4
+  ghc ==8.6.5
+  ghc ==8.8.4
+  ghc ==8.10.4
+  ghc ==9.0.1
+  ghc ==9.2.1
+  ghc ==9.4.2
+  ghc ==9.6.2
+  ghc ==9.8.2
+  ghc ==9.10.1
+  ghc ==9.12.1
 
 common common
   default-language: Haskell2010
@@ -44,22 +44,27 @@ common common
     -Wno-name-shadowing
     -Wno-safe
     -Wno-unsafe
-  if (impl(ghc >= 8.8))
+
+  if (impl(ghc >=8.8))
     ghc-options: -Wno-missing-deriving-strategies
-  if (impl(ghc >= 8.10))
+
+  if (impl(ghc >=8.10))
     ghc-options:
       -Wno-missing-safe-haskell-mode
       -Wno-prepositive-qualified-module
-  if (impl(ghc >= 9.2))
+
+  if (impl(ghc >=9.2))
     ghc-options:
       -Wno-missing-kind-signatures
+
   -- Temporary hack to deal with a bug in GHC 9.6 where
   -- derivations of MonadTrans cause spurious redundant-constraint warnings.
   -- https://gitlab.haskell.org/ghc/ghc/-/issues/23143
-  if (impl(ghc >= 9.6))
+  if (impl(ghc >=9.6))
     ghc-options:
       -Wno-redundant-constraints
-  if (impl(ghc >= 9.8))
+
+  if (impl(ghc >=9.8))
     ghc-options:
       -Wno-missing-role-annotations
       -Wno-term-variable-capture
@@ -67,12 +72,13 @@ common common
       -Wno-missing-poly-kind-signatures
 
 library
-  import:         common
+  import: common
   hs-source-dirs: src
   exposed-modules:
+    -- Carriers
+    -- Effects
     Control.Algebra
     Control.Algebra.Handler
-    -- Carriers
     Control.Carrier.Accum.Church
     Control.Carrier.Accum.IORef
     Control.Carrier.Accum.Strict
@@ -100,7 +106,6 @@ library
     Control.Carrier.Trace.Returning
     Control.Carrier.Writer.Church
     Control.Carrier.Writer.Strict
-    -- Effects
     Control.Effect.Accum
     Control.Effect.Catch
     Control.Effect.Choose
@@ -121,6 +126,7 @@ library
     Control.Effect.Throw
     Control.Effect.Trace
     Control.Effect.Writer
+
   other-modules:
     Control.Effect.Accum.Internal
     Control.Effect.Catch.Internal
@@ -133,17 +139,17 @@ library
     Control.Effect.State.Internal
     Control.Effect.Throw.Internal
     Control.Effect.Writer.Internal
-  build-depends:
-      base          >= 4.9 && < 4.22
-    , transformers  >= 0.4 && < 0.7
-    , unliftio-core >= 0.2 && < 0.3
 
+  build-depends:
+    base >=4.9 && <4.22,
+    transformers >=0.4 && <0.7,
+    unliftio-core >=0.2 && <0.3,
 
 test-suite examples
-  import:         common
-  type:           exitcode-stdio-1.0
+  import: common
+  type: exitcode-stdio-1.0
   hs-source-dirs: examples
-  main-is:        Main.hs
+  main-is: Main.hs
   other-modules:
     Inference
     Labelled
@@ -151,18 +157,18 @@ test-suite examples
     ReinterpretLog
     Teletype
     Utils
-  build-depends:
-    , base
-    , fused-effects
-    , hedgehog           >= 1 && < 1.6
-    , hedgehog-fn        ^>= 1
 
+  build-depends:
+    base,
+    fused-effects,
+    hedgehog >=1 && <1.6,
+    hedgehog-fn ^>=1,
 
 test-suite test
-  import:         common
-  type:           exitcode-stdio-1.0
+  import: common
+  type: exitcode-stdio-1.0
   hs-source-dirs: test
-  main-is:        Test.hs
+  main-is: Test.hs
   other-modules:
     Accum
     Catch
@@ -185,33 +191,36 @@ test-suite test
     State
     Throw
     Writer
-  build-depends:
-    , base
-    , containers          >= 0.5 && < 0.8
-    , fused-effects
-    , hedgehog
-    , hedgehog-fn
-    , inspection-testing  >= 0.4 && < 0.7
-    , transformers
 
+  build-depends:
+    base,
+    containers >=0.5 && <0.8,
+    fused-effects,
+    hedgehog,
+    hedgehog-fn,
+    inspection-testing >=0.4 && <0.7,
+    transformers,
 
 test-suite docs
-  import:      common
-  type:        exitcode-stdio-1.0
-  main-is:     README.lhs
-  ghc-options: -pgmL markdown-unlit
-  build-depends:
-    , base
-    , fused-effects
-  build-tool-depends:
-      markdown-unlit:markdown-unlit ^>= 0.5
+  import: common
+  type: exitcode-stdio-1.0
+  main-is: README.lhs
+  ghc-options:
+    -pgmL
+    markdown-unlit
 
+  build-depends:
+    base,
+    fused-effects,
+
+  build-tool-depends:
+    markdown-unlit:markdown-unlit ^>=0.5
 
 benchmark benchmark
-  import:         common
-  type:           exitcode-stdio-1.0
+  import: common
+  type: exitcode-stdio-1.0
   hs-source-dirs: benchmark
-  main-is:        Bench.hs
+  main-is: Bench.hs
   other-modules:
     Bench.Error
     Bench.Interpret
@@ -220,15 +229,16 @@ benchmark benchmark
     Bench.Reader
     Bench.State
     Bench.Writer
+
   build-depends:
-    , base
-    , fused-effects
-    , tasty-bench == 0.3.*
-    , transformers
+    base,
+    fused-effects,
+    tasty-bench ==0.3.*,
+    transformers,
+
   ghc-options:
     -threaded
 
-
 source-repository head
-  type:     git
+  type: git
   location: https://github.com/fused-effects/fused-effects

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -141,7 +141,7 @@ library
     Control.Effect.Writer.Internal
 
   build-depends:
-    base >=4.9 && <4.22,
+    base >=4.9 && <4.23,
     transformers >=0.4 && <0.7,
     unliftio-core >=0.2 && <0.3,
 

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -8,7 +8,7 @@ license: BSD-3-Clause
 license-file: LICENSE
 author: Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 maintainer: rob.rix@me.com
-copyright: 2018-2025 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
+copyright: 2018-2026 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 category: Control
 build-type: Simple
 extra-source-files:

--- a/fused-effects.cabal
+++ b/fused-effects.cabal
@@ -7,7 +7,7 @@ homepage: https://github.com/fused-effects/fused-effects
 license: BSD-3-Clause
 license-file: LICENSE
 author: Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
-maintainer: robrix@github.com
+maintainer: rob.rix@me.com
 copyright: 2018-2025 Nicolas Wu, Tom Schrijvers, Rob Rix, Patrick Thomson
 category: Control
 build-type: Simple


### PR DESCRIPTION
Really just supporting `base` 4.22. Sorry for the auto-formatted .cabal file changes.